### PR TITLE
Add new status codes for node discovery

### DIFF
--- a/bindings/python/enums.cpp
+++ b/bindings/python/enums.cpp
@@ -36,7 +36,9 @@ void init_enums(py::module& m) {
     .value("Unspecified", broker::sc::unspecified)
     .value("PeerAdded", broker::sc::peer_added)
     .value("PeerRemoved", broker::sc::peer_removed)
-    .value("PeerLost", broker::sc::peer_lost);
+    .value("PeerLost", broker::sc::peer_lost)
+    .value("EndpointDiscovered", broker::sc::endpoint_discovered)
+    .value("EndpointUnreachable", broker::sc::endpoint_unreachable);
 
   py::enum_<broker::peer_status>(m, "PeerStatus")
     .value("Initialized", broker::peer_status::initialized)

--- a/doc/comm.rst
+++ b/doc/comm.rst
@@ -106,7 +106,7 @@ as they come in (asynchronous API).
 
 Synchronous API
 ***************
-    
+
 The synchronous API exists for applications that want to poll for
 messages explicitly. Once a subscriber is registered for topics,
 calling ``get`` will wait for a new message:
@@ -150,9 +150,9 @@ TODO: Document.
 .. If your application does not require a blocking API, the non-blocking API
 .. offers an asynchronous alternative. Unlike the blocking API, non-blocking
 .. endpoints take a callback for each topic they subscribe to:
-.. 
+..
 .. .. code-block:: cpp
-.. 
+..
 ..   context ctx;
 ..   auto ep = ctx.spawn<nonblocking>();
 ..   ep.subscribe("/foo", [=](const topic& t, const data& d) {
@@ -161,12 +161,12 @@ TODO: Document.
 ..   ep.subscribe("/bar", [=](const topic& t, const data& d) {
 ..     std::cout << t << " -> " << d << std::endl;
 ..   });
-.. 
+..
 .. When a new message matching the subscription arrives, Broker dispatches it to
 .. the callback without blocking.
-.. 
+..
 .. .. warning::
-.. 
+..
 ..   The function ``subscribe`` returns immediately. Capturing variable *by
 ..   reference* introduces a dangling reference once the outer frame returns.
 ..   Therefore, only capture locals *by value*.
@@ -211,7 +211,8 @@ depend on its embedded code, which the enum ``sc`` codifies:
 
 .. literalinclude:: ../broker/status.hh
    :language: cpp
-   :lines: 26-35
+   :start-after: --sc-enum-start
+   :end-before: --sc-enum-end
 
 Status messages have an optional *context* and an optional descriptive
 *message*. The member function ``context<T>`` returns a ``const T*``

--- a/include/broker/error.hh
+++ b/include/broker/error.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 #include <utility>
 
 #include <caf/atom.hpp>
@@ -16,7 +17,7 @@ namespace broker {
 using caf::error;
 
 /// Broker's error codes.
-// -- ec-enum-start
+// --ec-enum-start
 enum class ec : uint8_t {
   /// Not-an-error.
   none,
@@ -28,6 +29,8 @@ enum class ec : uint8_t {
   peer_invalid,
   /// Remote peer not listening.
   peer_unavailable,
+  /// Remote peer closed the connection during handshake.
+  peer_disconnect_during_handshake,
   /// An peering request timed out.
   peer_timeout,
   /// Master with given name already exist.
@@ -57,8 +60,22 @@ enum class ec : uint8_t {
   end_of_file,
   /// Received an unknown type tag value.
   invalid_tag,
+  /// Deserialized an invalid status.
+  invalid_status,
 };
-// -- ec-enum-end
+// --ec-enum-end
+
+/// Evaluates to `true` if an ::error with code `E` can contain a `network_info`
+/// in its context.
+/// @relates ec
+template <ec E>
+constexpr bool ec_has_network_info_v
+  = E == ec::peer_invalid || E == ec::peer_unavailable
+    || E == ec::peer_disconnect_during_handshake;
+
+/// @relates ec
+template <ec Value>
+using ec_constant = std::integral_constant<ec, Value>;
 
 /// @relates ec
 const char* to_string(ec code) noexcept;

--- a/src/error.cc
+++ b/src/error.cc
@@ -16,6 +16,7 @@ const char* ec_names[] = {
   "peer_incompatible",
   "peer_invalid",
   "peer_unavailable",
+  "peer_disconnect_during_handshake",
   "peer_timeout",
   "master_exists",
   "no_such_master",
@@ -30,6 +31,7 @@ const char* ec_names[] = {
   "invalid_topic_key",
   "end_of_file",
   "invalid_tag",
+  "invalid_status",
 };
 
 } // namespace

--- a/tests/cpp/status.cc
+++ b/tests/cpp/status.cc
@@ -11,10 +11,14 @@ using namespace std::string_literals;
 
 namespace {
 
-data make_data_status(sc code, vector context = {}) {
-  vector result{"status"s, enum_value{to_string(code)}, nil};
+data make_data_status(sc code, vector context, std::string text) {
+  vector result;
+  result.resize(4);
+  result[0] = "status"s;
+  result[1] = enum_value{to_string(code)};
   if (!context.empty())
     result[2] = std::move(context);
+  result[3] = std::move(text);
   return data{std::move(result)};
 }
 
@@ -55,56 +59,70 @@ TEST(sc is convertible to and from string) {
   CHECK_EQUAL(to_string(sc::peer_removed), "peer_removed"s);
   CHECK_EQUAL(to_string(sc::peer_lost), "peer_lost"s);
   CHECK_EQUAL(from_string<sc>("unspecified"), sc::unspecified);
+  CHECK_EQUAL(to_string(sc::endpoint_discovered), "endpoint_discovered"s);
+  CHECK_EQUAL(to_string(sc::endpoint_unreachable), "endpoint_unreachable"s);
   CHECK_EQUAL(from_string<sc>("peer_added"), sc::peer_added);
   CHECK_EQUAL(from_string<sc>("peer_removed"), sc::peer_removed);
   CHECK_EQUAL(from_string<sc>("peer_lost"), sc::peer_lost);
+  CHECK_EQUAL(from_string<sc>("endpoint_discovered"), sc::endpoint_discovered);
+  CHECK_EQUAL(from_string<sc>("endpoint_unreachable"), sc::endpoint_unreachable);
   CHECK_EQUAL(from_string<sc>("foo"), nil);
 }
 
 TEST(status is convertible to and from data) {
   CHECK_EQUAL(get_as<data>(status{}),
-              vector({"status"s, enum_value{"unspecified"}, nil}));
-  CHECK_EQUAL(get_as<data>(status::make<sc::unspecified>("text")),
-              make_data_status(sc::unspecified, {nil, "text"}));
+              vector({"status"s, enum_value{"unspecified"}, nil, nil}));
   CHECK_EQUAL(get_as<data>(status::make<sc::peer_added>({uri_id, nil}, "text")),
-              make_data_status(sc::peer_added,
-                               {vector{uri_id_str, nil, nil, nil}, "text"}));
+              make_data_status(sc::peer_added, {uri_id_str, nil, nil, nil},
+                               "text"));
   CHECK_EQUAL(get_as<status>(make_data_status(
-                sc::peer_added, {vector{uri_id_str, nil, nil, nil}, "text"})),
+                sc::peer_added, {uri_id_str, nil, nil, nil}, "text")),
               status::make<sc::peer_added>({uri_id, nil}, "text"));
   CHECK_EQUAL(get_as<data>(status::make<sc::peer_added>({def_id, nil}, "text")),
-              make_data_status(sc::peer_added,
-                               {vector{def_id_str, nil, nil, nil}, "text"}));
+              make_data_status(sc::peer_added, {def_id_str, nil, nil, nil},
+                               "text"));
   CHECK_EQUAL(get_as<status>(make_data_status(
-                sc::peer_added, {vector{def_id_str, nil, nil, nil}, "text"})),
+                sc::peer_added, {def_id_str, nil, nil, nil}, "text")),
               status::make<sc::peer_added>({def_id, nil}, "text"));
-  CHECK_EQUAL(
-    get_as<data>(status::make<sc::peer_added>(
-      {def_id, network_info{"foo", 8080, timeout::seconds{42}}}, "text")),
-    make_data_status(
-      sc::peer_added,
-      {vector{def_id_str, "foo"s, port{8080, port::protocol::tcp}, count{42}},
-       "text"}));
+  CHECK_EQUAL(get_as<data>(
+                status::make<sc::endpoint_discovered>(def_id, "text")),
+              make_data_status(sc::endpoint_discovered,
+                               {def_id_str, nil, nil, nil}, "text"));
+  CHECK_EQUAL(get_as<data>(
+                status::make<sc::endpoint_discovered>(def_id, "text")),
+              make_data_status(sc::endpoint_discovered,
+                               {def_id_str, nil, nil, nil}, "text"));
+  CHECK_EQUAL(get_as<data>(status::make<sc::peer_added>(
+                {def_id, network_info{"foo", 8080, timeout::seconds{42}}},
+                "text")),
+              make_data_status(sc::peer_added,
+                               {def_id_str, "foo"s,
+                                port{8080, port::protocol::tcp}, count{42}},
+                               "text"));
   CHECK_EQUAL(
     get_as<status>(make_data_status(
       sc::peer_added,
-      {vector{def_id_str, "foo"s, port{8080, port::protocol::tcp}, count{42}},
-       "text"})),
+      {def_id_str, "foo"s, port{8080, port::protocol::tcp}, count{42}},
+      "text")),
     status::make<sc::peer_added>(
       {def_id, network_info{"foo", 8080, timeout::seconds{42}}}, "text"));
 }
 
 TEST(status views operate directly on raw data) {
   data raw{vector{"status"s, enum_value{"peer_added"},
-                  vector{vector{def_id_str, "foo"s,
-                                port{8080, port::protocol::tcp}, count{42}},
-                         "text"s}}};
+                  vector{def_id_str, "foo"s, port{8080, port::protocol::tcp},
+                         count{42}},
+                  "text"s}};
   auto view = make_status_view(raw);
   REQUIRE(view.valid());
   CHECK_EQUAL(view.code(), sc::peer_added);
   CHECK_EQUAL(*view.message(), "text"s);
   auto cxt = view.context();
