### PR TITLE
Fix concurrency setup for the Cirrus/MSVC build

### DIFF
--- a/ci/windows/build.cmd
+++ b/ci/windows/build.cmd
@@ -1,6 +1,6 @@
 set PATH=%PATH%;C:\Program Files\CMake\bin
 mkdir build
 cd build
-cmake -A x64 -DOPENSSL_ROOT_DIR="C:\Program Files\OpenSSL-Win64" .. || exit \b 1
-cmake --build . --target install --config release -j %BROKER_CI_CPUS% || exit \b 1
+cmake -A x64 -DOPENSSL_ROOT_DIR="C:\Program Files\OpenSSL-Win64" -DEXTRA_FLAGS=/MP%BROKER_CI_CPUS% .. || exit \b 1
+cmake --build . --target install --config release || exit \b 1
 cd ..


### PR DESCRIPTION
MSVC requires setting `/MPn` for concurrent builds, where `n` is the desired concurrency level. Setting `-j n` when building via CMake has no effect.