### PR TITLE
Fix position of project(), require CMake 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -- Project Setup ------------------------------------------------------------
 
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(broker C CXX)
-cmake_minimum_required(VERSION 2.8.12)
 include(cmake/CommonCMakeConfig.cmake)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)


### PR DESCRIPTION
The call to `project` must come after `cmake_minimum_required` in CMake in order to get the correct policy settings (see https://gitlab.kitware.com/cmake/cmake/issues/19067).