+  REQUIRE(cxt);
+  REQUIRE(cxt->network);
   CHECK_EQUAL(cxt->node, def_id);
+  CHECK_EQUAL(cxt->network->address, "foo");
+  CHECK_EQUAL(cxt->network->port, 8080u);
 }
 
 FIXTURE_SCOPE_END()

--- a/tests/cpp/status_subscriber.cc
+++ b/tests/cpp/status_subscriber.cc
@@ -28,7 +28,11 @@ namespace {
 
 struct fixture : base_fixture {
   fixture() {
-    // nop
+    auto x = caf::make_node_id(10, "402FA79E64ACFA54522FFC7AC886630670517900");
+    if (!x)
+      FAIL("caf::make_node_id failed");
+    node = std::move(*x);
+    node_str = to_string(node);
   }
 
   void push(error x) {
@@ -46,6 +50,10 @@ struct fixture : base_fixture {
     caf::anon_send(ep.core(), atom::publish::value, atom::local::value,
                    make_data_message(topics::statuses, std::move(xs)));
   }
+
+  caf::node_id node;
+
+  std::string node_str;
 };
 
 } // namespace <anonymous>
@@ -69,7 +77,7 @@ CAF_TEST(base_tests) {
   CAF_REQUIRE_EQUAL(sub2.available(), 1u);
   CAF_REQUIRE_EQUAL(sub2.get(), e1);
   CAF_MESSAGE("test status event");
-  auto s1 = status::make<sc::unspecified>("foobar");;
+  auto s1 = status::make<sc::endpoint_discovered>(node, "foobar");
   push(s1);
   run();
   CAF_REQUIRE_EQUAL(sub1.available(), 1u);


### PR DESCRIPTION
The new status codes are currently unused, but become relevant when switching to the ALM-based communication backend. I've also simplified the implementation of `status` to no longer wrap the context unnecessarily into a `caf::message`.

Integrating this set of changes (cherry-picked from the ALM branch) ahead of time helps avoiding merge conflicts later. I did a brief pass over Broker to see what files we'd have to touch for supporting CAF 0.18 and `status.hh` was one of them (the new implementation without `caf::message` dependency would not require changes, btw).