### PR TITLE
Add CMake variable to disable doc examples

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,4 +15,6 @@ add_custom_target(broker-doc-html
 
 add_dependencies(doc broker-doc-html)
 
-add_subdirectory(_examples)
+if ( NOT BROKER_DISABLE_DOC_EXAMPLES )
+  add_subdirectory(_examples)
+endif ()


### PR DESCRIPTION
This is going to be part of a Zeek change to disable the examples when also disabling broker tests.