### PR TITLE
Add additional modes to broker-stream-benchmark tool

### DIFF
--- a/tests/benchmark/broker-stream-benchmark.cc
+++ b/tests/benchmark/broker-stream-benchmark.cc
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
   auto host = cfg.host;
   topic foobar{"foo/bar"};
   std::thread t{rate_calculator};
-  switch (caf::atom_uint(caf::to_lowercase(mode))) {
+  switch (caf::atom_uint(mode)) {
     default:
       std::cerr << "invalid mode: " << to_string(mode) << endl;
       return EXIT_FAILURE;


### PR DESCRIPTION
The additional benchmark modes allow us to better understand performance by allowing us to host sink and source in the same process (`both` mode) and even bypassing network entirely by running two "bare" core actors (`fused` mode).