### PR TITLE
Fix a race condition in data store flare operations

### DIFF
--- a/include/broker/detail/flare_actor.hh
+++ b/include/broker/detail/flare_actor.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <atomic>
+#include <mutex>
 #include <chrono>
 #include <limits>
 
@@ -54,7 +54,8 @@ public:
 
 private:
   flare flare_;
-  std::atomic<int> flare_count_;
+  int flare_count_;
+  std::mutex flare_mtx_;
 };
 
 } // namespace detail


### PR DESCRIPTION
The race (as seen via Zeek usage) goes like:

Thread A: enqueue item, get suspended
Thread B: sees mailbox has items
Thread B: dequeue item
Thread B: extinguish flare
Thread A: resume, fire flare

That ordering can leave the flare in an active state without any actual
items remaining in the mailbox.

This patch adds a mutex/lock such that extinguishing of the flare cannot
be interleaved between the enqueue and firing of the flare.

This likely relates to https://github.com/zeek/zeek/issues/838,
https://github.com/zeek/zeek/issues/716, as well as this thread
http://mailman.icsi.berkeley.edu/pipermail/zeek/2020-February/015062.html

For reference, also attaching a patch that applies against the Broker version shipped with Zeek 3.0.x:

[broker-store-race-3.0.patch.txt](https://github.com/zeek/broker/files/4290901/broker-store-race-3.0.patch.txt)

The CPU load caused by this bug seems particularly exaggerated in Zeek 3.0.x due to some vagaries of its main loop logic: `threading::Manager` is never idle and prevents `FindSoonest` from ever doing the 20 usec sleep when all sources are idle; while the Broker source is also always in the idle state (since it never processes any new messages) but with always-ready FD (due to this bug), meaning the loop tries to process Broker every iteration instead of every 25th iteration had there been an actual way for all sources to be in a legit idle state.
