### PR TITLE
Increase template backtrace limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,8 @@ if (NOT broker_is_subproject)
     set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wall -Wno-unused -pedantic")
     # Increase maximum number of instantiations.
     set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-depth=512")
-    # Reduce the number of template instantiations shown in backtrace.
-    set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-backtrace-limit=3")
+    # Make sure to get the full context on template errors.
+    set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-backtrace-limit=0")
   endif ()
 
   # Append our extra flags to the existing value of CXXFLAGS.


### PR DESCRIPTION
Setting the template backtrace limit to allow number renders compiler
output on templated code practically useless. In fact, doing the
opposite (disabling the limit altogether) is often times the only way to
get sufficient context for fixing an error.