### PR TITLE
Add -DNO_AUTO_LIBCPP when building CAF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ else ()
         -DCAF_NO_TOOLS:bool=yes
         -DCAF_NO_PYTHON:bool=yes
         -DCAF_NO_OPENCL:bool=yes
+        -DCAF_NO_AUTO_LIBCPP:bool=yes
         -DCAF_BUILD_STATIC:bool=${ENABLE_STATIC}
         -DCAF_BUILD_STATIC_ONLY:bool=${ENABLE_STATIC_ONLY}
         # Sticking CAF libs in the same output dir as libbroker is a bit of a


### PR DESCRIPTION
When setting the C++ compiler to clang, CAF by default switches to
compiling with `-stdlib=libc++`. As Broker doesn't do that, the two end
up linking against different libaries. Setting `NO_AUTO_LIBCPP` lets CAF
use the same library settings as Broker.

(An alternative work-around is telling Zeek/Broker to likewise use libc++ by configuring with `CXXFLAGS="-stdlib=libc++"`. However, aligning defaults seems to be the right fix.)