### PR TITLE
Use Ubuntu 18.04 (Bionic) for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 language: cpp
 compiler:
   - gcc


### PR DESCRIPTION
Mostly as a simple way to get a C++17-capable compiler in the default
build environment.  (PR just to get Travis to run, I'll merge if/once I see it pass)