### PR TITLE
Deploy copy-on-write for more efficient messaging

### DIFF
--- a/bindings/python/_broker.cpp
+++ b/bindings/python/_broker.cpp
@@ -271,7 +271,7 @@ PYBIND11_MODULE(_broker, m) {
     .def("publish", (void (broker::endpoint::*)(broker::topic t, broker::data d)) &broker::endpoint::publish)
     .def("publish", (void (broker::endpoint::*)(const broker::endpoint_info& dst, broker::topic t, broker::data d)) &broker::endpoint::publish)
     .def("publish_batch",
-       [](broker::endpoint& ep, std::vector<broker::endpoint::value_type> xs) { ep.publish(xs); })
+       [](broker::endpoint& ep, std::vector<broker::data_message> xs) { ep.publish(xs); })
     .def("make_publisher", &broker::endpoint::make_publisher)
     .def("make_subscriber", &broker::endpoint::make_subscriber, py::arg("topics"), py::arg("max_qsize") = 20)
     .def("make_status_subscriber", &broker::endpoint::make_status_subscriber, py::arg("receive_statuses") = false)

--- a/broker/detail/clone_actor.hh
+++ b/broker/detail/clone_actor.hh
@@ -38,6 +38,8 @@ public:
     forward(make_internal_command<T>(std::move(x)));
   }
 
+  void command(internal_command::variant_type& cmd);
+
   void command(internal_command& cmd);
 
   void operator()(none);

--- a/broker/detail/master_actor.hh
+++ b/broker/detail/master_actor.hh
@@ -49,6 +49,8 @@ public:
 
   void command(internal_command& cmd);
 
+  void command(internal_command::variant_type& cmd);
+
   void operator()(none);
 
   void operator()(put_command&);

--- a/broker/detail/prefix_matcher.hh
+++ b/broker/detail/prefix_matcher.hh
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include <caf/cow_tuple.hpp>
 #include <caf/message.hpp>
 
 #include "broker/topic.hh"
