### PR TITLE
Fix unusable subscriber.poll() method in Python bindings

### DIFF
--- a/bindings/python/_broker.cpp
+++ b/bindings/python/_broker.cpp
@@ -177,7 +177,15 @@ PYBIND11_MODULE(_broker, m) {
        return rval;
 	  })
 
-    .def("poll", &subscriber_base::poll)
+    .def("poll",
+         [](subscriber_base& ep) -> std::vector<topic_data_pair> {
+       auto res = ep.poll();
+       std::vector<topic_data_pair> rval;
+       rval.reserve(res.size());
+       for ( auto& e : res )
+         rval.emplace_back(std::make_pair(broker::get_topic(e), broker::get_data(e)));
+       return rval;
+      })
     .def("available", &subscriber_base::available)
     .def("fd", &subscriber_base::fd);
 

--- a/tests/python/communication.py
+++ b/tests/python/communication.py
@@ -33,7 +33,18 @@ class TestCommunication(unittest.TestCase):
         self.assertEqual(d[0], "ping")
 
         ep1.publish(t, ["pong"])
-        (t, d) = s2.get()
+
+        while True:
+            # This loop exists just for sake of test coverage for "poll()"
+            msgs = s2.poll()
+
+            if msgs:
+                self.assertEqual(len(msgs), 1)
+                (t, d) = msgs[0]
+                break;
+
+            time.sleep(0.1)
+
         self.assertEqual(t, "/test")
         self.assertEqual(d[0], "pong")
 


### PR DESCRIPTION
Fixes #109