### PR TITLE
Remove zeek::Batch and simplify API

### DIFF
--- a/bindings/python/zeek.cpp
+++ b/bindings/python/zeek.cpp
@@ -1,4 +1,5 @@
 
+#include <stdexcept>
 #include <utility>
 #include <string>
 
@@ -21,7 +22,9 @@ void init_zeek(py::module& m) {
 
   py::class_<broker::zeek::Event, broker::zeek::Message>(m, "Event")
     .def(py::init([](broker::data data) {
-       return broker::zeek::Event(std::move(data));
+       if (!broker::zeek::Event::valid(data))
+         throw std::invalid_argument("invalid data for broker::zeek::Event");
+       return broker::zeek::Event::from(std::move(data));
        }))
     .def(py::init([](std::string name, broker::data args) {
        return broker::zeek::Event(std::move(name), std::move(caf::get<broker::vector>(args)));

--- a/doc/_examples/ping.cc
+++ b/doc/_examples/ping.cc
@@ -25,12 +25,14 @@ int main() {
     for ( int n = 0; n < 5; n++ ) {
         // Send event "ping(n)".
         zeek::Event ping("ping", {n});
-        ep.publish("/topic/test", ping);
+        ep.publish("/topic/test", ping.move_data());
 
         // Wait for "pong" reply event.
         auto msg = sub.get();
-        zeek::Event pong(move_data(msg));
-        std::cout << "received " << pong.name() << pong.args() << std::endl;
+        if (zeek::Event::valid(get_data(msg))) {
+          auto pong = zeek::Event::from(move_data(msg));
+          std::cout << "received " << pong.name() << pong.args() << std::endl;
+        }
     }
 
     return 0;

--- a/doc/comm.rst
+++ b/doc/comm.rst
@@ -271,8 +271,8 @@ Zeek:
     # g++ -std=c++11 -lbroker -lcaf_core -lcaf_io -lcaf_openssl -o ping ping.cc
     # zeek ping.zeek &
     # ./ping
-    received pong[0]
-    received pong[1]
-    received pong[2]
-    received pong[3]
-    received pong[4]
+    received pong(0)
+    received pong(1)
+    received pong(2)
+    received pong(3)
+    received pong(4)

--- a/tests/benchmark/broker-benchmark.cc
+++ b/tests/benchmark/broker-benchmark.cc
@@ -146,7 +146,7 @@ void send_batch(endpoint& ep, publisher& p) {
   vector batch;
   for (int i = 0; i < batch_size; i++) {
     auto ev = zeek::Event(std::string(name), createEventArgs());
-    batch.emplace_back(std::move(ev));
+    batch.emplace_back(ev.move_data());
   }
   total_sent += batch.size();
   p.publish(std::move(batch));
@@ -195,7 +195,7 @@ void receivedStats(endpoint& ep, data x) {
 
   if (max_received && total_recv > max_received) {
     zeek::Event ev("quit_benchmark", std::vector<data>{});
-    ep.publish("/benchmark/terminate", ev);
+    ep.publish("/benchmark/terminate", ev.move_data());
     sleep(2); // Give clients a bit.
     exit(0);
   }
@@ -311,9 +311,6 @@ void server_mode(endpoint& ep, const std::string& iface, int port) {
       // Count number of events (counts each element in a batch as one event).
       if (zeek::Message::type(msg) == zeek::Message::Type::Event) {
         ++num_events;
-      } else if (zeek::Message::type(msg) == zeek::Message::Type::Batch) {
-        zeek::Batch batch(std::move(msg));
-        num_events += batch.batch().size();
       } else {
         std::cerr << "unexpected message type" << std::endl;
         exit(1);
@@ -348,11 +345,12 @@ void server_mode(endpoint& ep, const std::string& iface, int port) {
     std::this_thread::sleep_until(timeout);
     // Generate and publish zeek event.
     timestamp now = std::chrono::system_clock::now();
-    auto stats = vector{now, now - last_time, count{reset_num_events()}};
+    auto msgs = count{reset_num_events()};
+    auto stats = vector{now, now - last_time, msgs};
     if (verbose)
-      std::cout << "stats: " << caf::deep_to_string(stats) << std::endl;
+      std::cout << msgs << " messages/s\n";
     zeek::Event ev("stats_update", vector{std::move(stats)});
-    ep.publish("/benchmark/stats", std::move(ev));
+    ep.publish("/benchmark/stats", ev.move_data());
     // Advance time and print status events.
     last_time = now;
     auto status_events = ss.poll();

--- a/tests/benchmark/broker-benchmark.cc
+++ b/tests/benchmark/broker-benchmark.cc
@@ -245,14 +245,13 @@ void client_mode(endpoint& ep, const std::string& host, int port) {
     ep.publish_all(
       [](caf::unit_t&) {},
       [](caf::unit_t&, caf::downstream<data_message>& out, size_t hint) {
-      for (size_t i = 0; i < hint; ++i) {
-      auto name = "event_" + std::to_string(event_type);
-      out.push(data_message{"/benchmark/events",
-               zeek::Event(std::move(name), createEventArgs())});
-      }
+        for (size_t i = 0; i < hint; ++i) {
+          auto name = "event_" + std::to_string(event_type);
+          zeek::Event event{std::move(name), createEventArgs()};
+          out.push(data_message{"/benchmark/events", event.move_data()});
+        }
       },
-      [](const caf::unit_t&) { return false; }
-      );
+      [](const caf::unit_t&) { return false; });
     for (;;) {
       // Print status events.
       auto ev = ss.get();


### PR DESCRIPTION
The Zeek-side batching was implemented in response to observing performance degradation with Broker compared to the old communication backend. Batching multiple Zeek messages into a single Broker message and making the content opaque to Broker by exchanging binary data (`serial_data`) mitigated the performance issues. Since then, we made several performance improvements. Most notably, Broker now uses [copy-on-write messaging](https://github.com/zeek/broker/pull/38) in order to avoid unnecessary copy overheads.

Latest benchmark results all seem to indicate that we no longer need the Zeek-side batching. Hence, this commit essentially undoes the batching:

- Remove `broker::zeek::Message::Batch` and `broker::zeek:: Batch`
- Consolidate the various `valid` functions and make them static
  + Previously, these member functions allowed to check whether an object contains valid data
  + Now, the static `valid` function checks whether it's safe to create an object in the first place
- Drop opaque `serial_data` members in favor of using Broker's `data::vector` directly

This API change also requires a patch in Zeek (see accompanying PR in `zeek/zeek`).