### PR TITLE
Redesign Broker's configuration setup

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -173,6 +173,13 @@ The environment variables take precedence over configuration file entries
 Broker is based on CAF_, so *experienced* users can also use the ``broker.conf``
 to  `tweak various settings
 <https://actor-framework.readthedocs.io/en/stable/ConfiguringActorApplications.html>`_.
+Making use of advanced features is most helpful for developers that contribute
+to Broker's CAF-based C++ source code. For seeing the "full picture", including
+CAF log output, developers can build CAF with log level ``debug`` or ``trace``
+(either by calling ``configure --with-log-level=LVL`` or passing
+``CAF_LOG_LEVEL=LVL`` to CMake directly when using the embedded CAF version) and
+add the entry ``component-blacklist = []`` to the ``logger`` section of the
+``broker.conf`` file.
 
 .. _Zeek: https://www.zeek.org
 .. _CAF: https://actor-framework.org

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -109,4 +109,70 @@ backends, which are currently: in-memory, `SQLite <https://www.sqlite.org>`_, an
 
 :ref:`data-stores` illustrates how to use data stores in different settings.
 
+Troubleshooting
+---------------
+
+By default, Broker keeps console output to a minimum. When running a Broker
+cluster, this bare minimum may omit too much information for troubleshooting.
+
+Users can enable more output either by setting environment variables or by
+providing a ``broker.conf`` file. Custom Broker appliations also may support
+passing command line arguments (Zeek_ does not forward command line arguments to
+Broker).
+
+In order to get a high-level view of what Broker is doing internally, we
+recommend settting:
+
+::
+
+    BROKER_CONSOLE_VERBOSITY=info
+
+Settings this environment variable before running Zeek_ (or any other Broker
+application) prints high-level events such as new network connections, peering
+requests, etc. The runtime cost of enabling this option and the volume of
+printed lines is moderate.
+
+Troubleshooting a Broker application (or Zeek_ scripts that communicate over
+Broker) sometimes requries tapping into the exchanged messages directly. Setting
+the verbosity to debug instead will provide such details:
+
+::
+
+    BROKER_CONSOLE_VERBOSITY=debug
+
+Note that using this verbosity level will slow down Broker and produce a high
+volume of printed output.
+
+Setting ``BROKER_FILE_VERBOSITY`` instead (or in addition) causes Broker to
+print the output to a file. This is particularly useful when troubleshooting a
+cluster, since it allows to run a test setup first and then collect all files
+for the analysis.
+
+The file output is also more detailled than the console output, as it includes
+information such as source file locations, timestamps, and functions names.
+
+In case setting environment variables is impossible or file-based configuration
+is simply more convenient, creating a file called ``broker.conf`` in the working
+directory of the application (before running it) provides an alternative way of
+configuring Broker.
+
+A minimal configuration file that sets console and file verbosity looks like
+this:
+
+::
+
+    logger {
+      ; note the single quotes!
+      console-verbosity = 'info'
+      file-verbosity = 'debug'
+    }
+
+The environment variables take precedence over configuration file entries
+(but command line arguments have the highest priority).
+
+Broker is based on CAF_, so *experienced* users can also use the ``broker.conf``
+to  `tweak various settings
+<https://actor-framework.readthedocs.io/en/stable/ConfiguringActorApplications.html>`_.
+
 .. _Zeek: https://www.zeek.org
+.. _CAF: https://actor-framework.org

--- a/include/broker/configuration.hh
+++ b/include/broker/configuration.hh
@@ -25,15 +25,43 @@ struct broker_options {
   broker_options() {}
 };
 
-/// Provides an execution context for brokers.
+/// Configures an ::endpoint.
+///
+/// The configuration draws user-provided options from three sources (in order):
+/// 1. The file `broker.conf`. Contents of this file override hard-coded
+///    defaults. Broker only scans the current working directory when looking
+///    for this file.
+/// 2. Environment variables. Broker currently recognizes the following
+///    environment variables:
+///    - `BROKER_CONSOLE_VERBOSITY`: enables console output by overriding
+///      `logger.console-verbosity`. Valid values are `trace`, `debug`, `info`,
+///      `warning`, and `error`.
+///    - `BROKER_FILE_VERBOSITY`: enables log file output by overriding
+///      `logger.file-verbosity`.
+///    - `BROKER_RECORDING_DIRECTORY` enables recording of meta data for the
+///      `broker-cluster-benchmark` tool.
+///    - `BROKER_OUTPUT_GENERATOR_FILE_CAP` restricts the number of recorded
+///      messages in recording mode.
+/// 3. Command line arguments (if provided).
+///
+/// As a rule of thumb, set `BROKER_CONSOLE_VERBOSITY` to `info` for getting
+/// output on high-level events such as peerings. If you need to tap
+/// into published messages, set `BROKER_CONSOLE_VERBOSITY` to `debug`. Enabling
+/// debug output will slow down Broker and generates a lot of console output.
+///
+/// Writing to a file instead of printing to the command line can help grepping
+/// through large logs or correlating logs from multiple Broker peers.
 class configuration : public caf::actor_system_config {
 public:
   using super = caf::actor_system_config;
 
   /// Default-constructs a configuration.
-  configuration(broker_options opts = broker_options());
+  configuration();
 
-  /// Constructs a configuration from the command line.
+  /// Constructs a configuration with non-default Broker options.
+  explicit configuration(broker_options opts);
+
+  /// Constructs a configuration from command line arguments.
   configuration(int argc, char** argv);
 
   /// Returns default Broker options and flags.
@@ -47,6 +75,8 @@ public:
   static void add_message_types(caf::actor_system_config& cfg);
 
 private:
+  void init(int argc, char** argv);
+
   broker_options options_;
 };
 

