### PR TITLE
CMake: Add the 'undefined' sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,46 @@ if ( ENABLE_CCACHE )
   set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
 endif ()
 
+include(TestBigEndian)
+test_big_endian(BROKER_BIG_ENDIAN)
+
+# Mac OS ignores -pthread but other platforms require it
+if (NOT BROKER_APPLE)
+  set(EXTRA_FLAGS "${EXTRA_FLAGS} -pthread")
+endif ()
+
+# Increase warnings.
+set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wall -Wno-unused -pedantic")
+
+# Increase maximum number of instantiations.
+set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-depth=512")
+
+option(ENABLE_ADDRESS_SANITIZER "Set to ON to enable the sanitizers")
+
+if ( ENABLE_ADDRESS_SANITIZER )
+  set(additional_flags "-fsanitize=address,undefined -fno-omit-frame-pointer")
+
+  set(EXTRA_FLAGS "${EXTRA_FLAGS} ${additional_flags}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${additional_flags}")
+  set(CAF_CMAKE_EXE_LINKER_FLAGS "-DCMAKE_EXE_LINKER_FLAGS=${additional_flags}")
+
+  # Some Linux distributions may not always select the correct linker
+  # http://stackoverflow.com/q/37603238/1170277
+  if (BROKER_LINUX)
+    set(EXTRA_FLAGS "${EXTRA_FLAGS} -fuse-ld=gold")
+  endif ()
+
+  if ( NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
+    message(WARNING "ENABLE_ADDRESS_SANITIZER requires the build type to be set to Debug")
+  endif ()
+
+  if ( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
+       NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" )
+
+    message(WARNING "ENABLE_ADDRESS_SANITIZER requires the compiler to be set to Clang")
+  endif ()
+endif ()
+
 # -- Dependencies -------------------------------------------------------------
 
 if ( CAF_ROOT_DIR )
@@ -163,6 +203,8 @@ else ()
         -DCAF_NO_AUTO_LIBCPP:bool=yes
         -DCAF_BUILD_STATIC:bool=${ENABLE_STATIC}
         -DCAF_BUILD_STATIC_ONLY:bool=${ENABLE_STATIC_ONLY}
+        "-DEXTRA_FLAGS:string=${EXTRA_FLAGS}"
+        ${CAF_CMAKE_EXE_LINKER_FLAGS}
         # Sticking CAF libs in the same output dir as libbroker is a bit of a
         # hack until CMake 3.8, which has BUILD_RPATH that can instead be set
         # on libbroker.  The problem here is that broker unit tests will fail
@@ -311,31 +353,12 @@ endif ()
 
 include(RequireCXX17)
 
-# Mac OS ignores -pthread but other platforms require it
-if (NOT BROKER_APPLE)
-  set(EXTRA_FLAGS "${EXTRA_FLAGS} -pthread")
-endif ()
-
-# Increase warnings.
-set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wall -Wno-unused -pedantic")
-
-# Increase maximum number of instantiations.
-set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-depth=512")
+# Append our extra flags to the existing value of CXXFLAGS and CFLAGS.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_FLAGS}")
 
 # Reduce the number of template instantiations shown in backtrace.
-set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-backtrace-limit=3")
-
-if (ENABLE_ADDRESS_SANITIZER)
-  set(EXTRA_FLAGS "${EXTRA_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  # Some Linux distributions have apparently cannot pick the right linker
-  # properly. See: http://stackoverflow.com/q/37603238/1170277
-  if (BROKER_LINUX)
-    set(EXTRA_FLAGS "${EXTRA_FLAGS} -fuse-ld=gold")
-  endif ()
-endif(ENABLE_ADDRESS_SANITIZER)
-
-# Append our extra flags to the existing value of CXXFLAGS.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-backtrace-limit=3")
 
 install(DIRECTORY include/broker DESTINATION include FILES_MATCHING PATTERN "*.hh")
 
@@ -395,9 +418,6 @@ set(BROKER_SRC
   src/version.cc
 )
 
-include(TestBigEndian)
-test_big_endian(BROKER_BIG_ENDIAN)
-
 include(CheckIncludeFiles)
 set(CMAKE_REQUIRED_FLAGS -msse2)
 check_include_files(emmintrin.h HAVE_SSE2)
@@ -407,6 +427,7 @@ if (HAVE_SSE2)
   add_definitions(-DBROKER_USE_SSE2 -msse2)
 endif ()
 
+include(CheckCXXSourceCompiles)
 set(atomic_64bit_ops_test "
   #include <atomic>
   struct s64 { char a, b, c, d, e, f, g, h; };


### PR DESCRIPTION
This PR turns the `ENABLE_ADDRESS_SANITIZERS` flag into an option, while also enabling the 'undefined' sanitizer.

This option is now forwarded to the built-in CAF library using `EXTRA_FLAGS` and `CMAKE_EXE_LINKER_SETTINGS`

When the sanitizers are enabled, a number of tests will fail due to either leaks or undefined behaviours.

```
Test project /home/alessandro/Projects/Public/broker/build
      Start  1: backend
 1/17 Test  #1: backend ..........................***Failed    1.09 sec
      Start  2: core
 2/17 Test  #2: core .............................***Failed    0.20 sec
      Start  3: data
 3/17 Test  #3: data .............................   Passed    0.06 sec
      Start  4: data_generator
 4/17 Test  #4: data_generator ...................   Passed    0.06 sec
      Start  5: generator_file_writer
 5/17 Test  #5: generator_file_writer ............   Passed    0.06 sec
      Start  6: meta_command_writer
 6/17 Test  #6: meta_command_writer ..............   Passed    0.06 sec
      Start  7: meta_data_writer
 7/17 Test  #7: meta_data_writer .................   Passed    0.06 sec
      Start  8: integration
 8/17 Test  #8: integration ......................***Failed    0.25 sec
      Start  9: master
 9/17 Test  #9: master ...........................***Failed    0.15 sec
      Start 10: publisher
10/17 Test #10: publisher ........................***Failed    0.12 sec
      Start 11: radix_tree
11/17 Test #11: radix_tree .......................   Passed    4.49 sec
      Start 12: ssl
12/17 Test #12: ssl ..............................***Failed    0.45 sec
      Start 13: status_subscriber
13/17 Test #13: status_subscriber ................***Failed    0.11 sec
      Start 14: store
14/17 Test #14: store ............................***Failed    1.27 sec
      Start 15: subscriber
15/17 Test #15: subscriber .......................***Failed    0.13 sec
      Start 16: topic
16/17 Test #16: topic ............................   Passed    0.06 sec
      Start 17: zeek
17/17 Test #17: zeek .............................   Passed    0.05 sec

47% tests passed, 9 tests failed out of 17

Total Test time (real) =   8.71 sec

The following tests FAILED:
	  1 - backend (Failed)
	  2 - core (Failed)
	  8 - integration (Failed)
	  9 - master (Failed)
	 10 - publisher (Failed)
	 12 - ssl (Failed)
	 13 - status_subscriber (Failed)
	 14 - store (Failed)
	 15 - subscriber (Failed)
Errors while running CTest
```

The full output (with the output of the sanitizers) can be seen by running `ctest -V`