### PR TITLE
Switch from header guards to pragma once

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,10 +97,9 @@ General
 Header
 ------
 
-- Header filenames end in `.h` and implementation filenames in `.cc`.
+- Header filenames end in `.hh` and implementation filenames in `.cc`.
 
-- All header files should use #define guards to prevent multiple inclusion. The
-  format of the symbol name should be `BROKER_<PATH>_<TO>_<FILE>_H`.
+- All header files should use `#pragma once` to prevent multiple inclusion.
 
 - Don't use `#include` when a forward declarations suffices. It can make sense
   to outsource forward declarations into a separate file per module. The file
@@ -119,7 +118,7 @@ Header
   ```
 
   Within each section the order should be alphabetical. Broker includes should
-  always be in doublequotes and relative to the source directory, whereas
+  always be in double quotes and relative to the source directory, whereas
   system-wide includes in angle brackets.
 
 - As in the standard library, the order of parameters when declaring a function

--- a/include/broker/address.hh
+++ b/include/broker/address.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_ADDRESS_HH
-#define BROKER_ADDRESS_HH
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -93,5 +92,3 @@ struct hash<broker::address> {
 };
 
 } // namespace std;
-
-#endif // BROKER_ADDRESS_HH

--- a/include/broker/api_flags.hh
+++ b/include/broker/api_flags.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_API_FLAGS_HH
-#define BROKER_API_FLAGS_HH
+#pragma once
 
 namespace broker {
 
@@ -25,5 +24,3 @@ constexpr bool has_api_flags(api_flags haystack, api_flags needle) {
 }
 
 } // namespace broker
-
-#endif // BROKER_API_FLAGS_HH

--- a/include/broker/atoms.hh
+++ b/include/broker/atoms.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_ATOMS_HH
-#define BROKER_ATOMS_HH
+#pragma once
 
 #include <caf/atom.hpp>
 
@@ -76,5 +75,3 @@ using snapshot = caf::atom_constant<caf::atom("snapshot")>;
 
 } // namespace atom
 } // namespace broker
-
-#endif // BROKER_ATOMS_HH

--- a/include/broker/backend.hh
+++ b/include/broker/backend.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_BACKEND_HH
-#define BROKER_BACKEND_HH
+#pragma once
 
 namespace broker {
 
@@ -11,5 +10,3 @@ enum backend {
 };
 
 } // namespace broker
-
-#endif // BROKER_BACKEND_HH

--- a/include/broker/backend_options.hh
+++ b/include/broker/backend_options.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_BACKEND_OPTIONS_HH
-#define BROKER_BACKEND_OPTIONS_HH
+#pragma once
 
 #include <string>
 #include <unordered_map>
@@ -11,5 +10,3 @@ namespace broker {
 using backend_options = std::unordered_map<std::string, data>;
 
 } // namespace broker
-
-#endif // BROKER_BACKEND_OPTIONS_HH

--- a/include/broker/bad_variant_access.hh
+++ b/include/broker/bad_variant_access.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_BAD_VARIANT_ACCESS_HH
-#define BROKER_BAD_VARIANT_ACCESS_HH
+#pragma once
 
 #include <exception>
 
@@ -15,5 +14,3 @@ public:
 };
 
 } // namespace broker
-
-#endif // BROKER_BAD_VARIANT_ACCESS_HH

--- a/include/broker/bro.hh
+++ b/include/broker/bro.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_BRO_HH
-#define BROKER_BRO_HH
+#pragma once
 
 #pragma message("Warning: bro.hh header is deprecated, use zeek.hh instead")
 
@@ -40,5 +39,3 @@ using IdentifierUpdate
 
 } // namespace broker
 } // namespace bro
-
-#endif // BROKER_BRO_HH

--- a/include/broker/broker.hh
+++ b/include/broker/broker.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_BROKER_HH
-#define BROKER_BROKER_HH
+#pragma once
 
 #include "broker/address.hh"
 #include "broker/atoms.hh"
@@ -16,5 +15,3 @@
 #include "broker/subscriber.hh"
 #include "broker/time.hh"
 #include "broker/version.hh"
-
-#endif // BROKER_BROKER_HH

--- a/include/broker/configuration.hh
+++ b/include/broker/configuration.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_CONFIGURATION_HH
-#define BROKER_CONFIGURATION_HH
+#pragma once
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
@@ -48,5 +47,3 @@ private:
 };
 
 } // namespace broker
-
-#endif // BROKER_CONFIGURATION_HH

--- a/include/broker/convert.hh
+++ b/include/broker/convert.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_CONVERT_HH
-#define BROKER_CONVERT_HH
+#pragma once
 
 #include <chrono>
 #include <ostream>
@@ -106,5 +105,3 @@ auto operator<<(std::basic_ostream<Char, Traits>& os, T&& x)
 }
 
 } // namespace broker
-
-#endif // BROKER_CONVERT_HH

--- a/include/broker/core_actor.hh
+++ b/include/broker/core_actor.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_CORE_ACTOR_HH
-#define BROKER_CORE_ACTOR_HH
+#pragma once
 
 #include <map>
 #include <unordered_map>
@@ -191,5 +190,3 @@ caf::behavior core_actor(caf::stateful_actor<core_state>* self,
                          endpoint::clock* clock);
 
 } // namespace broker
-
-#endif // BROKER_CORE_ACTOR_HH

--- a/include/broker/data.hh
+++ b/include/broker/data.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DATA_HH
-#define BROKER_DATA_HH
+#pragma once
 
 #include <cstdint>
 #include <map>
@@ -328,5 +327,3 @@ struct hash<broker::table>
   : broker::detail::container_hasher<broker::table> {};
 
 } // namespace std
-
-#endif // BROKER_DATA_HH

--- a/include/broker/defaults.hh
+++ b/include/broker/defaults.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DEFAULTS_HH
-#define BROKER_DEFAULTS_HH
+#pragma once
 
 #include "caf/string_view.hpp"
 
@@ -14,5 +13,3 @@ extern const size_t output_generator_file_cap;
 
 } // namespace defaults
 } // namespace broker
-
-#endif // BROKER_DEFAULTS_HH

--- a/include/broker/detail/abstract_backend.hh
+++ b/include/broker/detail/abstract_backend.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_ABSTRACT_BACKEND_HH
-#define BROKER_DETAIL_ABSTRACT_BACKEND_HH
+#pragma once
 
 #include "broker/data.hh"
 #include "broker/expected.hh"
@@ -107,5 +106,3 @@ public:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_ABSTRACT_BACKEND_HH

--- a/include/broker/detail/appliers.hh
+++ b/include/broker/detail/appliers.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_APPLIERS_HH
-#define BROKER_DETAIL_APPLIERS_HH
+#pragma once
 
 #include "broker/data.hh"
 #include "broker/error.hh"
@@ -162,5 +161,3 @@ struct retriever {
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_APPLIERS_HH

--- a/include/broker/detail/assert.hh
+++ b/include/broker/detail/assert.hh
@@ -1,9 +1,5 @@
-#ifndef BROKER_DETAIL_ASSERT_HH
-#define BROKER_DETAIL_ASSERT_HH
+#pragma once
 
 #include <caf/config.hpp>
 
 #define BROKER_ASSERT CAF_ASSERT
-
-#endif // BROKER_DETAIL_ASSERT_HH
-

--- a/include/broker/detail/blob.hh
+++ b/include/broker/detail/blob.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_BLOB_HH
-#define BROKER_DETAIL_BLOB_HH
+#pragma once
 
 #include <string>
 #include <vector>
@@ -36,5 +35,3 @@ T from_blob(const std::string& str) {
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_BLOB_HH

--- a/include/broker/detail/clone_actor.hh
+++ b/include/broker/detail/clone_actor.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_CLONE_ACTOR_HH
-#define BROKER_DETAIL_CLONE_ACTOR_HH
+#pragma once
 
 #include <unordered_map>
 #include <vector>
@@ -101,5 +100,3 @@ caf::behavior clone_actor(caf::stateful_actor<clone_state>* self,
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_CLONE_ACTOR_HH

--- a/include/broker/detail/core_policy.hh
+++ b/include/broker/detail/core_policy.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_CORE_POLICY_HH
-#define BROKER_DETAIL_CORE_POLICY_HH
+#pragma once
 
 #include <vector>
 #include <utility>
@@ -411,5 +410,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_CORE_POLICY_HH

--- a/include/broker/detail/core_scatterer.hh
+++ b/include/broker/detail/core_scatterer.hh
@@ -1,10 +1,7 @@
-#ifndef BROKER_DETAIL_CORE_SCATTERER_HH
-#define BROKER_DETAIL_CORE_SCATTERER_HH
+#pragma once
 
 namespace broker {
 namespace detail {
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_CORE_SCATTERER_HH

--- a/include/broker/detail/data_generator.hh
+++ b/include/broker/detail/data_generator.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_DATA_GENERATOR_HH
-#define BROKER_DETAIL_DATA_GENERATOR_HH
+#pragma once
 
 #include <random>
 #include <unordered_map>
@@ -98,5 +97,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_DATA_GENERATOR_HH

--- a/include/broker/detail/die.hh
+++ b/include/broker/detail/die.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_DIE_HH
-#define BROKER_DETAIL_DIE_HH
+#pragma once
 
 #include <iostream>
 
@@ -29,5 +28,3 @@ template <class... Ts>
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_DIE_HH

--- a/include/broker/detail/filesystem.hh
+++ b/include/broker/detail/filesystem.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_FILESYSTEM_HH
-#define BROKER_DETAIL_FILESYSTEM_HH
+#pragma once
 
 #include <string>
 
@@ -38,5 +37,3 @@ bool remove_all(const path& p);
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_FILESYSTEM_HH

--- a/include/broker/detail/flare.hh
+++ b/include/broker/detail/flare.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_FLARE_HH
-#define BROKER_DETAIL_FLARE_HH
+#pragma once
 
 #include <cstddef>
 #include <chrono>
@@ -74,5 +73,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_FLARE_HH

--- a/include/broker/detail/flare_actor.hh
+++ b/include/broker/detail/flare_actor.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_FLARE_ACTOR_HH
-#define BROKER_DETAIL_FLARE_ACTOR_HH
+#pragma once
 
 #include <atomic>
 #include <chrono>
@@ -58,5 +57,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_FLARE_ACTOR_HH

--- a/include/broker/detail/generator_file_reader.hh
+++ b/include/broker/detail/generator_file_reader.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_GENERATOR_FILE_READER_HH
-#define BROKER_DETAIL_GENERATOR_FILE_READER_HH
+#pragma once
 
 #include <memory>
 #include <cstddef>
@@ -50,5 +49,3 @@ generator_file_reader_ptr make_generator_file_reader(const std::string& fname);
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_GENERATOR_FILE_READER_HH

--- a/include/broker/detail/generator_file_writer.hh
+++ b/include/broker/detail/generator_file_writer.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_GENERATOR_FILE_WRITER_HH
-#define BROKER_DETAIL_GENERATOR_FILE_WRITER_HH
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -89,5 +88,3 @@ generator_file_writer& operator<<(generator_file_writer& out,
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_GENERATOR_FILE_WRITER_HH

--- a/include/broker/detail/hash.hh
+++ b/include/broker/detail/hash.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_HASH_HH
-#define BROKER_DETAIL_HASH_HH
+#pragma once
 
 #include <functional>
 
@@ -45,5 +44,3 @@ struct container_hasher {
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_HASH_HH

--- a/include/broker/detail/make_backend.hh
+++ b/include/broker/detail/make_backend.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_MAKE_BACKEND_HH
-#define BROKER_DETAIL_MAKE_BACKEND_HH
+#pragma once
 
 #include <memory>
 
@@ -16,5 +15,3 @@ std::unique_ptr<abstract_backend> make_backend(backend type,
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_MAKE_BACKEND_HH

--- a/include/broker/detail/make_unique.hh
+++ b/include/broker/detail/make_unique.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_MAKE_UNIQUE_HH
-#define BROKER_DETAIL_MAKE_UNIQUE_HH
+#pragma once
 
 #include <memory>
 
@@ -12,5 +11,3 @@ unique_ptr<T> make_unique(Ts&&... xs) {
 }
 
 } // namespace std
-
-#endif // BROKER_DETAIL_MAKE_UNIQUE_HH

--- a/include/broker/detail/master_actor.hh
+++ b/include/broker/detail/master_actor.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_MASTER_ACTOR_HH
-#define BROKER_DETAIL_MASTER_ACTOR_HH
+#pragma once
 
 #include <unordered_set>
 
@@ -95,5 +94,3 @@ caf::behavior master_actor(caf::stateful_actor<master_state>* self,
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_MASTER_ACTOR_HH

--- a/include/broker/detail/master_resolver.hh
+++ b/include/broker/detail/master_resolver.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_MASTER_RESOLVER_HH
-#define BROKER_DETAIL_MASTER_RESOLVER_HH
+#pragma once
 
 #include <vector>
 
@@ -23,5 +22,3 @@ caf::behavior master_resolver(master_resolver_actor* self);
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_MASTER_RESOLVER_HH

--- a/include/broker/detail/memory_backend.hh
+++ b/include/broker/detail/memory_backend.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_MEMORY_BACKEND_HH
-#define BROKER_DETAIL_MEMORY_BACKEND_HH
+#pragma once
 
 #include <unordered_map>
 
@@ -54,5 +53,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_MEMORY_BACKEND_HH

--- a/include/broker/detail/meta_command_writer.hh
+++ b/include/broker/detail/meta_command_writer.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_META_COMMAND_WRITER_HH
-#define BROKER_DETAIL_META_COMMAND_WRITER_HH
+#pragma once
 
 #include <cstdint>
 
@@ -46,5 +45,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_META_COMMAND_WRITER_HH

--- a/include/broker/detail/meta_data_writer.hh
+++ b/include/broker/detail/meta_data_writer.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_META_DATA_WRITER_HH
-#define BROKER_DETAIL_META_DATA_WRITER_HH
+#pragma once
 
 #include <unordered_map>
 
@@ -81,5 +80,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_META_DATA_WRITER_HH

--- a/include/broker/detail/network_cache.hh
+++ b/include/broker/detail/network_cache.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_NETWORK_CACHE_HPP
-#define BROKER_DETAIL_NETWORK_CACHE_HPP
+#pragma once
 
 #include <cstdint>
 #include <set>
@@ -125,5 +124,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_NETWORK_CACHE_HPP

--- a/include/broker/detail/operators.hh
+++ b/include/broker/detail/operators.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_OPERATORS_HH
-#define BROKER_DETAIL_OPERATORS_HH
+#pragma once
 
 namespace broker {
 namespace detail {
@@ -32,5 +31,3 @@ struct totally_ordered : equality_comparable<T, U>,
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_OPERATORS_HH

--- a/include/broker/detail/prefix_matcher.hh
+++ b/include/broker/detail/prefix_matcher.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_PREFIX_MATCHER_HH
-#define BROKER_DETAIL_PREFIX_MATCHER_HH
+#pragma once
 
 #include <utility>
 #include <vector>
@@ -26,6 +25,3 @@ struct prefix_matcher {
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_PREFIX_MATCHER_HH
-

--- a/include/broker/detail/radix_tree.hh
+++ b/include/broker/detail/radix_tree.hh
@@ -29,8 +29,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef BROKER_DETAIL_RADIX_TREE_HH
-#define BROKER_DETAIL_RADIX_TREE_HH
+#pragma once
 
 #include <cstdint>
 #include <cstdlib>
@@ -1453,5 +1452,3 @@ void serialize(caf::deserializer& source, radix_tree<T, N>& rt,
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_RADIX_TREE_HH

--- a/include/broker/detail/rocksdb_backend.hh
+++ b/include/broker/detail/rocksdb_backend.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_ROCKSDB_BACKEND_HH
-#define BROKER_DETAIL_ROCKSDB_BACKEND_HH
+#pragma once
 
 #include <string>
 
@@ -66,5 +65,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_ROCKSDB_BACKEND_HH

--- a/include/broker/detail/scoped_flare_actor.hh
+++ b/include/broker/detail/scoped_flare_actor.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_SCOPED_FLARE_ACTOR_HH
-#define BROKER_DETAIL_SCOPED_FLARE_ACTOR_HH
+#pragma once
 
 #include <caf/message.hpp>
 #include <caf/actor_system.hpp>
@@ -50,5 +49,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_SCOPED_FLARE_ACTOR_HH

--- a/include/broker/detail/shared_publisher_queue.hh
+++ b/include/broker/detail/shared_publisher_queue.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_SHARED_PUBLISHER_QUEUE_HH
-#define BROKER_DETAIL_SHARED_PUBLISHER_QUEUE_HH
+#pragma once
 
 #include <caf/intrusive_ptr.hpp>
 #include <caf/make_counted.hpp>
@@ -137,5 +136,3 @@ make_shared_publisher_queue(size_t buffer_size) {
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_SHARED_PUBLISHER_QUEUE_HH

--- a/include/broker/detail/shared_queue.hh
+++ b/include/broker/detail/shared_queue.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_SHARED_QUEUE_HH
-#define BROKER_DETAIL_SHARED_QUEUE_HH
+#pragma once
 
 #include <atomic>
 #include <deque>
@@ -99,5 +98,3 @@ protected:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_SHARED_QUEUE_HH

--- a/include/broker/detail/shared_subscriber_queue.hh
+++ b/include/broker/detail/shared_subscriber_queue.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_SHARED_SUBSCRIBER_QUEUE_HH
-#define BROKER_DETAIL_SHARED_SUBSCRIBER_QUEUE_HH
+#pragma once
 
 #include <vector>
 #include <caf/intrusive_ptr.hpp>
@@ -107,5 +106,3 @@ shared_subscriber_queue_ptr<ValueType> make_shared_subscriber_queue() {
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_SHARED_SUBSCRIBER_QUEUE_HH

--- a/include/broker/detail/sqlite_backend.hh
+++ b/include/broker/detail/sqlite_backend.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_SQLITE_BACKEND_HH
-#define BROKER_DETAIL_SQLITE_BACKEND_HH
+#pragma once
 
 #include "broker/backend_options.hh"
 
@@ -54,5 +53,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_SQLITE_BACKEND_HH

--- a/include/broker/detail/subscription.hh
+++ b/include/broker/detail/subscription.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_SUBSCRIPTION_HH
-#define BROKER_DETAIL_SUBSCRIPTION_HH
+#pragma once
 
 #include <cstdint>
 #include <deque>
@@ -99,5 +98,3 @@ private:
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_SUBSCRIPTION_HH

--- a/include/broker/detail/type_traits.hh
+++ b/include/broker/detail/type_traits.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_DETAIL_TYPE_TRAITS_HH
-#define BROKER_DETAIL_TYPE_TRAITS_HH
+#pragma once
 
 #include <cstddef>
 
@@ -167,5 +166,3 @@ void verify_status_callback() {
 
 } // namespace detail
 } // namespace broker
-
-#endif // BROKER_DETAIL_TYPE_TRAITS_HH

--- a/include/broker/endpoint.hh
+++ b/include/broker/endpoint.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_ENDPOINT_HH
-#define BROKER_ENDPOINT_HH
+#pragma once
 
 #include <cstdint>
 #include <functional>
@@ -403,5 +402,3 @@ private:
 };
 
 } // namespace broker
-
-#endif // BROKER_ENDPOINT_HH

--- a/include/broker/endpoint_info.hh
+++ b/include/broker/endpoint_info.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_ENDPOINT_INFO_HH
-#define BROKER_ENDPOINT_INFO_HH
+#pragma once
 
 #include <caf/node_id.hpp>
 
@@ -24,5 +23,3 @@ typename Inspector::result_type inspect(Inspector& f, endpoint_info& info) {
 }
 
 } // namespace broker
-
-#endif // BROKER_ENDPOINT_INFO_HH

--- a/include/broker/enum_value.hh
+++ b/include/broker/enum_value.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_ENUM_VALUE_HH
-#define BROKER_ENUM_VALUE_HH
+#pragma once
 
 #include <functional>
 #include <ostream>
@@ -57,5 +56,3 @@ struct hash<broker::enum_value> {
 };
 
 } // namespace std;
-
-#endif // BROKER_ENUM_VALUE_HH

--- a/include/broker/error.hh
+++ b/include/broker/error.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_ERROR_HH
-#define BROKER_ERROR_HH
+#pragma once
 
 // ATTENTION
 // ---------
@@ -112,5 +111,3 @@ error make_error(ec x, Ts&&... xs) {
 #define BROKER_TRY(...) CAF_PP_OVERLOAD(BROKER_TRY_, __VA_ARGS__)(__VA_ARGS__)
 
 } // namespace broker
-
-#endif // BROKER_ERROR_HH

--- a/include/broker/expected.hh
+++ b/include/broker/expected.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_EXPECTED_HH
-#define BROKER_EXPECTED_HH
+#pragma once
 
 #include <caf/expected.hpp>
 
@@ -8,5 +7,3 @@ namespace broker {
 using caf::expected;
 
 } // namespace broker
-
-#endif // BROKER_EXPECTED_HH

--- a/include/broker/filter_type.hh
+++ b/include/broker/filter_type.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_FILTER_TYPE_HH
-#define BROKER_FILTER_TYPE_HH
+#pragma once
 
 #include <vector>
 
@@ -10,5 +9,3 @@ namespace broker {
 using filter_type = std::vector<topic>;
 
 } // namespace broker
-
-#endif // BROKER_FILTER_TYPE_HH

--- a/include/broker/frontend.hh
+++ b/include/broker/frontend.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_FRONTEND_HH
-#define BROKER_FRONTEND_HH
+#pragma once
 
 namespace broker {
 
@@ -16,5 +15,3 @@ enum frontend {
 };
 
 } // namespace broker
-
-#endif // BROKER_FRONTEND_HH

--- a/include/broker/fwd.hh
+++ b/include/broker/fwd.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_FWD_HH
-#define BROKER_FWD_HH
+#pragma once
 
 #include <cstdint>
 
@@ -74,5 +73,3 @@ class mailbox;
 } // namespace detail
 
 } // namespace broker
-
-#endif // BROKER_FWD_HH

--- a/include/broker/internal_command.hh
+++ b/include/broker/internal_command.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_INTERNAL_COMMAND_HH
-#define BROKER_INTERNAL_COMMAND_HH
+#pragma once
 
 #include <utility>
 #include <unordered_map>
@@ -205,5 +204,3 @@ constexpr uint8_t internal_command_uint_tag() {
 }
 
 } // namespace broker
-
-#endif // BROKER_INTERNAL_COMMAND_HH

--- a/include/broker/logger.hh
+++ b/include/broker/logger.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_LOGGER_HH
-#define BROKER_LOGGER_HH
+#pragma once
 
 #include <caf/logger.hpp>
 
@@ -23,5 +22,3 @@
 #define BROKER_ARG2 CAF_ARG2
 
 #define BROKER_ARG3 CAF_ARG3
-
-#endif // BROKER_LOGGER_HH

--- a/include/broker/mailbox.hh
+++ b/include/broker/mailbox.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_MAILBOX_HH
-#define BROKER_MAILBOX_HH
+#pragma once
 
 #include <cstddef>
 
@@ -39,5 +38,3 @@ private:
 };
 
 } // namespace broker
-
-#endif // BROKER_MAILBOX_HH

--- a/include/broker/message.hh
+++ b/include/broker/message.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_MESSAGE_HH
-#define BROKER_MESSAGE_HH
+#pragma once
 
 #include <cstdint>
 
@@ -159,5 +158,3 @@ inline internal_command::variant_type&& move_command(command_message& x) {
 }
 
 } // namespace broker
-
-#endif // BROKER_MESSAGE_HH

--- a/include/broker/network_info.hh
+++ b/include/broker/network_info.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_NETWORK_INFO_HH
-#define BROKER_NETWORK_INFO_HH
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -51,5 +50,3 @@ struct hash<broker::network_info> {
 };
 
 } // namespace std
-
-#endif // BROKER_NETWORK_INFO_HH

--- a/include/broker/none.hh
+++ b/include/broker/none.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_NONE_HH
-#define BROKER_NONE_HH
+#pragma once
 
 #include <functional>
 #include <string>
@@ -64,6 +63,4 @@ struct hash<broker::none> {
   }
 };
 
-}
-
-#endif // BROKER_NONE_HH
+} // namespace std

--- a/include/broker/optional.hh
+++ b/include/broker/optional.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_OPTIONAL_HH
-#define BROKER_OPTIONAL_HH
+#pragma once
 
 #include <caf/optional.hpp>
 
@@ -26,5 +25,3 @@ struct hash<broker::optional<T>> {
 };
 
 } // namespace std
-
-#endif // BROKER_OPTIONAL_HH

--- a/include/broker/peer_filter.hh
+++ b/include/broker/peer_filter.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_PEER_FILTER_HH
-#define BROKER_PEER_FILTER_HH
+#pragma once
 
 #include <utility>
 #include <vector>
@@ -24,5 +23,3 @@ struct peer_filter_matcher {
 };
 
 } // namespace broker
-
-#endif // BROKER_PEER_FILTER_HH

--- a/include/broker/peer_flags.hh
+++ b/include/broker/peer_flags.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_PEER_FLAGS_HH
-#define BROKER_PEER_FLAGS_HH
+#pragma once
 
 namespace broker {
 
@@ -43,5 +42,3 @@ constexpr bool is_inbound(peer_flags p) {
 }
 
 } // namespace broker
-
-#endif // BROKER_PEER_FLAGS_HH

--- a/include/broker/peer_info.hh
+++ b/include/broker/peer_info.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_PEER_INFO_HH
-#define BROKER_PEER_INFO_HH
+#pragma once
 
 #include "broker/endpoint_info.hh"
 #include "broker/peer_flags.hh"
@@ -21,5 +20,3 @@ typename Inspector::result_type inspect(Inspector& f, peer_info& pi) {
 }
 
 } // namespace broker
-
-#endif // BROKER_PEER_INFO_HH

--- a/include/broker/peer_status.hh
+++ b/include/broker/peer_status.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_PEER_STATUS_HH
-#define BROKER_PEER_STATUS_HH
+#pragma once
 
 namespace broker {
 
@@ -19,5 +18,3 @@ enum class peer_status {
 const char* to_string(peer_status);
 
 } // namespace broker
-
-#endif // BROKER_PEER_STATUS_HH

--- a/include/broker/port.hh
+++ b/include/broker/port.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_PORT_HH
-#define BROKER_PORT_HH
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -65,5 +64,3 @@ struct hash<broker::port> {
   size_t operator()(const broker::port&) const;
 };
 } // namespace std;
-
-#endif // BROKER_PORT_HH

--- a/include/broker/publisher.hh
+++ b/include/broker/publisher.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_PUBLISHER_HH
-#define BROKER_PUBLISHER_HH
+#pragma once
 
 #include <chrono>
 #include <cstddef>
@@ -97,5 +96,3 @@ private:
 };
 
 } // namespace broker
-
-#endif // BROKER_PUBLISHER_HH

--- a/include/broker/snapshot.hh
+++ b/include/broker/snapshot.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_SNAPSHOT_HH
-#define BROKER_SNAPSHOT_HH
+#pragma once
 
 #include <unordered_map>
 
@@ -11,5 +10,3 @@ namespace broker {
 using snapshot = std::unordered_map<data, data>;
 
 } // namespace broker
-
-#endif // BROKER_SNAPSHOT_HH

--- a/include/broker/status.hh
+++ b/include/broker/status.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_STATUS_HH
-#define BROKER_STATUS_HH
+#pragma once
 
 // ATTENTION
 // ---------
@@ -117,5 +116,3 @@ status make_status(Ts&&... xs) {
 }
 
 } // namespace broker
-
-#endif // BROKER_STATUS_HH

--- a/include/broker/status_subscriber.hh
+++ b/include/broker/status_subscriber.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_EVENT_SUBSCRIBER_HH
-#define BROKER_EVENT_SUBSCRIBER_HH
+#pragma once
 
 #include <vector>
 
@@ -81,5 +80,3 @@ inline const T& get(const status_variant& d) {
 }
 
 } // namespace broker
-
-#endif // BROKER_EVENT_SUBSCRIBER_HH

--- a/include/broker/store.hh
+++ b/include/broker/store.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_STORE_HH
-#define BROKER_STORE_HH
+#pragma once
 
 #include <string>
 #include <vector>
@@ -284,5 +283,3 @@ private:
 };
 
 } // namespace broker
-
-#endif // BROKER_STORE_HH

--- a/include/broker/subnet.hh
+++ b/include/broker/subnet.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_SUBNET_HH
-#define BROKER_SUBNET_HH
+#pragma once
 
 #include "broker/address.hh"
 
@@ -55,5 +54,3 @@ struct hash<broker::subnet> {
   size_t operator()(const broker::subnet&) const;
 };
 } // namespace std;
-
-#endif // BROKER_SUBNET_HH

--- a/include/broker/subscriber.hh
+++ b/include/broker/subscriber.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_SUBSCRIBER_HH
-#define BROKER_SUBSCRIBER_HH
+#pragma once
 
 #include <vector>
 
@@ -60,5 +59,3 @@ private:
 };
 
 } // namespace broker
-
-#endif // BROKER_SUBSCRIBER_HH

--- a/include/broker/subscriber_base.hh
+++ b/include/broker/subscriber_base.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_SUBSCRIBER_BASE_HH
-#define BROKER_SUBSCRIBER_BASE_HH
+#pragma once
 
 #include <vector>
 
@@ -187,5 +186,3 @@ protected:
 };
 
 } // namespace broker
-
-#endif // BROKER_SUBSCRIBER_BASE_HH

--- a/include/broker/time.hh
+++ b/include/broker/time.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_TIME_HH
-#define BROKER_TIME_HH
+#pragma once
 
 #include <chrono>
 #include <cstdint>
@@ -97,5 +96,3 @@ struct hash<broker::timestamp> {
 };
 
 } // namespace std
-
-#endif // BROKER_TIME_HH

--- a/include/broker/timeout.hh
+++ b/include/broker/timeout.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_TIMEOUT_HH
-#define BROKER_TIMEOUT_HH
+#pragma once
 
 #include <chrono>
 
@@ -26,5 +25,3 @@ constexpr auto infinite = caf::infinite;
 
 } // namespace timeout
 } // namespace broker
-
-#endif // BROKER_TIMEOUT_HH

--- a/include/broker/topic.hh
+++ b/include/broker/topic.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_TOPIC_HH
-#define BROKER_TOPIC_HH
+#pragma once
 
 #include <cstddef>
 #include <string>
@@ -106,5 +105,3 @@ struct hash<broker::topic> {
 };
 
 } // namespace std
-
-#endif // BROKER_TOPIC_HH

--- a/include/broker/version.hh
+++ b/include/broker/version.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_VERSION_HH
-#define BROKER_VERSION_HH
+#pragma once
 
 #include <string>
 
@@ -29,5 +28,3 @@ std::string string();
 
 } // namespace version
 } // namespace broker
-
-#endif // BROKER_VERSION_HH

--- a/include/broker/zeek.hh
+++ b/include/broker/zeek.hh
@@ -1,5 +1,4 @@
-#ifndef BROKER_ZEEK_HH
-#define BROKER_ZEEK_HH
+#pragma once
 
 #include "broker/data.hh"
 
@@ -363,5 +362,3 @@ public:
 
 } // namespace broker
 } // namespace zeek
-
-#endif // BROKER_ZEEK_HH

--- a/tests/cpp/test.hh
+++ b/tests/cpp/test.hh
@@ -1,5 +1,4 @@
-#ifndef TEST_HPP
-#define TEST_HPP
+#pragma once
 
 #ifdef SUITE
 #define CAF_SUITE SUITE
@@ -98,5 +97,3 @@ data_msgs(std::initializer_list<std::pair<broker::topic, broker::data>> xs) {
     result.emplace_back(x.first, x.second);
   return result;
 }
-
-#endif


### PR DESCRIPTION
Both "parent projects" (Zeek and CAF) use `#pragma once`, so it makes IMO little sense for Broker to be stuck using header guards.