--- a/src/broker-node.cc
+++ b/src/broker-node.cc
@@ -171,7 +171,9 @@ constexpr size_t max_cap = std::numeric_limits<size_t>::max();
 
 class config : public broker::configuration {
 public:
-  config() {
+  using super = broker::configuration;
+
+  config() : super(skip_init) {
     opt_group{custom_options_, "global"}
       .add<bool>("verbose,v", "print status and debug output")
       .add<bool>("rate,r", "print receive rate ('relay' mode only)")
@@ -193,6 +195,8 @@ public:
       .add<uint16_t>("local-port,l",
                      "local port for publishing this endpoint at");
   }
+
+  using super::init;
 };
 
 // -- convenience get_or and get_if overloads for enpoint ----------------------
@@ -463,8 +467,10 @@ void pong_mode(broker::endpoint& ep, topic_list topics) {
 int main(int argc, char** argv) {
   // Parse CLI parameters using our config.
   config cfg;
-  if (auto err = cfg.parse(argc, argv)) {
-    err::println("error while reading config: ", cfg.render(err));
+  try {
+    cfg.init(argc, argv);
+  } catch (std::exception& ex) {
+    err::println(ex.what());
     return EXIT_FAILURE;
   }
   if (cfg.cli_helptext_printed)

--- a/src/broker-pipe.cc
+++ b/src/broker-pipe.cc
@@ -70,6 +70,8 @@ void print_line(std::ostream& out, const std::string& line) {
 
 class config : public broker::configuration {
 public:
+  using super = broker::configuration;
+
   atom_value mode = atom("");
   atom_value impl = atom("blocking");
   std::string topic;

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -23,9 +24,66 @@
 #include "broker/topic.hh"
 #include "broker/version.hh"
 
+#include <unistd.h>
+
 namespace broker {
 
+namespace {
+
+constexpr const char* conf_file = "broker.conf";
+
+template <class... Ts>
+auto concat(Ts... xs) {
+  std::string result;
+  ((result += xs), ...);
+  return result;
+}
+
+bool valid_log_level(caf::atom_value x) {
+  using caf::atom_uint;
+  switch (atom_uint(x)) {
+    default:
+      return false;
+    case atom_uint("trace"):
+    case atom_uint("debug"):
+    case atom_uint("info"):
+    case atom_uint("warning"):
+    case atom_uint("error"):
+    case atom_uint("quiet"):
+      return true;
+  }
+}
+
+optional<caf::atom_value> to_log_level(const char* cstr) {
+  caf::string_view str{cstr, strlen(cstr)};
+  auto atm = caf::to_lowercase(caf::atom_from_string(str));
+  if (valid_log_level(atm))
+    return atm;
+  return nil;
+}
+
+[[noreturn]] void throw_illegal_log_level(const char* var, const char* cstr) {
+  auto what
+    = concat("illegal value for environment variable ", var, ": '", cstr,
+             "' (legal values: 'trace', 'debug', 'info', 'warning', 'error')");
+  throw std::invalid_argument(what);
+}
+
+} // namespace
+
 configuration::configuration(broker_options opts) : options_(std::move(opts)) {
+  init(0, nullptr);
+}
+
+configuration::configuration() : configuration(broker_options{}) {
+  // nop
+}
+
+configuration::configuration(int argc, char** argv) {
+  init(argc, argv);
+}
+
+void configuration::init(int argc, char** argv) {
   // Add runtime type information for Broker types.
   add_message_types(*this);
   // Load CAF modules.
@@ -44,44 +102,63 @@ configuration::configuration(broker_options opts) : options_(std::move(opts)) {
                       "path for storing recorded meta information")
     .add<size_t>("output-generator-file-cap",
                  "maximum number of entries when recording published messages");
-  // Override CAF default file names.
+  // Phase "0": Override CAF defaults.
+  using caf::atom;
   set("logger.file-name", "broker_[PID]_[TIMESTAMP].log");
-  set("logger.file-verbosity", caf::atom("quiet"));
-  set("logger.console-verbosity", caf::atom("quiet"));
-  // Check for supported environment variables.
-  if (auto env = getenv("BROKER_DEBUG_VERBOSE")) {
-    if (*env && *env != '0') {
-      set("logger.file-verbosity", caf::atom("DEBUG"));
-      set("logger.console-verbosity", caf::atom("DEBUG"));
-      set("logger.component-filter", "");
-    }
+  set("logger.file-verbosity", atom("quiet"));
+  // Enable console output (and color it if stdout is a TTY) but set verbosty to
+  // quiet. This allows users to only care about the environment variable
+  // BROKER_CONSOLE_VERBOSITY.
+  if (isatty(STDOUT_FILENO))
+    set("logger.console", atom("colored"));
+  else
+    set("logger.console", atom("uncolored"));
+  set("logger.console-verbosity", atom("quiet"));
+  // Turn off all CAF output by default.
+  std::vector<caf::atom_value> blacklist{atom("caf"), atom("caf_io"),
+                                         atom("caf_net"), atom("caf_flow"),
+                                         atom("caf_stream")};
+  set("logger.component-blacklist", std::move(blacklist));
+  // Phase 1: parse broker.conf (overrides hard-coded defaults).
+  if (auto err = parse(0, nullptr, conf_file)) {
+    auto what = concat("Error while reading ", conf_file, ": ", render(err));
+    throw std::runtime_error(what);
   }
-  if (auto env = getenv("BROKER_DEBUG_LEVEL")) {
-    char level[10];
-    strncpy(level, env, sizeof(level));
-    level[sizeof(level) - 1] = '\0';
-    set("logger.file-verbosity", caf::atom(level));
-    set("logger.console-verbosity", caf::atom(level));
+  // Phase 2: parse environment variables (override config file settings).
+  if (auto console_verbosity = getenv("BROKER_CONSOLE_VERBOSITY")) {
+    if (auto level = to_log_level(console_verbosity))
+      set("logger.console-verbosity", *level);
+    else
+      throw_illegal_log_level("BROKER_CONSOLE_VERBOSITY", console_verbosity);
   }
-  if (auto env = getenv("BROKER_DEBUG_COMPONENT_FILTER"))
-    set("logger.component-filter", env);
-  if (auto env = getenv("BROKER_RECORDING_DIRECTORY"))
+  if (auto file_verbosity = getenv("BROKER_FILE_VERBOSITY")) {
+    if (auto level = to_log_level(file_verbosity))
+      set("logger.file-verbosity", *level);
+    else
+      throw_illegal_log_level("BROKER_FILE_VERBOSITY", file_verbosity);
+  }
+  if (auto env = getenv("BROKER_RECORDING_DIRECTORY")) {
     set("broker.recording-directory", env);
-  if (auto env = getenv("BROKER_OUTPUT_GENERATOR_FILE_CAP")) {
-    try {
-      auto value = static_cast<size_t>(std::stoi(env));
-      if (value < 0)
-        throw std::runtime_error("expected a positive number");
-      set("broker.output-generator-file-cap", static_cast<size_t>(value));
-    } catch (...) {
-      std::cerr << "*** invalid value for BROKER_OUTPUT_GENERATOR_FILE_CAP: "
-                << env << " (expected a positive number)";
-    }
   }
-}
-
-configuration::configuration(int argc, char** argv) : configuration{} {
-  parse(argc, argv);
+  if (auto env = getenv("BROKER_OUTPUT_GENERATOR_FILE_CAP")) {
+    char* end = nullptr;
+    auto value = strtol(env, &end, 10);
+    if (errno == ERANGE || *end != '\0' || value < 0) {
+      auto what
+        = concat("invalid value for BROKER_OUTPUT_GENERATOR_FILE_CAP: ", env,
+                 " (expected a positive integer)");
+      throw std::invalid_argument(what);
+    }
+    set("broker.output-generator-file-cap", static_cast<size_t>(value));
+  }
+  // Phase 3: parse command line arguments.
+  if (argc == 0)
+    return;
+  std::stringstream dummy;
+  if (auto err = parse(argc, argv, dummy)) {
+    auto what = concat("Error while parsing CLI arguments: ", render(err));
+    throw std::runtime_error(what);
+  }
 }
 
 caf::settings configuration::dump_content() const {

--- a/src/core_actor.cc
+++ b/src/core_actor.cc
@@ -79,10 +79,10 @@ struct retry_state {
       [self, cpy](actor x) mutable {
         init_peering(self, std::move(x), std::move(cpy.rp));
       },
-      [self, cpy](error) mutable {
-        auto desc = "remote endpoint unavailable";
+      [self, cpy](error err) mutable {
+        auto desc = "remote endpoint unavailable: " + self->system().render(err);
         BROKER_ERROR(desc);
-        self->state.emit_error<ec::peer_unavailable>(cpy.addr, desc);
+        self->state.emit_error<ec::peer_unavailable>(cpy.addr, desc.c_str());
         if (cpy.addr.retry.count() > 0) {
           BROKER_INFO("retrying" << cpy.addr << "in"
                                  << to_string(cpy.addr.retry));

--- a/src/endpoint.cc
+++ b/src/endpoint.cc
@@ -169,6 +169,9 @@ endpoint::endpoint(configuration config)
   : config_(std::move(config)),
     await_stores_on_shutdown_(false),
     destroyed_(false) {
+  // Stop immediately if any helptext was printed.
+  if (config_.cli_helptext_printed)
+    exit(0);
   // Create a directory for storing the meta data if requested.
   auto meta_dir = get_or(config_, "broker.recording-directory",
                          defaults::recording_directory);

--- a/tests/benchmark/broker-benchmark.cc
+++ b/tests/benchmark/broker-benchmark.cc
@@ -364,7 +364,9 @@ void server_mode(endpoint& ep, const std::string& iface, int port) {
 }
 
 struct config : configuration {
-  config(){
+  using super = configuration;
+
+  config() : configuration(skip_init) {
     opt_group{custom_options_, "global"}
       .add(event_type, "event-type,t",
            "1 (vector, default) | 2 (conn log entry) | 3 (table)")
@@ -380,6 +382,8 @@ struct config : configuration {
       .add(server, "server", "run in server mode")
       .add(verbose, "verbose", "enable status output");
   }
+
+  using super::init;
 
   std::string help_text() const {
     return custom_options_.help_text();
@@ -397,8 +401,10 @@ void usage(const config& cfg, const char* cmd_name) {
 
 int main(int argc, char** argv) {
   config cfg;
-  if (auto err = cfg.parse(argc,argv)){
-    std::cerr << "*** invalid command line: " << cfg.render(err) << "\n\n";
+  try {
+    cfg.init(argc, argv);
+  } catch (std::exception& ex) {
+    std::cerr << ex.what() << "\n\n";
     usage(cfg, argv[0]);
     return EXIT_FAILURE;
   }

--- a/tests/benchmark/broker-cluster-benchmark.cc
+++ b/tests/benchmark/broker-cluster-benchmark.cc
@@ -352,7 +352,7 @@ struct node_manager_state {
     broker::broker_options opts;
     opts.forward = this_node_ptr->forward;
     opts.disable_ssl = true;
-    opts.ignore_broker_conf = true; // Make no one messes with our setup.
+    opts.ignore_broker_conf = true; // Make sure no one messes with our setup.
     broker::configuration cfg{opts};
     cfg.set("middleman.workers", 0);
     cfg.set("logger.file-name", this_node->name + ".log");

--- a/tests/benchmark/broker-cluster-benchmark.cc
+++ b/tests/benchmark/broker-cluster-benchmark.cc
@@ -352,6 +352,7 @@ struct node_manager_state {
     broker::broker_options opts;
     opts.forward = this_node_ptr->forward;
     opts.disable_ssl = true;
+    opts.ignore_broker_conf = true; // Make no one messes with our setup.
     broker::configuration cfg{opts};
     cfg.set("middleman.workers", 0);
     cfg.set("logger.file-name", this_node->name + ".log");


### PR DESCRIPTION
This set of changes fixes some quirks about Broker's handling of configuration parameters. In particular, it removes the two environment variables `BROKER_DEBUG_VERBOSE` and `BROKER_DEBUG_LEVEL`. They had unclear semantics and did too many (undocumented) things.

The newly recommended way for users to tap into more verbose Broker output is:

- `BROKER_CONSOLE_VERBOSITY=info` for high-level events such as connections/peerings/etc
- `BROKER_CONSOLE_VERBOSITY=debug` for low-level events and seeing what get's published

Users that want the output in a file instead can use `BROKER_FILE_VERBOSITY`.

Please read the detailed commit description of fa952b8 for more technical details. This new set of variables is easy to comprehend and to explain.

Last but not least, I've added a new entry `Troubleshooting` to the documentation that walks users through the available options of getting verbose output. I left out advanced topics such as tweaking the component filter intentionally. Developers that are familiar with CAF can refer to the CAF manual in order to tap into more logging options. Broker users should not have to care about log output of CAF.

I'll also provide a followup to this PR to refine Broker's log output. In particular to make sure users get a better understanding of what went wrong in case of an error. Recent example: Broker's output gives users no clue what went wrong in case two Broker instances with incompatible versions of CAF clash (all they see is a TCP connect followed by a disconnect).

Relates #80.