@@ -17,13 +18,8 @@ struct prefix_matcher {
   bool operator()(const filter_type& filter, const topic& t) const;
 
   template <class T>
-  bool operator()(const filter_type& filter,
-                  const std::pair<topic, T>& x) const {
-    return (*this)(filter, x.first);
-  }
-
-  bool operator()(const filter_type& filter, const caf::message& msg) const {
-    return msg.match_element<topic>(0) && (*this)(filter, msg.get_as<topic>(0));
+  bool operator()(const filter_type& filter, const T& x) const {
+    return (*this)(filter, get_topic(x));
   }
 };
 

--- a/broker/detail/shared_publisher_queue.hh
+++ b/broker/detail/shared_publisher_queue.hh
@@ -6,6 +6,7 @@
 
 #include "broker/detail/assert.hh"
 #include "broker/detail/shared_queue.hh"
+#include "broker/message.hh"
 
 namespace broker {
 namespace detail {
@@ -21,7 +22,7 @@ namespace detail {
 /// - consume() fires the flare when it removes items from xs_ and less than 20
 ///   items remain
 /// - produce() extinguishes the flare it adds items to xs_, exceeding 20
-template <class ValueType = std::pair<topic, data>>
+template <class ValueType = data_message>
 class shared_publisher_queue : public shared_queue<ValueType> {
 public:
   using value_type = ValueType;
@@ -124,16 +125,15 @@ private:
   const size_t capacity_;
 };
 
-template <class ValueType = std::pair<topic, data>>
+template <class ValueType = data_message>
 using shared_publisher_queue_ptr
   = caf::intrusive_ptr<shared_publisher_queue<ValueType>>;
 
-template <class ValueType = std::pair<topic, data>>
+template <class ValueType = data_message>
 shared_publisher_queue_ptr<ValueType>
 make_shared_publisher_queue(size_t buffer_size) {
   return caf::make_counted<shared_publisher_queue<ValueType>>(buffer_size);
 }
-
 
 } // namespace detail
 } // namespace broker

--- a/broker/detail/shared_queue.hh
+++ b/broker/detail/shared_queue.hh
@@ -11,6 +11,7 @@
 #include <caf/ref_counted.hpp>
 
 #include "broker/data.hh"
+#include "broker/message.hh"
 #include "broker/topic.hh"
 
 #include "broker/detail/flare.hh"
@@ -19,7 +20,7 @@ namespace broker {
 namespace detail {
 
 /// Base class for `shared_publisher_queue` and `shared_subscriber_queue`.
-template <class ValueType = std::pair<topic, data>>
+template <class ValueType = data_message>
 class shared_queue : public caf::ref_counted {
 public:
   using value_type = ValueType;

--- a/broker/detail/shared_subscriber_queue.hh
+++ b/broker/detail/shared_subscriber_queue.hh
@@ -5,13 +5,14 @@
 #include <caf/make_counted.hpp>
 
 #include "broker/detail/shared_queue.hh"
+#include "broker/message.hh"
 
 namespace broker {
 namespace detail {
 
 /// Synchronizes a publisher with a background worker. Uses the `pending` flag
 /// and the `flare` to signalize demand to the user. Users can write as long as
-/// the flare remains active. The user consumes items, while the worker 
+/// the flare remains active. The user consumes items, while the worker
 /// produces them.
 ///
 /// The protocol on the flare is as follows:
@@ -19,12 +20,12 @@ namespace detail {
 /// - the flare is active as long as xs_ has more than one item
 /// - produce() fires the flare when it adds items to xs_ and xs_ was empty
 /// - consume() extinguishes the flare when it removes the last item from xs_
-template <class ValueType = std::pair<topic, data>>
+template <class ValueType = data_message>
 class shared_subscriber_queue : public shared_queue<ValueType> {
 public:
   using value_type = ValueType;
 
-  using super = shared_queue<ValueType>;
+  using super = shared_queue<value_type>;
 
   using guard_type = typename super::guard_type;
 
@@ -75,11 +76,11 @@ public:
   }
 };
 
-template <class ValueType = std::pair<topic, data>>
+template <class ValueType = data_message>
 using shared_subscriber_queue_ptr
   = caf::intrusive_ptr<shared_subscriber_queue<ValueType>>;
 
-template <class ValueType = std::pair<topic, data>>
+template <class ValueType = data_message>
 shared_subscriber_queue_ptr<ValueType> make_shared_subscriber_queue() {
   return caf::make_counted<shared_subscriber_queue<ValueType>>();
 }

--- a/broker/endpoint.hh
+++ b/broker/endpoint.hh
@@ -22,16 +22,17 @@
 #include "broker/backend_options.hh"
 #include "broker/configuration.hh"
 #include "broker/endpoint_info.hh"
-#include "broker/status_subscriber.hh"
 #include "broker/expected.hh"
 #include "broker/frontend.hh"
 #include "broker/fwd.hh"
+#include "broker/message.hh"
 #include "broker/network_info.hh"
 #include "broker/peer_info.hh"
 #include "broker/status.hh"
+#include "broker/status_subscriber.hh"
 #include "broker/store.hh"
-#include "broker/topic.hh"
 #include "broker/time.hh"
+#include "broker/topic.hh"
 
 namespace broker {
 
@@ -42,9 +43,7 @@ class endpoint {
 public:
   // --- member types ----------------------------------------------------------
 
-  using value_type = std::pair<topic, data>;
-
-  using stream_type = caf::stream<value_type>;
+  using stream_type = caf::stream<data_message>;
 
   using actor_init_fun = std::function<void (caf::event_based_actor*)>;
 
@@ -201,7 +200,7 @@ public:
   void publish(topic t, std::initializer_list<data> xs);
 
   // Publishes all messages in `xs`.
-  void publish(std::vector<value_type> xs);
+  void publish(std::vector<data_message> xs);
 
   publisher make_publisher(topic ts);
 

--- a/broker/message.hh
+++ b/broker/message.hh
@@ -1,0 +1,131 @@
+#ifndef BROKER_EVENT_HH
+#define BROKER_EVENT_HH
+
+#include <cstdint>
+
+#include <caf/cow_tuple.hpp>
+#include <caf/variant.hpp>
+
+#include "broker/data.hh"
+#include "broker/internal_command.hh"
+#include "broker/topic.hh"
+
+namespace broker {
+
+/// A user-defined message with topic and data.
+using data_message = caf::cow_tuple<topic, data>;
+
+/// A broker-internal message with topic and command.
+using command_message = caf::cow_tuple<topic, internal_command>;
+
+/// A message for node-to-node communication with either a user-defined data
+/// message or a broker-internal command messages.
+struct node_message {
+  /// Content of the message.
+  caf::variant<data_message, command_message> content;
+
+  /// Time-to-life counter.
+  uint16_t ttl;
+};
+
+/// @relates node_message
+template <class Inspector>
+typename Inspector::result_type inspect(Inspector& f, node_message& x) {
+  return f(x.content, x.ttl);
+}
+
+/// Generates a broker ::data_message.
+template <class Topic, class Data>
+data_message make_data_message(Topic&& t, Data&& d) {
+  return data_message(std::forward<Topic>(t), std::forward<Data>(d));
+}
+
+/// Generates a broker ::command_message.
+template <class Topic, class Command>
+command_message make_command_message(Topic&& t, Command&& d) {
+  return command_message(std::forward<Topic>(t), std::forward<Command>(d));
+}
+
+/// Generates a broker ::node_message.
+inline node_message make_node_message(data_message msg, uint16_t ttl) {
+  return {std::move(msg), ttl};
+}
+
+/// Generates a broker ::node_message.
+inline node_message make_node_message(command_message msg, uint16_t ttl) {
+  return {std::move(msg), ttl};
+}
+
+/// Retrieves the topic from a ::data_message.
+inline const topic& get_topic(const data_message& x) {
+  return get<0>(x);
+}
+
+/// Retrieves the topic from a ::command_message.
+inline const topic& get_topic(const command_message& x) {
+  return get<0>(x);
+}
+
+/// Retrieves the topic from a ::generic_message.
+inline const topic& get_topic(const node_message& x) {
+  if(caf::holds_alternative<data_message>(x.content))
+    return get_topic(caf::get<data_message>(x.content));
+  return get_topic(caf::get<command_message>(x.content));
+}
+
+/// Moves the topic out of a ::data_message, copying it if more than one
+/// reference exists..
+inline topic&& move_topic(data_message& x) {
+  return std::move(get<0>(x.unshared()));
+}
+
+/// Moves the topic out of a ::command_message, copying it if more than one
+/// reference exists..
+inline topic&& move_topic(command_message& x) {
+  return std::move(get<0>(x.unshared()));
+}
+
+/// Moves the topic out of a ::generic_message, copying it if more than one
+/// reference exists..
+inline topic&& move_topic(node_message& x) {
+  if( caf::holds_alternative<data_message>(x.content))
+    return move_topic(caf::get<data_message>(x.content));
+  return move_topic(caf::get<command_message>(x.content));
+}
+
+/// Retrieves the data from a ::data_message.
+inline const data& get_data(const data_message& x) {
+  return get<1>(x);
+}
+
+/// Moves the data out of a ::data_message, copying it if more than one
+/// reference exists.
+inline const data&& move_data(data_message& x) {
+  return std::move(get<1>(x.unshared()));
+}
+/// Retrieves the command from a ::command_message.
+inline const internal_command::variant_type&
+get_command(const command_message& x) {
+  return get<1>(x).content;
+}
+
+/// Moves the command out of a ::command_message, copying it if more than one
+/// reference exists.
+inline internal_command::variant_type
+move_command(command_message& x) {
+  return std::move(get<1>(x.unshared()).content);
+}
+
+/// Returns whether `x` contains a ::node_message.
+inline bool is_data_message(const node_message& x) {
+  return caf::holds_alternative<data_message>(x.content);
+}
+
+/// Returns whether `x` contains a ::command_message.
+inline bool is_command_message(const node_message& x) {
+  return caf::holds_alternative<command_message>(x.content);
+}
+
+} // namespace broker
+
+#endif // BROKER_EVENT_HH

--- a/broker/publisher.hh
+++ b/broker/publisher.hh
@@ -9,6 +9,7 @@
 
 #include "broker/atoms.hh"
 #include "broker/fwd.hh"
+#include "broker/message.hh"
 
 #include "broker/detail/shared_publisher_queue.hh"
 
@@ -23,7 +24,7 @@ public:
 
   // --- nested types ----------------------------------------------------------
 
-  using value_type = std::pair<topic, data>;
+  using value_type = data_message;
 
   using guard_type = std::unique_lock<std::mutex>;
 
@@ -72,13 +73,13 @@ public:
   }
 
   // --- mutators --------------------------------------------------------------
-  
+
   /// Forces the publisher to drop all remaining items from the queue when the
   /// destructor gets called.
   void drop_all_on_destruction();
-  
+
   // --- messaging -------------------------------------------------------------
-  
+
   /// Sends `x` to all subscribers.
   void publish(data x);
 

--- a/broker/store.hh
+++ b/broker/store.hh
@@ -4,10 +4,11 @@
 #include <string>
 
 #include <caf/actor.hpp>
-#include <caf/stream.hpp>
+#include <caf/cow_tuple.hpp>
 #include <caf/error.hpp>
 #include <caf/make_message.hpp>
 #include <caf/scoped_actor.hpp>
+#include <caf/stream.hpp>
 
 #include "broker/api_flags.hh"
 #include "broker/atoms.hh"
@@ -30,7 +31,7 @@ class store {
 public:
   friend class endpoint;
 
-  using stream_type = caf::stream<std::pair<topic, internal_command>>;
+  using stream_type = caf::stream<caf::cow_tuple<topic, internal_command>>;
 
   /// A response to a lookup request issued by a ::proxy.
   struct response {

--- a/broker/subscriber.hh
+++ b/broker/subscriber.hh
@@ -7,15 +7,16 @@
 
 #include "broker/data.hh"
 #include "broker/fwd.hh"
-#include "broker/topic.hh"
+#include "broker/message.hh"
 #include "broker/subscriber_base.hh"
+#include "broker/topic.hh"
 
 #include "broker/detail/shared_subscriber_queue.hh"
 
 namespace broker {
 
 /// Provides blocking access to a stream of data.
-class subscriber : public subscriber_base<std::pair<topic, data>> {
+class subscriber : public subscriber_base<data_message> {
 public:
   // --- friend declarations ---------------------------------------------------
 
@@ -23,7 +24,7 @@ public:
 
   // --- nested types ----------------------------------------------------------
 
-  using super = subscriber_base<std::pair<topic, data>>;
+  using super = subscriber_base<data_message>;
 
   // --- constructors and destructors ------------------------------------------
 

--- a/broker/topic.hh
+++ b/broker/topic.hh
@@ -1,10 +1,10 @@
 #ifndef BROKER_TOPIC_HH
 #define BROKER_TOPIC_HH
 
-#include <utility>
 #include <cstddef>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "broker/detail/operators.hh"

--- a/doc/_examples/comm.cc
+++ b/doc/_examples/comm.cc
@@ -12,8 +12,8 @@ void f1() {
 endpoint ep;
 auto sub = ep.make_subscriber({"/topic/test"});
 auto msg = sub.get();
-auto topic = msg.first;
-auto data_ = msg.second;
+auto topic = get_topic(msg);
+auto data_ = get_data(msg);
 std::cout << "topic: " << topic << " data: " << data_ << std::endl;
 // --get-end
 
@@ -24,7 +24,7 @@ if ( sub.available() )
     msg = sub.get(); // Won't block now.
 
 for ( auto m : sub.poll() ) // Iterate over all available messages
-    std::cout << "topic: " << m.first << " data: " << m.second << std::endl;
+    std::cout << "topic: " << get_topic(m) << " data: " << get_data(m) << std::endl;
 // --poll-end
 
 ///

--- a/doc/_examples/ping.cc
+++ b/doc/_examples/ping.cc
@@ -19,7 +19,7 @@ int main() {
     auto st = caf::get_if<status>(&ss_res);
     if ( ! (st && st->code() == sc::peer_added) ) {
         std::cerr << "could not connect" << std::endl;
-	return 1;
+	      return 1;
     }
 
     for ( int n = 0; n < 5; n++ ) {
@@ -29,7 +29,7 @@ int main() {
 
         // Wait for "pong" reply event.
         auto msg = sub.get();
-	bro::Event pong(std::move(msg.second));
+       	bro::Event pong(move_data(msg));
         std::cout << "received " << pong.name() << pong.args() << std::endl;
     }
 

--- a/doc/_examples/synopsis.cc
+++ b/doc/_examples/synopsis.cc
@@ -14,7 +14,7 @@ int main()
 
     auto sub = ep.make_subscriber({"/test/t2"}); // Subscribe to incoming messages for topic.
     auto msg = sub.get(); // Wait for one incoming message.
-    std::cout << "got data for topic " << msg.first << ": " << msg.second << std::endl;
+    std::cout << "got data for topic " << get_topic(msg) << ": " << get_data(msg) << std::endl;
 
     // Data stores
 

--- a/src/broker-node.cc
+++ b/src/broker-node.cc
@@ -261,11 +261,12 @@ void relay_mode(broker::endpoint& ep, broker::topic topic) {
   auto in = ep.make_subscriber({topic});
   for (;;) {
     auto x = in.get();
-    if (is_ping_msg(x.second)) {
-      verbose::println("received ping ", msg_id(x.second));
-    } else if (is_pong_msg(x.second)) {
-      verbose::println("received pong ", msg_id(x.second));
-    } else if (is_stop_msg(x.second)) {
+    auto& val = get<1>(x);
+    if (is_ping_msg(val)) {
+      verbose::println("received ping ", msg_id(val));
+    } else if (is_pong_msg(val)) {
+      verbose::println("received pong ", msg_id(val));
+    } else if (is_stop_msg(val)) {
       verbose::println("received stop");
       return;
     }
@@ -290,7 +291,7 @@ void ping_mode(broker::endpoint& ep, broker::topic topic) {
   ep.publish(topic, make_ping_msg(0, 0));
   while (!connected) {
     auto x = in.get(caf::duration{retry_timeout});
-    if (x && is_pong_msg(x->second, 0))
+    if (x && is_pong_msg(get<1>(*x), 0))
       connected = true;
     else
       ep.publish(topic, make_ping_msg(0, 0));
@@ -303,7 +304,7 @@ void ping_mode(broker::endpoint& ep, broker::topic topic) {
     ep.publish(topic, make_ping_msg(i, s));
     do {
       auto x = in.get();
-      done = is_pong_msg(x.second, i);
+      done = is_pong_msg(get<1>(x), i);
     } while (!done);
     auto t1 = std::chrono::system_clock::now();
     auto roundtrip = std::chrono::duration_cast<timespan>(t1 - t0);
@@ -318,10 +319,11 @@ void pong_mode(broker::endpoint& ep, broker::topic topic) {
   auto in = ep.make_subscriber({topic});
   for (;;) {
     auto x = in.get();
-    if (is_ping_msg(x.second)) {
-      verbose::println("received ping ", msg_id(x.second));
-      ep.publish(topic, make_pong_msg(msg_id(x.second)));
-    } else if (is_stop_msg(x.second)) {
+    auto& val = get<1>(x);
+    if (is_ping_msg(val)) {
+      verbose::println("received ping ", msg_id(val));
+      ep.publish(topic, make_pong_msg(msg_id(val)));
+    } else if (is_stop_msg(val)) {
       verbose::println("received stop");
       return;
     }

--- a/src/broker-pipe.cc
+++ b/src/broker-pipe.cc
@@ -22,12 +22,12 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <caf/atom.hpp>
 #include <caf/behavior.hpp>
+#include <caf/config_option_adder.hpp>
 #include <caf/deep_to_string.hpp>
 #include <caf/downstream.hpp>
 #include <caf/event_based_actor.hpp>
 #include <caf/exit_reason.hpp>
 #include <caf/send.hpp>
-#include <caf/config_option_adder.hpp>
 #pragma GCC diagnostic pop
 
 #include "broker/atoms.hh"
@@ -41,6 +41,8 @@
 #include "broker/topic.hh"
 
 using broker::data;
+using broker::data_message;
+using broker::make_data_message;
 using broker::topic;
 
 using namespace caf;
@@ -137,7 +139,8 @@ void publish_mode_stream(broker::endpoint& ep, const std::string& topic_str,
     [](size_t& msgs) {
       msgs = 0;
     },
-    [=](size_t& msgs, downstream<std::pair<topic, data>>& out, size_t hint) {
+    [=](size_t& msgs, downstream<data_message>& out,
+        size_t hint) {
       auto num = std::min(cap - msgs, hint);
       std::string line;
       for (size_t i = 0; i < num; ++i)
@@ -146,7 +149,7 @@ void publish_mode_stream(broker::endpoint& ep, const std::string& topic_str,
           msgs = cap;
           return;
         } else {
-          out.push(std::make_pair(topic_str, std::move(line)));
+          out.push(make_data_message(topic_str, std::move(line)));
         }
       msgs += num;
       msg_count += num;
@@ -202,7 +205,7 @@ void subscribe_mode_stream(broker::endpoint& ep, const std::string& topic_str,
     [](size_t& msgs) {
       msgs = 0;
     },
-    [=](size_t& msgs, std::pair<topic, data> x) {
+    [=](size_t& msgs, data_message x) {
       ++msg_count;
       if (!rate)
         print_line(std::cout, deep_to_string(x));

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -42,6 +42,9 @@ configuration::configuration(broker_options opts) : options_(std::move(opts)) {
   add_message_type<optional<timespan>>("broker::optional<broker::timespan>");
   add_message_type<snapshot>("broker::snapshot");
   add_message_type<internal_command>("broker::internal_command");
+  add_message_type<command_message>("broker::command_message");
+  add_message_type<data_message>("broker::data_message");
+  add_message_type<node_message>("broker::node_message");
   add_message_type<set_command>("broker::set_command");
   add_message_type<store::stream_type::value_type>(
     "broker::store::stream_type::value_type");

--- a/src/endpoint.cc
+++ b/src/endpoint.cc
@@ -268,18 +268,21 @@ void endpoint::forward(std::vector<topic> ts)
 
 void endpoint::publish(topic t, data d) {
   BROKER_INFO("publishing" << std::make_pair(t, d));
-  caf::anon_send(core(), atom::publish::value, std::move(t), std::move(d));
+  caf::anon_send(core(), atom::publish::value,
+                 make_data_message(std::move(t), std::move(d)));
 }
 
 void endpoint::publish(const endpoint_info& dst, topic t, data d) {
   BROKER_INFO("publishing" << std::make_pair(t, d) << "to" << dst.node);
-  caf::anon_send(core(), atom::publish::value, dst, std::move(t), std::move(d));
+  caf::anon_send(core(), atom::publish::value, dst,
+                 make_data_message(std::move(t), std::move(d)));
 }
 
-void endpoint::publish(std::vector<value_type> xs) {
+void endpoint::publish(std::vector<data_message> xs) {
   for ( auto& x : xs ) {
     BROKER_INFO("publishing" << x);
-    caf::anon_send(core(), atom::publish::value, std::move(x.first), std::move(x.second));
+    auto& tup = x.unshared();
+    caf::anon_send(core(), atom::publish::value, std::move(x));
   }
 }
 

--- a/src/publisher.cc
+++ b/src/publisher.cc
@@ -5,6 +5,7 @@
 
 #include "broker/data.hh"
 #include "broker/endpoint.hh"
+#include "broker/message.hh"
 #include "broker/topic.hh"
 
 using namespace caf;
@@ -55,9 +56,9 @@ behavior publisher_worker(stateful_actor<publisher_worker_state>* self,
     [](unit_t&) {
       // nop
     },
-    [=](unit_t&, downstream<endpoint::value_type>& out, size_t num) {
+    [=](unit_t&, downstream<data_message>& out, size_t num) {
       auto& st = self->state;
-      auto consumed = qptr->consume(num, [&](std::pair<topic, data>&& x) {
+      auto consumed = qptr->consume(num, [&](data_message&& x) {
         out.push(std::move(x));
       });
       if (consumed > 0) {

--- a/src/subscriber.cc
+++ b/src/subscriber.cc
@@ -51,11 +51,9 @@ struct subscriber_worker_state {
 
 const char* subscriber_worker_state::name = "subscriber_worker";
 
-using input_type = std::pair<topic, data>;
-
-class subscriber_sink : public stream_sink<input_type> {
+class subscriber_sink : public stream_sink<data_message> {
 public:
-  using super = stream_sink<input_type>;
+  using super = stream_sink<data_message>;
 
   using queue_ptr = detail::shared_subscriber_queue_ptr<>;
 
@@ -76,7 +74,7 @@ public:
 protected:
    void handle(inbound_path*, downstream_msg::batch& x) override {
     CAF_LOG_TRACE(CAF_ARG(x));
-    using vec_type = std::vector<input_type>;
+    using vec_type = std::vector<data_message>;
     if (x.xs.match_elements<vec_type>()) {
       auto& xs = x.xs.get_mutable_as<vec_type>(0);
       auto xs_size = xs.size();

--- a/tests/benchmark/broker-stream-benchmark.cc
+++ b/tests/benchmark/broker-stream-benchmark.cc
@@ -52,7 +52,7 @@ void sink_mode(broker::endpoint& ep, topic t) {
     [](caf::unit_t&) {
       // nop
     },
-    [=](caf::unit_t&, std::vector<std::pair<topic, data>>& xs) {
+    [=](caf::unit_t&, std::vector<data_message>& xs) {
       global_count += xs.size();
     },
     [=](caf::unit_t&, const caf::error&) {
@@ -65,14 +65,15 @@ void sink_mode(broker::endpoint& ep, topic t) {
 
 void source_mode(broker::endpoint& ep, topic t) {
   using namespace caf;
-  auto msg = std::make_pair(std::move(t), data{"Lorem ipsum dolor sit amet."});
+  auto msg = make_data_message(t, "Lorem ipsum dolor sit amet.");
   auto worker = ep.publish_all(
     [](caf::unit_t&) {
       // nop
     },
-    [=](caf::unit_t&, downstream<std::pair<topic, data>>& out, size_t num) {
+    [=](caf::unit_t&, downstream<data_message>& out, size_t num) {
       for (size_t i = 0; i < num; ++i)
         out.push(msg);
+      global_count += num;
     },
     [=](const caf::unit_t&) {
       return false;

--- a/tests/cpp/master.cc
+++ b/tests/cpp/master.cc
@@ -47,8 +47,9 @@ CAF_TEST(local_master) {
   CAF_CHECK_EQUAL(n, "foo");
   // send put command to the master's topic
   anon_send(core, atom::publish::value, atom::local::value,
-            n / topics::master_suffix,
-            make_internal_command<put_command>("hello", "universe"));
+            make_command_message(
+              n / topics::master_suffix,
+              make_internal_command<put_command>("hello", "universe")));
   run();
   // read back what we have written
   sched.inline_next_enqueue(); // ds.get talks to the master_actor (blocking)
@@ -161,8 +162,8 @@ CAF_TEST(master_with_clone) {
   ds_mars.put("user", "neverlord");
   expect_on(mars, (atom_value, internal_command),
             from(_).to(ds_mars.frontend()).with(atom::local::value, _));
-  expect_on(mars, (atom_value, topic, internal_command),
-            from(_).to(mars.ep.core()).with(atom::publish::value, _, _));
+  expect_on(mars, (atom_value, command_message),
+            from(_).to(mars.ep.core()).with(atom::publish::value, _));
   exec_all();
   earth.sched.inline_next_enqueue(); // .get talks to the master
   CAF_CHECK_EQUAL(value_of(ds_earth.get("user")), data{"neverlord"});

--- a/tests/cpp/ssl.cc
+++ b/tests/cpp/ssl.cc
@@ -81,9 +81,8 @@ MESSAGE("prepare authenticated connection");
   auto b = venus_auth.ep.peer("127.0.0.1", p);
   CAF_REQUIRE(b);
 
-  using value_type = std::pair<topic, data>;
-  value_type ping{"/broker/test", "ping"};
-  value_type pong{"/broker/test", "pong"};
+  data_message ping{"/broker/test", "ping"};
+  data_message pong{"/broker/test", "pong"};
 
   MESSAGE("mercury_auth sending ping");
   mercury_auth.ep.publish({ping});

--- a/tests/cpp/status_subscriber.cc
+++ b/tests/cpp/status_subscriber.cc
@@ -23,8 +23,6 @@ using namespace caf;
 using namespace broker;
 using namespace broker::detail;
 
-using value_type = std::pair<topic, data>;
-
 namespace {
 
 struct fixture : base_fixture {

--- a/tests/cpp/subscriber.cc
+++ b/tests/cpp/subscriber.cc
@@ -17,6 +17,7 @@
 #include "broker/data.hh"
 #include "broker/endpoint.hh"
 #include "broker/filter_type.hh"
+#include "broker/message.hh"
 #include "broker/subscriber.hh"
 #include "broker/topic.hh"
 
@@ -28,32 +29,28 @@ using namespace caf;
 using namespace broker;
 using namespace broker::detail;
 
-using value_type = std::pair<topic, data>;
-
 namespace {
 
 void driver(event_based_actor* self, const actor& sink) {
-  using buf_type = std::vector<value_type>;
+  using buf_type = std::vector<data_message>;
   self->make_source(
     // Destination.
     sink,
     // Initialize send buffer with 10 elements.
     [](buf_type& xs) {
-      xs = buf_type{{"a", 0}, {"b", true}, {"a", 1}, {"a", 2}, {"b", false},
-                    {"b", true}, {"a", 3}, {"b", false}, {"a", 4}, {"a", 5}};
+      xs = data_msgs({{"a", 0},     {"b", true}, {"a", 1}, {"a", 2},
+                      {"b", false}, {"b", true}, {"a", 3}, {"b", false},
+                      {"a", 4},     {"a", 5}});
     },
     // Get next element.
-    [](buf_type& xs, downstream<value_type>& out, size_t num) {
+    [](buf_type& xs, downstream<data_message>& out, size_t num) {
       auto n = std::min(num, xs.size());
       for (size_t i = 0u; i < n; ++i)
         out.push(xs[i]);
       xs.erase(xs.begin(), xs.begin() + static_cast<ptrdiff_t>(n));
     },
     // Did we reach the end?.
-    [](const buf_type& xs) {
-      return xs.empty();
-    }
-  );
+    [](const buf_type& xs) { return xs.empty(); });
 }
 
 } // namespace <anonymous>
@@ -86,8 +83,9 @@ CAF_TEST(blocking_subscriber) {
   CAF_MESSAGE("driver: " << to_string(d1));
   run();
   CAF_MESSAGE("check content of the subscriber's buffer");
-  using buf = std::vector<value_type>;
-  buf expected{{"b", true}, {"b", false}, {"b", true}, {"b", false}};
+  using buf = std::vector<data_message>;
+  auto expected = data_msgs({{"b", true}, {"b", false},
+                             {"b", true}, {"b", false}});
   CAF_CHECK_EQUAL(sub.poll(), expected);
   // Shutdown.
   CAF_MESSAGE("Shutdown core actors.");
@@ -109,14 +107,14 @@ CAF_TEST(nonblocking_subscriber) {
   self->send(core1, atom::peer::value, core2);
   run();
   // Connect a subscriber (leaf) to core2.
-  using buf = std::vector<value_type>;
+  using buf = std::vector<data_message>;
   buf result;
   ep.subscribe_nosync(
     {"b"},
     [](unit_t&) {
       // nop
     },
-    [&](unit_t&, value_type x) {
+    [&](unit_t&, data_message x) {
       result.emplace_back(std::move(x));
     },
     [](unit_t&, const error&) {
@@ -127,7 +125,8 @@ CAF_TEST(nonblocking_subscriber) {
   auto d1 = sys.spawn(driver, core1);
   // Communication is identical to the consumer-centric test in test/cpp/core.cc
   run();
-  buf expected{{"b", true}, {"b", false}, {"b", true}, {"b", false}};
+  auto expected = data_msgs({{"b", true}, {"b", false},
+                             {"b", true}, {"b", false}});
   CAF_REQUIRE_EQUAL(result, expected);
   // Shutdown.
   CAF_MESSAGE("Shutdown core actors.");

--- a/tests/test.hpp
+++ b/tests/test.hpp
@@ -95,4 +95,14 @@ inline caf::error error_of(caf::expected<broker::data> x) {
   return std::move(x.error());
 }
 
+/// Convenience function for creating a vector of events from topic and data
+/// pairs.
+inline std::vector<broker::data_message>
+data_msgs(std::initializer_list<std::pair<broker::topic, broker::data>> xs) {
+  std::vector<broker::data_message> result;
+  for (auto& x : xs)
+    result.emplace_back(x.first, x.second);
+  return result;
+}
+
 #endif


### PR DESCRIPTION
**This is a breaking API change.**

Sorry for the long delay. I had this in the pipeline for quite a while now, but I hadn't the cycles since we were working non-stop on releasing our first version for Tenzir.

# Summary

One of the outcomes of the performance evaluation we did for BroCon 2018 was that Broker wastes a lot of cycles by making unnecessary copies. This is because CAF assumes that individual elements in a stream are cheap to copy but `broker::data` is not.

To fix this, we wrap the topic/data pairs that travel through Broker's pub/sub channels into copy-on-write optimized tuples. This turns the previous deep copies for each individual pair into a simple reference increase.

Is it worth it? I think it's a crucial step into the right direction and drastically improves performance for multiple local subscribers, but Broker's performance in a distributed setup isn't affected as much as I'd hoped.

# API Changes

From a user-perspective, Broker now returns a `data_message` (please see the new `message.hh` header) wherever it used to return a `std::pair<topic, data>`. I've added convenience functions to interact with the new COW-tuple in a more descriptive manner than using `get<0>(...)` and `get<1>(...)`:

```diff
  auto sub = ep.make_subscriber({"/topic/test"});
  auto msg = sub.get();
- auto topic = msg.first;
- auto data_ = msg.second;
+ auto topic = get_topic(msg);
+ auto data_ = get_data(msg);
```

Please note that I did *not* look into the Python bindings. Maybe the C++ changes can even be hidden in the Python API without loss of efficiency.

# Evaluation

I've used my personal MacMini for the evaluation (Late 2012, 4 cores), so by all means please feel free to re-run this on more sophisticated hardware.

## `broker-stream-benchmark`

This benchmark uses `endpoint::subscribe` and `endpoint::publish_all`. It's as close to the underlying stream processing when using the `both` mode to run everything in one process. Hence, this benchmark should show the biggest improvement.

First up is `master`, hitting CTRL+C after the first 10 messages.

```
[master] $ broker-stream-benchmark -m both
132055 msgs/s
181842 msgs/s
198092 msgs/s
190648 msgs/s
185640 msgs/s
189253 msgs/s
173780 msgs/s
150490 msgs/s
133849 msgs/s
106028 msgs/s
```

106k to 198k messages per second.

```
[PR] $ broker-stream-benchmark -m both
3495604 msgs/s
2719193 msgs/s
1065131 msgs/s
1466757 msgs/s
2632291 msgs/s
2253084 msgs/s
1112171 msgs/s
2491704 msgs/s
1492858 msgs/s
791025 msgs/s
```

We can see that the values fluctuate more heavily this time around. However, we get 790k to 3.4M messages per second out of Broker this time. The worst case of the new implementation is a 4x speedup over the previous best case.

## BroCon18 Throughput Setup

I've also revisited the BroCon18 setup for the throughput measurement. The scripts can be found in our [events repository](https://github.com/tenzir/events/tree/master/brocon18/evaluation/throughput). I tweaked it slightly to stop at 1k payload and only used 1-2 nodes.

This time around, we are measuring Broker in a distributed setup: `Publisher -> Node_1 -> ... -> Node_n -> Subscriber` with varying payloads. Because we are dealing with serialization and deserialization this time around, we won't see a similar jump in performance.

At BroCon, we've seen that serialization overhead starts dominating at 1k payloads. So I've only looked at payloads of 100.

First up is `master` again. At the beginning of each run there's a couple of 0 entries in the CSV entries, so we take the last 10 measurements.

```
$ grep "2,100," MacMiniMaster.csv | tail -n 10 | awk -F , '{ print $3 }'
55574
42143
43507
45365
45128
49288
47180
37242
47334
48977
```

42k to 55k messages per second with two nodes between Ping and Pong. How is the topic branch performing?

```
$ grep "2,100," MacMiniBranch.csv | tail -n 10 | awk -F , '{ print $3 }'
76578
74185
69911
61505
64530
68059
64589
63636
68188
67829
```

No 4x speedup this time, but 61k to 76k is still an increase of more than 10% over the previous best case. Keep in mind that this is purely based on pruning unnecessary copies.