### PR TITLE
Make sure broker-cluster-benchmark receives all data

### DIFF
--- a/tests/benchmark/broker-cluster-benchmark.cc
+++ b/tests/benchmark/broker-cluster-benchmark.cc
@@ -558,7 +558,12 @@ void run_receive_mode(node_manager_actor* self, caf::actor observer) {
 
 caf::behavior node_manager(node_manager_actor* self, node* this_node) {
   self->state.init(this_node);
-  //self->state.ep.forward(topics(*this_node));
+  // Make sure we subscribe to all topics locally *before* we initiate peering.
+  // Otherwise, we get a race on the topics and can "loose" initial messages.
+  // Despite its name, endpoint::forward does not force any forwarding. It only
+  // makes sure that the topic is in our local filter.
+  if (is_receiver(*this_node) || this_node->forward)
+    self->state.ep.forward(topics(*this_node));
   return {
     [=](broker::atom::init) -> caf::result<caf::atom_value> {
       // Open up the ports and start peering.


### PR DESCRIPTION
Applying both this patch and #69 seems to fix #66 for me. I've run the benchmark 500 times without it ever hanging.