### PR TITLE
Add missing binding for broker_options member

### DIFF
--- a/bindings/python/_broker.cpp
+++ b/bindings/python/_broker.cpp
@@ -234,6 +234,7 @@ PYBIND11_MODULE(_broker, m) {
     .def_readwrite("disable_ssl", &broker::broker_options::disable_ssl)
     .def_readwrite("ttl", &broker::broker_options::ttl)
     .def_readwrite("forward", &broker::broker_options::forward)
+    .def_readwrite("ignore_broker_conf", &broker::broker_options::ignore_broker_conf)
     .def_readwrite("use_real_time", &broker::broker_options::use_real_time);
 
   // We need a configuration class here that's separate from


### PR DESCRIPTION
Give Python scripts access to `broker_options::ignore_broker_conf`.