### PR TITLE
Ensure default logging level of "quiet"

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -46,10 +46,13 @@ configuration::configuration(broker_options opts) : options_(std::move(opts)) {
                  "maximum number of entries when recording published messages");
   // Override CAF default file names.
   set("logger.file-name", "broker_[PID]_[TIMESTAMP].log");
+  set("logger.file-verbosity", caf::atom("quiet"));
+  set("logger.console-verbosity", caf::atom("quiet"));
   // Check for supported environment variables.
   if (auto env = getenv("BROKER_DEBUG_VERBOSE")) {
     if (*env && *env != '0') {
-      set("logger.verbosity", caf::atom("DEBUG"));
+      set("logger.file-verbosity", caf::atom("DEBUG"));
+      set("logger.console-verbosity", caf::atom("DEBUG"));
       set("logger.component-filter", "");
     }
   }
@@ -57,7 +60,8 @@ configuration::configuration(broker_options opts) : options_(std::move(opts)) {
     char level[10];
     strncpy(level, env, sizeof(level));
     level[sizeof(level) - 1] = '\0';
-    set("logger.verbosity", caf::atom(level));
+    set("logger.file-verbosity", caf::atom(level));
+    set("logger.console-verbosity", caf::atom(level));
   }
   if (auto env = getenv("BROKER_DEBUG_COMPONENT_FILTER"))
     set("logger.component-filter", env);


### PR DESCRIPTION
@Neverlord I noticed recently that, by default, a broker debugging log (like `broker_41230_1567711072863207642.log`) is being produced.  It's probably from the change here:

https://github.com/zeek/broker/pull/50/commits/9ad279fb7df7f498ddd10aefa82312574d2ddccc#diff-796ff3abb46ec8392fcee018e603fe2dL128

Don't really remember the full story about that workaround and maybe isn't completely relevant anymore after switching to CAF 0.17.x, but bottom line is that I think we shouldn't be producing a log by default, only when the user takes an action to enable it.  So does this PR look like a sane way to accomplish that?  Though, I kind of expected that the default logging behavior/level inherited from CAF would have been quiet in the first place?