### PR TITLE
Fix accidential error/log output

### DIFF
--- a/src/subscriber.cc
+++ b/src/subscriber.cc
@@ -82,6 +82,7 @@ protected:
       state_->counter += xs_size;
       queue_->produce(xs_size, std::make_move_iterator(xs.begin()),
                       std::make_move_iterator(xs.end()));
+      return;
     }
     BROKER_ERROR("received unexpected batch type (dropped)");
   }


### PR DESCRIPTION
Closes #83.

It's one of these bugs where you look at stacktraces for way too long until realizing it's just a missing return. 🤦🏻‍♂️