### PR TITLE
Slim down the core actor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ set(BROKER_SRC
   src/defaults.cc
   src/detail/abstract_backend.cc
   src/detail/clone_actor.cc
+  src/detail/core_recorder.cc
   src/detail/data_generator.cc
   src/detail/filesystem.cc
   src/detail/flare.cc

--- a/include/broker/core_actor.hh
+++ b/include/broker/core_actor.hh
@@ -24,6 +24,7 @@
 #include "broker/mixin/connector.hh"
 #include "broker/mixin/data_store_manager.hh"
 #include "broker/mixin/notifier.hh"
+#include "broker/mixin/recorder.hh"
 #include "broker/network_info.hh"
 #include "broker/optional.hh"
 #include "broker/peer_info.hh"
@@ -34,7 +35,8 @@ namespace broker {
 class core_manager
   : public caf::extend<alm::stream_transport<core_manager, caf::node_id>,
                        core_manager>:: //
-    with<mixin::connector, mixin::notifier, mixin::data_store_manager> {
+    with<mixin::connector, mixin::notifier, mixin::data_store_manager,
+         mixin::recorder> {
 public:
   // --- member types ----------------------------------------------------------
 
@@ -110,12 +112,6 @@ private:
   /// Keeps track of all actors that currently wait for handshakes to
   /// complete.
   std::unordered_map<caf::actor, size_t> peers_awaiting_status_sync_;
-
-  /// Handle for recording all subscribed topics (if enabled).
-  std::ofstream topics_file_;
-
-  /// Handle for recording all peers (if enabled).
-  std::ofstream peers_file_;
 };
 
 struct core_state {

--- a/include/broker/detail/core_recorder.hh
+++ b/include/broker/detail/core_recorder.hh
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <fstream>
+
+#include <caf/fwd.hpp>
+
+#include "broker/detail/assert.hh"
+#include "broker/detail/generator_file_writer.hh"
+#include "broker/filter_type.hh"
+#include "broker/logger.hh"
+#include "broker/message.hh"
+
+namespace broker::detail {
+
+class core_recorder {
+public:
+  explicit core_recorder(caf::local_actor* self);
+
+  void record_subscription(const filter_type& what);
+
+  void record_peer(const caf::node_id& peer_id);
+
+  explicit operator bool() const noexcept {
+    return writer_ != nullptr;
+  }
+
+  bool operator!() const noexcept {
+    return !writer_;
+  }
+
+  size_t remaining_records() const noexcept {
+    return remaining_records_ ;
+  }
+
+  template <class T>
+  bool try_record(const T& x) {
+    BROKER_ASSERT(writer_ != nullptr);
+    BROKER_ASSERT(remaining_records_ > 0);
+    if (auto err = writer_->write(x)) {
+      BROKER_WARNING("unable to write to generator file:" << err);
+      writer_ = nullptr;
+      remaining_records_ = 0;
+      return false;
+    }
+    if (--remaining_records_ == 0) {
+      BROKER_DEBUG("reached recording cap, close file");
+      writer_ = nullptr;
+    }
+    return true;
+  }
+
+  bool try_record(const node_message& x) {
+    return try_record(get_content(x));
+  }
+
+private:
+  bool open_file(std::ofstream& fs, std::string file_name);
+
+  /// Helper for recording meta data of published messages.
+  detail::generator_file_writer_ptr writer_;
+
+  /// Counts down when using a `recorder_` to cap maximum file entries.
+  size_t remaining_records_ = 0;
+
+  /// Handle for recording all subscribed topics.
+  std::ofstream topics_file_;
+
+  /// Handle for recording all peers.
+  std::ofstream peers_file_;
+};
+
+} // namespace broker::detail

--- a/include/broker/detail/has_network_info.hh
+++ b/include/broker/detail/has_network_info.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <type_traits>
+
+#include "broker/error.hh"
+#include "broker/status.hh"
+
+namespace broker::detail {
+
+/// Convenience metaprogramming utility that evaluates to either
+/// `sc_has_network_info_v` or `ec_has_network_info_v`.
+template <class EnumConstant>
+struct has_network_info;
+
+template <sc S>
+struct has_network_info<std::integral_constant<sc, S>> {
+  static constexpr bool value = sc_has_network_info_v<S>;
+};
+
+template <ec E>
+struct has_network_info<std::integral_constant<ec, E>> {
+  static constexpr bool value = ec_has_network_info_v<E>;
+};
+
+/// @relates has_network_info
+template <class EnumConstant>
+constexpr bool has_network_info_v = has_network_info<EnumConstant>::value;
+
+} // namespace broker::detail

--- a/include/broker/detail/lift.hh
+++ b/include/broker/detail/lift.hh
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <type_traits>
+
+#include "broker/none.hh"
+
+namespace broker::detail {
+
+template <class... AtomPrefix>
+struct lift_helper {
+  template <class T, class U, class R, class... Ts>
+  auto operator()(T& obj, R (U::*fun)(Ts...)) const {
+    return [&obj, fun](AtomPrefix..., Ts... xs) { return (obj.*fun)(xs...); };
+  }
+};
+
+/// Lifts a member function pointer to a message handler, prefixed with
+/// `AtomPrefix`.
+template <class... AtomPrefix>
+constexpr lift_helper<AtomPrefix...> lift = lift_helper<AtomPrefix...>{};
+
+} // namespace broker::detail

--- a/include/broker/detail/retry_state.hh
+++ b/include/broker/detail/retry_state.hh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+
+#include <caf/allowed_unsafe_message_type.hpp>
+#include <caf/response_promise.hpp>
+
+#include "broker/network_info.hh"
+
+namespace broker::detail {
+
+struct retry_state {
+  network_info addr;
+  caf::response_promise rp;
+  uint32_t count;
+};
+
+} // namespace broker::detail
+
+CAF_ALLOW_UNSAFE_MESSAGE_TYPE(broker::detail::retry_state)                               \

--- a/include/broker/fwd.hh
+++ b/include/broker/fwd.hh
@@ -158,17 +158,18 @@ CAF_BEGIN_TYPE_ID_BLOCK(broker, caf::first_custom_type_id)
 
   BROKER_ADD_ATOM(ack, "ack")
   BROKER_ADD_ATOM(default_, "default")
-  BROKER_ADD_ATOM(init, "init")
-  BROKER_ADD_ATOM(name, "name")
-  BROKER_ADD_ATOM(network, "network")
-  BROKER_ADD_ATOM(peer, "peer")
-  BROKER_ADD_ATOM(read, "read")
-  BROKER_ADD_ATOM(retry, "retry")
-  BROKER_ADD_ATOM(run, "run")
-  BROKER_ADD_ATOM(shutdown, "shutdown")
-  BROKER_ADD_ATOM(status, "status")
-  BROKER_ADD_ATOM(unpeer, "unpeer")
-  BROKER_ADD_ATOM(write, "write")
+  BROKER_ADD_ATOM(id, "id");
+  BROKER_ADD_ATOM(init, "init");
+  BROKER_ADD_ATOM(name, "name");
+  BROKER_ADD_ATOM(network, "network");
+  BROKER_ADD_ATOM(peer, "peer");
+  BROKER_ADD_ATOM(read, "read");
+  BROKER_ADD_ATOM(retry, "retry");
+  BROKER_ADD_ATOM(run, "run");
+  BROKER_ADD_ATOM(shutdown, "shutdown");
+  BROKER_ADD_ATOM(status, "status");
+  BROKER_ADD_ATOM(unpeer, "unpeer");
+  BROKER_ADD_ATOM(write, "write");
 
   // -- atoms for communication with workers -----------------------------------
 

--- a/include/broker/message.hh
+++ b/include/broker/message.hh
@@ -164,4 +164,10 @@ inline internal_command::variant_type&& move_command(command_message& x) {
   return std::move(get<1>(x.unshared()).content);
 }
 
+/// Retrieves the content from a ::data_message.
+template <class PeerId>
+const node_message_content& get_content(const generic_node_message<PeerId>& x) {
+  return x.content;
+}
+
 } // namespace broker

--- a/include/broker/mixin/connector.hh
+++ b/include/broker/mixin/connector.hh
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <caf/allowed_unsafe_message_type.hpp>
+#include <caf/response_promise.hpp>
+
+#include "broker/atoms.hh"
+#include "broker/detail/lift.hh"
+#include "broker/detail/network_cache.hh"
+#include "broker/detail/retry_state.hh"
+#include "broker/error.hh"
+#include "broker/message.hh"
+
+namespace broker::mixin {
+
+/// Adds these handlers:
+///
+/// ~~~
+/// (atom::peer, network_info addr) -> void
+/// => try_peering(addr, self->make_response_promise(), 0)
+///
+/// (atom::publish, network_info addr, data_message msg) -> void
+/// => try_publish(addr, msg, self->make_response_promise())
+/// ~~~
+template <class Base, class Subtype>
+class connector : public Base {
+public:
+  using extended_base = connector;
+
+  using super = Base;
+
+  using peer_id_type = typename super::peer_id_type;
+
+  using communication_handle_type = typename Base::communication_handle_type;
+
+  template <class... Ts>
+  explicit connector(Ts&&... xs)
+    : super(std::forward<Ts>(xs)...), cache_(super::self()) {
+    // nop
+  }
+
+  void try_peering(const network_info& addr, caf::response_promise rp,
+                   uint32_t count) {
+    auto self = super::self();
+    // Fetch the comm. handle from the cache and with that fetch the ID from the
+    // remote peer via direct request messages.
+    cache_.fetch(
+      addr,
+      [=](communication_handle_type hdl) mutable {
+        dref().start_peering(hdl.node(), hdl, std::move(rp));
+      },
+      [=](error err) mutable {
+        dref().peer_unavailable(addr);
+        if (addr.retry.count() == 0 && ++count < 10) {
+          rp.deliver(std::move(err));
+        } else {
+          self->delayed_send(self, addr.retry,
+                             detail::retry_state{addr, std::move(rp), count});
+        }
+      });
+  }
+
+  void try_publish(const network_info& addr, data_message& msg,
+                   caf::response_promise rp) {
+    auto self = super::self();
+    cache_.fetch(
+      addr,
+      [=, msg{std::move(msg)}](communication_handle_type hdl) mutable {
+        dref().ship(msg, hdl);
+        rp.deliver(caf::unit);
+      },
+      [=](error err) mutable { rp.deliver(std::move(err)); });
+  }
+
+  void peer_disconnected(const peer_id_type& peer_id,
+                         const communication_handle_type& hdl,
+                         const error& reason) {
+    if (!dref().shutting_down()) {
+      auto x = cache_.find(hdl);
+      if (x && x->retry != timeout::seconds(0)) {
+        BROKER_INFO("will try reconnecting to" << *x << "in"
+                                               << to_string(x->retry));
+        auto self = super::self();
+        self->delayed_send(self, x->retry, atom::peer_v, atom::retry_v, *x);
+      }
+    }
+    super::peer_disconnected(peer_id, hdl, reason);
+  }
+
+  template <class... Fs>
+  caf::behavior make_behavior(Fs... fs) {
+    using detail::lift;
+    auto& d = dref();
+    return super::make_behavior(
+      std::move(fs)...,
+      [=](atom::peer, const network_info& addr) {
+        dref().try_peering(addr, super::self()->make_response_promise(), 0);
+      },
+      [=](atom::peer, atom::retry, network_info& addr) {
+        dref().try_peering(addr, caf::response_promise{}, 0);
+      },
+      [=](detail::retry_state& st) {
+        dref().try_peering(st.addr, std::move(st.rp), st.count);
+      },
+      [=](atom::publish, const network_info& addr, data_message& msg) {
+        dref().try_publish(addr, msg, super::self()->make_response_promise());
+      },
+      [=](atom::unpeer, const network_info& addr) {
+        if (auto hdl = cache_.find(addr))
+          dref().unpeer(*hdl);
+        else
+          dref().cannot_remove_peer(addr);
+      });
+  }
+
+  auto& cache() {
+    return cache_;
+  }
+
+private:
+  Subtype& dref() {
+    return static_cast<Subtype&>(*this);
+  }
+
+  /// Associates network addresses to remote actor handles and vice versa.
+  detail::network_cache cache_;
+};
+
+} // namespace broker::mixin

--- a/include/broker/mixin/data_store_manager.hh
+++ b/include/broker/mixin/data_store_manager.hh
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <caf/actor.hpp>
+#include <caf/behavior.hpp>
+
+#include "broker/backend.hh"
+#include "broker/backend_options.hh"
+#include "broker/detail/clone_actor.hh"
+#include "broker/detail/lift.hh"
+#include "broker/detail/make_backend.hh"
+#include "broker/detail/master_actor.hh"
+#include "broker/detail/master_resolver.hh"
+#include "broker/endpoint.hh"
+#include "broker/filter_type.hh"
+#include "broker/logger.hh"
+#include "broker/topic.hh"
+
+namespace broker::mixin {
+
+template <class Base, class Subtype>
+class data_store_manager : public Base {
+public:
+  // --- member types ----------------------------------------------------------
+
+  using super = Base;
+
+  using extended_base = data_store_manager;
+
+  // --- constants -------------------------------------------------------------
+
+  static constexpr auto spawn_flags = caf::linked + caf::lazy_init;
+
+  // --- construction and destruction ------------------------------------------
+
+  template <class... Ts>
+  explicit data_store_manager(endpoint::clock* clock, Ts&&... xs)
+    : super(std::forward<Ts>(xs)...), clock_(clock) {
+    // nop
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns whether a master for `name` probably exists already on one of our
+  /// peers.
+  bool has_remote_master(const std::string& name) {
+    // If we don't have a master recorded locally, we could still have a
+    // propagated filter to a remote core hosting a master.
+    return dref().has_remote_subscriber(name / topics::master_suffix);
+  }
+
+  const auto& masters() const noexcept {
+    return masters_;
+  }
+
+  const auto& clones() const noexcept {
+    return clones_;
+  }
+
+  // -- data store management --------------------------------------------------
+
+  /// Attaches a master for given store to this peer.
+  caf::result<caf::actor> attach_master(const std::string& name,
+                                        backend backend_type,
+                                        backend_options opts) {
+    BROKER_TRACE(BROKER_ARG(name)
+                 << BROKER_ARG(backend_type) << BROKER_ARG(opts));
+    auto i = masters_.find(name);
+    if (i != masters_.end())
+      return i->second;
+    if (has_remote_master(name)) {
+      BROKER_WARNING("remote master with same name exists already");
+      return ec::master_exists;
+    }
+    auto ptr = detail::make_backend(backend_type, std::move(opts));
+    BROKER_ASSERT(ptr != nullptr);
+    BROKER_INFO("spawning new master:" << name);
+    auto self = super::self();
+    auto ms = self->template spawn<spawn_flags>(detail::master_actor, self,
+                                                name, std::move(ptr), clock_);
+    filter_type filter{name / topics::master_suffix};
+    if (auto err = dref().add_store(ms, filter))
+      return err;
+    masters_.emplace(name, ms);
+    return ms;
+  }
+
+  /// Attaches a clone for given store to this peer.
+  caf::result<caf::actor>
+  attach_clone(const std::string& name, double resync_interval,
+               double stale_interval, double mutation_buffer_interval) {
+    BROKER_TRACE(BROKER_ARG(name)
+                 << BROKER_ARG(resync_interval) << BROKER_ARG(stale_interval)
+                 << BROKER_ARG(mutation_buffer_interval));
+    auto i = masters_.find(name);
+    if (i != masters_.end()) {
+      BROKER_WARNING("attempted to run clone & master on the same endpoint");
+      return ec::no_such_master;
+    }
+    BROKER_INFO("spawning new clone:" << name);
+    auto self = super::self();
+    auto cl = self->template spawn<spawn_flags>(detail::clone_actor, self, name,
+                                                resync_interval, stale_interval,
+                                                mutation_buffer_interval,
+                                                clock_);
+    filter_type filter{name / topics::clone_suffix};
+    if (auto err = dref().add_store(cl, filter))
+      return err;
+    clones_.emplace(name, cl);
+    return cl;
+  }
+
+  /// Returns whether the master for the given store runs at this peer.
+  caf::result<caf::actor> get_master(const std::string& name) {
+    auto i = masters_.find(name);
+    if (i != masters_.end())
+      return i->second;
+    return ec::no_such_master;
+  }
+
+  /// Instructs the master of the given store to generate a snapshot.
+  void snapshot(const std::string& name, caf::actor& clone) {
+    auto msg = make_internal_command<snapshot_command>(super::self(),
+                                                       std::move(clone));
+    dref().publish(make_command_message(name / topics::master_suffix, msg));
+  }
+
+  /// Detaches all masters and clones by sending exit messages to the
+  /// corresponding actors.
+  void detach_stores() {
+    auto self = super::self();
+    auto f = [&](auto& container) {
+      for (auto& kvp : container)
+        self->send_exit(kvp.second, caf::exit_reason::user_shutdown);
+      container.clear();
+    };
+    f(masters_);
+    f(clones_);
+  }
+
+  // -- factories --------------------------------------------------------------
+
+  template <class... Fs>
+  caf::behavior make_behavior(Fs... fs) {
+    using detail::lift;
+    auto& d = dref();
+    return super::make_behavior(
+      std::move(fs)...,
+      lift<atom::store, atom::clone, atom::attach>(d, &Subtype::attach_clone),
+      lift<atom::store, atom::master, atom::attach>(d, &Subtype::attach_master),
+      lift<atom::store, atom::master, atom::get>(d, &Subtype::get_master),
+      lift<atom::store, atom::master, atom::snapshot>(d, &Subtype::snapshot),
+      lift<atom::shutdown, atom::store>(d, &Subtype::detach_stores),
+      [this](atom::store, atom::master, atom::resolve, std::string& name,
+             caf::actor& who_asked) {
+        // TODO: get rid of the who_asked parameter and use proper
+        // request/response semantics with forwarding/dispatching
+        auto self = super::self();
+        auto i = masters_.find(name);
+        if (i != masters_.end()) {
+          self->send(who_asked, atom::master_v, i->second);
+          return;
+        }
+        auto peers = dref().peer_handles();
+        if (peers.empty()) {
+          BROKER_INFO("no peers to ask for the master");
+          self->send(who_asked, atom::master_v,
+                     make_error(ec::no_such_master, "no peers"));
+          return;
+        }
+        auto resolver
+          = self->template spawn<caf::lazy_init>(detail::master_resolver);
+        self->send(resolver, std::move(peers), std::move(name),
+                   std::move(who_asked));
+      });
+  }
+
+private:
+  // -- CRTP scaffold ----------------------------------------------------------
+
+  Subtype& dref() {
+    return static_cast<Subtype&>(*this);
+  }
+
+  // -- member variables -------------------------------------------------------
+
+  /// Enables manual time management by the user.
+  endpoint::clock* clock_;
+
+  /// Stores all master actors created by this core.
+  std::unordered_map<std::string, caf::actor> masters_;
+
+  /// Stores all clone actors created by this core.
+  std::unordered_multimap<std::string, caf::actor> clones_;
+};
+
+} // namespace broker::mixin

--- a/include/broker/mixin/notifier.hh
+++ b/include/broker/mixin/notifier.hh
@@ -1,0 +1,182 @@
+#pragma once
+
+#include <caf/behavior.hpp>
+#include <caf/group.hpp>
+
+#include "broker/atoms.hh"
+#include "broker/data.hh"
+#include "broker/detail/assert.hh"
+#include "broker/detail/has_network_info.hh"
+#include "broker/detail/lift.hh"
+#include "broker/endpoint_info.hh"
+#include "broker/error.hh"
+#include "broker/logger.hh"
+#include "broker/message.hh"
+#include "broker/status.hh"
+#include "broker/topic.hh"
+
+namespace broker::mixin {
+
+template <class Base, class Subtype>
+class notifier : public Base {
+public:
+  using super = Base;
+
+  using extended_base = notifier;
+
+  using peer_id_type = typename super::peer_id_type;
+
+  using communication_handle_type = typename Base::communication_handle_type;
+
+  // The notifier embeds `endpoint_info` objects into status and error updates.
+  // While we keep the implementation as generic as possible, the current
+  // implementation `endpoint_info` prohibits any other peer ID type at the
+  // moment.
+  static_assert(std::is_same<peer_id_type, caf::node_id>::value);
+
+  template <class... Ts>
+  explicit notifier(Ts&&... xs) : super(std::forward<Ts>(xs)...) {
+    // nop
+  }
+
+  void peer_connected(const peer_id_type& peer_id,
+                      const communication_handle_type& hdl) {
+    BROKER_TRACE(BROKER_ARG(peer_id) << BROKER_ARG(hdl));
+    emit(hdl, sc_constant<sc::peer_added>(), "handshake successful");
+    super::peer_connected(peer_id, hdl);
+  }
+
+  void peer_disconnected(const peer_id_type& peer_id,
+                         const communication_handle_type& hdl,
+                         const error& reason) {
+    BROKER_TRACE(BROKER_ARG(peer_id) << BROKER_ARG(hdl) << BROKER_ARG(reason));
+    // Calling emit() with the peer_id only trigges a network info lookup that
+    // can stall this actor if we're already in shutdown mode. Hence, we perform
+    // a manual cache lookup and simply omit the network information if we
+    // cannot find a cached entry.
+    network_info peer_addr;
+    if (auto addr = dref().cache().find(hdl))
+      peer_addr = *addr;
+    emit(peer_id, peer_addr, sc_constant<sc::peer_lost>(),
+         "lost connection to remote peer");
+    super::peer_disconnected(peer_id, hdl, reason);
+  }
+
+  void peer_removed(const peer_id_type& peer_id,
+                    const communication_handle_type& hdl) {
+    BROKER_TRACE(BROKER_ARG(peer_id) << BROKER_ARG(hdl));
+    emit(hdl, sc_constant<sc::peer_removed>(),
+         "removed connection to remote peer");
+    super::peer_removed(peer_id, hdl);
+  }
+
+  void peer_unavailable(const peer_id_type& peer_id,
+                        const communication_handle_type& hdl,
+                        const error& reason) {
+    auto self = super::self();
+    emit(hdl, ec_constant<ec::peer_unavailable>(),
+         "failed to complete handhsake");
+    super::peer_unavailable(peer_id, hdl, reason);
+  }
+
+  void peer_unavailable(const network_info& addr) {
+    auto self = super::self();
+    emit(addr, ec_constant<ec::peer_unavailable>(),
+         "unable to connect to remote peer");
+  }
+
+  void cannot_remove_peer(const network_info& addr) {
+    BROKER_TRACE(BROKER_ARG(addr));
+    emit(addr, ec_constant<ec::peer_invalid>(),
+         "cannot unpeer from unknown peer");
+    super::cannot_remove_peer(addr);
+  }
+
+  void cannot_remove_peer(const peer_id_type& peer_id,
+                          const communication_handle_type& hdl) {
+    BROKER_TRACE(BROKER_ARG(hdl));
+    if (hdl)
+      emit(hdl, ec_constant<ec::peer_invalid>(),
+           "cannot unpeer from unknown peer");
+    super::cannot_remove_peer(peer_id, hdl);
+  }
+
+  void disable_notifications() {
+    BROKER_TRACE("");
+    disable_notifications_ = true;
+  }
+
+  template <class... Fs>
+  caf::behavior make_behavior(Fs... fs) {
+    using detail::lift;
+    auto& d = dref();
+    return super::make_behavior(
+      fs..., lift<atom::no_events>(d, &Subtype::disable_notifications));
+  }
+
+private:
+  auto& dref() {
+    return *static_cast<Subtype*>(this);
+  }
+
+  void emit(const status& stat) {
+    auto dmsg = make_data_message(topics::statuses, get_as<data>(stat));
+    dref().ship_locally(std::move(dmsg));
+  }
+
+  void emit(const error& err) {
+    auto dmsg = make_data_message(topics::errors, get_as<data>(err));
+    dref().ship_locally(std::move(dmsg));
+  }
+
+  template <class Enum, Enum Code>
+  void emit(const peer_id_type& peer_id, const network_info& x,
+            std::integral_constant<Enum, Code>, const char* msg) {
+    BROKER_INFO("emit:" << Code << x);
+    if (disable_notifications_)
+      return;
+    if constexpr (std::is_same<Enum, sc>::value)
+      emit(status::make<Code>(endpoint_info{peer_id, x}, msg));
+    else
+      emit(make_error(Code, endpoint_info{peer_id, x}, msg));
+  }
+
+  template <class Enum, Enum Code>
+  void emit(const network_info& x, std::integral_constant<Enum, Code>,
+            const char* msg) {
+    BROKER_INFO("emit:" << Code << x);
+    if (disable_notifications_)
+      return;
+    if constexpr (std::is_same<Enum, sc>::value) {
+      emit(status::make<Code>(endpoint_info{{}, x}, msg));
+    } else {
+      emit(make_error(Code, endpoint_info{{}, x}, msg));
+    }
+  }
+
+  /// Reports a status or error to all status subscribers.
+  template <class EnumConstant>
+  void emit(const communication_handle_type& hdl, EnumConstant code,
+            const char* msg) {
+    if (disable_notifications_)
+      return;
+    using value_type = typename EnumConstant::value_type;
+    if constexpr (detail::has_network_info_v<EnumConstant>) {
+      auto on_cache_hit = [=](network_info x) { emit(hdl.node(), x, code, msg); };
+      auto on_cache_miss = [=](caf::error) { emit(hdl.node(), {}, code, msg); };
+      if (super::self()->node() != hdl.node()) {
+        dref().cache().fetch(hdl, on_cache_hit, on_cache_miss);
+      } else {
+        on_cache_miss({});
+      }
+    } else if constexpr (std::is_same<value_type, sc>::value) {
+      emit(status::make<EnumConstant::value>(hdl, msg));
+    } else {
+      emit(make_error(EnumConstant::value, endpoint_info{hdl, nil}, msg));
+    }
+  }
+
+  bool disable_notifications_ = false;
+};
+
+} // namespace broker::mixin

--- a/include/broker/mixin/recorder.hh
+++ b/include/broker/mixin/recorder.hh
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "broker/detail/core_recorder.hh"
+#include "broker/filter_type.hh"
+
+namespace broker::mixin {
+
+template <class Base, class Subtype>
+class recorder : public Base {
+public:
+  using super = Base;
+
+  using extended_base = recorder;
+
+  using message_type = typename super::message_type;
+
+  using peer_id_type = typename super::peer_id_type;
+
+  using communication_handle_type = typename super::communication_handle_type;
+
+  template <class... Ts>
+  explicit recorder(Ts&&... xs)
+    : super(std::forward<Ts>(xs)...), rec_(super::self()) {
+    // nop
+  }
+
+  template <class T>
+  void ship(T& msg) {
+    if (rec_)
+      rec_.try_record(msg);
+    super::ship(msg);
+  }
+
+  void ship(data_message& msg, const communication_handle_type& receiver) {
+    // TODO: extend recording interface to cover direct messages
+    super::ship(msg, receiver);
+  }
+
+  void subscribe(const filter_type& what) {
+    if (rec_)
+      rec_.record_subscription(what);
+    super::subscribe(what);
+  }
+
+  void peer_connected(const peer_id_type& remote_id,
+                      const communication_handle_type& hdl) {
+    if (rec_)
+      rec_.record_peer(remote_id);
+    super::peer_connected(remote_id, hdl);
+  }
+
+private:
+  detail::core_recorder rec_;
+};
+
+} // namespace broker::mixin

--- a/src/core_actor.cc
+++ b/src/core_actor.cc
@@ -41,87 +41,36 @@
 
 using namespace caf;
 
-namespace broker::detail {
-
-result<void> init_peering(core_actor_type* self, actor remote_core,
-                          response_promise rp) {
-  BROKER_TRACE(BROKER_ARG(remote_core));
-  auto& mgr = *self->state.mgr;
-  // Sanity checking.
-  if (remote_core == nullptr) {
-    rp.deliver(sec::invalid_argument);
-    return rp;
-  }
-  // Ignore repeated peering requests without error.
-  if (mgr.pending_connections().count(remote_core) > 0
-      || mgr.connected_to(remote_core)) {
-    rp.deliver(caf::unit);
-    return rp;
-  }
-  if (mgr.peers_file)
-    mgr.peers_file << to_string(remote_core.node()) << std::endl;
-  // Create necessary state and send message to remote core.
-  mgr.pending_connections().emplace(remote_core,
-                                    core_manager::pending_connection{0, rp});
-  self->send(self * remote_core, atom::peer_v, mgr.filter, self);
-  self->monitor(remote_core);
-  return rp;
-}
-
-void retry_state::try_once(core_actor_type* self) {
-  auto cpy = std::move(*this);
-  self->state.mgr->cache.fetch(
-    cpy.addr,
-    [self, cpy](actor x) mutable {
-      init_peering(self, std::move(x), std::move(cpy.rp));
-    },
-    [self, cpy](error err) mutable {
-      auto desc = "remote endpoint unavailable: " + to_string(err);
-      BROKER_ERROR(desc);
-      self->state.mgr->emit_error<ec::peer_unavailable>(cpy.addr, desc.c_str());
-      if (cpy.addr.retry.count() > 0) {
-        BROKER_INFO("retrying" << cpy.addr << "in"
-                               << to_string(cpy.addr.retry));
-        self->delayed_send(self, cpy.addr.retry, cpy);
-      } else
-        cpy.rp.deliver(sec::cannot_connect_to_node);
-    });
-}
-
-} // namespace broker::detail
-
 namespace broker {
 
 core_manager::core_manager(caf::event_based_actor* ptr,
                            const filter_type& initial_filter,
                            broker_options opts, endpoint::clock* ep_clock)
-  : super(ptr, filter),
-    options(opts),
-    filter(initial_filter),
-    cache(ptr),
-    shutting_down(false),
-    clock(ep_clock) {
-  cache.set_use_ssl(!options.disable_ssl);
+  : super(ptr, initial_filter),
+    options_(opts),
+    filter_(initial_filter),
+    clock_(ep_clock) {
+  cache().set_use_ssl(!options_.disable_ssl);
   auto meta_dir = get_or(self()->config(), "broker.recording-directory",
                          defaults::recording_directory);
   if (!meta_dir.empty() && detail::is_directory(meta_dir)) {
     auto file_name = meta_dir + "/topics.txt";
-    topics_file.open(file_name);
-    if (topics_file.is_open()) {
+    topics_file_.open(file_name);
+    if (topics_file_.is_open()) {
       BROKER_DEBUG("opened file for recording:" << file_name);
-      for (const auto& x : filter) {
-        if (!(topics_file << x.string() << '\n')) {
+      for (const auto& x : filter_) {
+        if (!(topics_file_ << x.string() << '\n')) {
           BROKER_WARNING("failed to write to topics file");
-          topics_file.close();
+          topics_file_.close();
           break;
         }
       }
-      topics_file.flush();
+      topics_file_.flush();
     } else {
       BROKER_WARNING("cannot open recording file" << file_name);
     }
-    peers_file.open(meta_dir + "/peers.txt");
-    if (!peers_file.is_open())
+    peers_file_.open(meta_dir + "/peers.txt");
+    if (!peers_file_.is_open())
       BROKER_WARNING("cannot open recording file" << file_name);
     std::ofstream id_file{meta_dir + "/id.txt"};
     id_file << to_string(self()->node()) << '\n';
@@ -131,7 +80,7 @@ core_manager::core_manager(caf::event_based_actor* ptr,
 void core_manager::update_filter_on_peers() {
   BROKER_TRACE("");
   for_each_peer([&](const actor& hdl) {
-    self()->send(hdl, atom::update_v, filter);
+    self()->send(hdl, atom::update_v, filter_);
   });
 }
 
@@ -146,18 +95,18 @@ void core_manager::add_to_filter(filter_type xs) {
   if (xs.empty())
     return;
   // Simply append to topics without de-duplication.
-  if (topics_file.is_open()) {
+  if (topics_file_.is_open()) {
     for (const auto& x : xs) {
-      if (!(topics_file << x.string() << '\n')) {
+      if (!(topics_file_ << x.string() << '\n')) {
         BROKER_WARNING("failed to write to topics file");
-        topics_file.close();
+        topics_file_.close();
         break;
       }
     }
-    topics_file.flush();
+    topics_file_.flush();
   }
-  if (filter_extend(filter, xs)) {
-    BROKER_DEBUG("Changed filter to " << filter);
+  if (filter_extend(filter_, xs)) {
+    BROKER_DEBUG("Changed filter to " << filter_);
     update_filter_on_peers();
   }
 }
@@ -172,275 +121,193 @@ bool core_manager::has_remote_master(const std::string& name) {
   });
 }
 
-static void sync_peer_status(core_manager* st, caf::actor new_peer) {
-  auto it = st->peers_awaiting_status_sync.find(new_peer);
-
-  if ( it == st->peers_awaiting_status_sync.end() )
-    return;
-
-  auto& c = it->second;
-  --c;
-
-  if ( c > 0 )
-    return;
-
-  st->peers_awaiting_status_sync.erase(new_peer);
-  st->unblock_peer(std::move(new_peer));
-}
-
-void core_manager::sync_with_status_subscribers(caf::actor new_peer) {
-  if ( status_subscribers.empty() ) {
+void core_manager::peer_connected(const peer_id_type& peer_id,
+                                  const communication_handle_type& hdl) {
+  super::peer_connected(peer_id, hdl);
+  if (status_subscribers_.empty()) {
     // Just in case it was blocked, then status subscribers got removed
     // before reaching here.
-    unblock_peer(new_peer);
+    unblock_peer(hdl);
     return;
   }
-
-  peers_awaiting_status_sync[new_peer] = status_subscribers.size();
-
-  for ( auto& ss : status_subscribers ) {
+  peers_awaiting_status_sync_[hdl] = status_subscribers_.size();
+  auto sync_peer_status = [this](caf::actor new_peer) {
+    auto it = peers_awaiting_status_sync_.find(new_peer);
+    if (it == peers_awaiting_status_sync_.end())
+      return;
+    auto& c = it->second;
+    if (--c > 0)
+      return;
+    peers_awaiting_status_sync_.erase(new_peer);
+    unblock_peer(std::move(new_peer));
+  };
+  for (auto& ss : status_subscribers_) {
     auto to = caf::infinite;
-    self()->request(ss, to, atom::sync_point_v).then(
-      [&, new_peer](atom::sync_point) {
-        sync_peer_status(this, std::move(new_peer));
-      },
-      [&, ss, new_peer](caf::error& e) {
-        status_subscribers.erase(ss);
-        sync_peer_status(this, std::move(new_peer));
-      }
-    );
+    self()
+      ->request(ss, to, atom::sync_point_v)
+      .then([=](atom::sync_point) mutable { sync_peer_status(std::move(hdl)); },
+            [=](caf::error& e) mutable {
+              status_subscribers_.erase(ss);
+              sync_peer_status(std::move(hdl));
+            });
   }
 }
 
-void core_manager::emit_peer_added_status(caf::actor hdl, const char* msg) {
-  auto emit = [=](network_info x) {
-    BROKER_INFO("status" << sc::peer_added << x);
-    auto stat = status::make<sc::peer_added>(
-      endpoint_info{hdl.node(), std::move(x)}, msg);
-    local_push(make_data_message(topics::statuses, get_as<data>(stat)));
-    sync_with_status_subscribers(hdl);
-  };
-
-  if (self()->node() != hdl.node())
-    cache.fetch(hdl,
-                [=](network_info x) { emit(x); },
-                [=](caf::error) { emit({}); });
-  else
-    emit({});
-}
-
-caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
-                         broker_options options, endpoint::clock* clock) {
-  self->state.mgr
-    = caf::make_counted<core_manager>(self, initial_filter, options, clock);
-  // We monitor remote inbound peerings and local outbound peerings.
-  self->set_down_handler([self](const caf::down_msg& down) {
-    // Only required because the initial `peer` message can get lost.
-    auto& mgr = *self->state.mgr;
-    auto hdl = caf::actor_cast<caf::actor>(down.source);
-    auto i = mgr.pending_connections().find(hdl);
-    if (i != mgr.pending_connections().end()) {
-      mgr.emit_error<ec::peer_unavailable>(hdl, "remote endpoint unavailable");
-      i->second.rp.deliver(down.reason);
-      mgr.pending_connections().erase(i);
-    }
-    /* TODO: still needed? Already tracked by governor.
-    BROKER_INFO("got DOWN from peer" << to_string(down.source));
-    auto peers = &self->state.peers;
-    auto pred = [&](const peer_state& p) {
-      return p.actor && p.actor->address() == down.source;
-    };
-    auto i = std::find_if(peers->begin(), peers->end(), pred);
-    BROKER_ASSERT(i != self->state.peers.end());
-    const char* desc;
-    if (is_outbound(i->info.flags)) {
-      BROKER_ASSERT(is_local(i->info.flags));
-      desc = "lost local outbound peer";
-    } else {
-      BROKER_ASSERT(is_inbound(i->info.flags));
-      BROKER_ASSERT(is_remote(i->info.flags));
-      desc = "lost remote inbound peer";
-    }
-    BROKER_INFO(desc);
-    self->send(subscriber, make_status<sc::peer_removed>(i->info.peer, desc));
-    peers->erase(i);
-    */
-  });
-  return {
+caf::behavior core_manager::make_behavior(){
+  return super::make_behavior(
     // --- filter manipulation -------------------------------------------------
     [=](atom::subscribe, filter_type& f) {
       BROKER_TRACE(BROKER_ARG(f));
-      self->state.mgr->add_to_filter(std::move(f));
+      add_to_filter(std::move(f));
     },
     // --- peering requests from local actors, i.e., "step 0" ------------------
-    [=](atom::peer, actor remote_core) -> result<void> {
-      return detail::init_peering(self, std::move(remote_core),
-                                  self->make_response_promise());
+    [=](atom::peer, actor remote_core) {
+      auto remote_id = remote_core.node();
+      start_peering(remote_id, std::move(remote_core),
+                    self()->make_response_promise());
     },
-    [=](atom::peer, network_info& addr) -> result<void> {
-      auto rp = self->make_response_promise();
-      detail::retry_state rt{std::move(addr), rp};
-      rt.try_once(self);
-      return rp;
-    },
-    [=](atom::peer, atom::retry, network_info& addr) {
-      detail::retry_state rt{std::move(addr), {}};
-      rt.try_once(self);
-    },
-    [=](detail::retry_state& rt) { rt.try_once(self); },
     // --- 3-way handshake for establishing peering streams between A and B ----
     // --- A (this node) performs steps #1 and #3; B performs #2 and #4 --------
     // Step #1: - A demands B shall establish a stream back to A
     //          - A has subscribers to the topics `ts`
     [=](atom::peer, filter_type& peer_ts, caf::actor& peer_hdl) {
       BROKER_TRACE(BROKER_ARG(peer_ts) << BROKER_ARG(peer_hdl));
-      auto& mgr = *self->state.mgr;
-      using result_type = decltype(mgr.start_peering<true>(peer_hdl, peer_ts));
+      using result_type = decltype(start_handshake<true>(peer_hdl, peer_ts));
       // Reject anonymous peering requests.
       if (peer_hdl == nullptr) {
         BROKER_DEBUG("Drop anonymous peering request.");
         return result_type{};
       }
       // Drop repeated handshake requests.
-      if (mgr.connected_to(peer_hdl)) {
+      if (connected_to(peer_hdl)) {
         BROKER_WARNING("Drop peering request from already connected peer.");
         return result_type{};
       }
       BROKER_DEBUG("received handshake step #1" << BROKER_ARG(peer_hdl)
-                    << BROKER_ARG(actor{self}));
+                                                << BROKER_ARG(actor{self()}));
       // Start CAF stream.
-      return mgr.start_peering<true>(peer_hdl, std::move(peer_ts));
+      return start_handshake<true>(peer_hdl, std::move(peer_ts));
     },
     // Step #2: B establishes a stream to A and sends its own filter
     [=](const stream<node_message>& in, filter_type& filter,
         caf::actor& peer_hdl) {
       BROKER_TRACE(BROKER_ARG(in) << BROKER_ARG(filter) << peer_hdl);
-      auto& mgr = *self->state.mgr;
-      BROKER_DEBUG("received handshake step #2 from" << peer_hdl
-                    << BROKER_ARG(actor{self}));
+      BROKER_DEBUG("received handshake step #2 from"
+                   << peer_hdl << BROKER_ARG(actor{self()}));
       // At this stage, we expect to have no path to the peer yet.
-      if (mgr.connected_to(peer_hdl)) {
+      if (connected_to(peer_hdl)) {
         BROKER_WARNING("Received unexpected or repeated step #2 handshake.");
         return;
       }
-      if (!mgr.status_subscribers.empty())
-        mgr.block_peer(peer_hdl);
-      mgr.ack_peering(in, peer_hdl);
-      mgr.start_peering<false>(peer_hdl, std::move(filter));
+      if (!status_subscribers_.empty())
+        block_peer(peer_hdl);
+      ack_peering(in, peer_hdl);
+      start_handshake<false>(peer_hdl, std::move(filter));
       // Emit peer added event.
-      mgr.emit_peer_added_status(peer_hdl, "received handshake from remote core");
+      peer_connected(peer_hdl.node(), peer_hdl);
       // Send handle to the actor that initiated a peering (if available).
-      auto i = mgr.pending_connections().find(peer_hdl);
-      if (i != mgr.pending_connections().end()) {
+      auto i = pending_connections().find(peer_hdl);
+      if (i != pending_connections().end()) {
         i->second.rp.deliver(peer_hdl);
-        mgr.pending_connections().erase(i);
+        pending_connections().erase(i);
       }
     },
     // Step #3: - A establishes a stream to B
     //          - B has a stream to A and vice versa now
     [=](const stream<node_message>& in, ok_atom, caf::actor& peer_hdl) {
       BROKER_TRACE(BROKER_ARG(in) << BROKER_ARG(peer_hdl));
-      auto& mgr = *self->state.mgr;
-      if (!mgr.has_outbound_path_to(peer_hdl)) {
+      if (!has_outbound_path_to(peer_hdl)) {
         BROKER_ERROR("Received a step #3 handshake, but no #1 previously.");
         return;
       }
-      if (mgr.has_inbound_path_from(peer_hdl)) {
+      if (has_inbound_path_from(peer_hdl)) {
         BROKER_DEBUG("Drop repeated step #3 handshake.");
         return;
       }
-      if (!mgr.status_subscribers.empty())
-        mgr.block_peer(peer_hdl);
-      mgr.emit_peer_added_status(peer_hdl, "handshake successful");
-      mgr.ack_peering(in, peer_hdl);
+      if (!status_subscribers_.empty())
+        block_peer(peer_hdl);
+      peer_connected(peer_hdl.node(), peer_hdl);
+      ack_peering(in, peer_hdl);
     },
     // --- asynchronous communication to peers ---------------------------------
     [=](atom::update, filter_type f) {
       BROKER_TRACE(BROKER_ARG(f));
-      auto& mgr = *self->state.mgr;
-      auto p = caf::actor_cast<caf::actor>(self->current_sender());
+      auto p = caf::actor_cast<caf::actor>(self()->current_sender());
       if (p == nullptr) {
         BROKER_DEBUG("Received anonymous filter update.");
         return;
       }
-      if (!mgr.update_peer(p, std::move(f)))
+      if (!update_peer(p, std::move(f)))
         BROKER_DEBUG("Cannot update filter of unknown peer:" << to_string(p));
     },
     // --- communication to local actors: incoming streams and subscriptions ---
     [=](atom::join, filter_type& filter) {
       BROKER_TRACE(BROKER_ARG(filter));
-      auto& mgr = *self->state.mgr;
-      auto result = mgr.add_worker(filter);
+      auto result = add_worker(filter);
       if (result != invalid_stream_slot)
-        mgr.add_to_filter(std::move(filter));
+        add_to_filter(std::move(filter));
       return result;
     },
     [=](atom::join, atom::update, stream_slot slot, filter_type& filter) {
-      auto& mgr = *self->state.mgr;
-      mgr.add_to_filter(filter);
-      mgr.worker_manager().set_filter(slot, std::move(filter));
+      add_to_filter(filter);
+      worker_manager().set_filter(slot, std::move(filter));
     },
     [=](atom::join, atom::update, stream_slot slot, filter_type& filter,
         caf::actor& who_asked) {
-      auto& mgr = *self->state.mgr;
-      mgr.add_to_filter(filter);
-      mgr.worker_manager().set_filter(slot, std::move(filter));
-      self->send(who_asked, true);
+      add_to_filter(filter);
+      worker_manager().set_filter(slot, std::move(filter));
+      self()->send(who_asked, true);
     },
     [=](atom::join, atom::store, filter_type& filter) {
       // Tap into data store messages.
-      auto& mgr = *self->state.mgr;
-      auto result = mgr.add_store(filter);
+      auto result = add_store(filter);
       if (result != invalid_stream_slot)
-        mgr.add_to_filter(std::move(filter));
+        add_to_filter(std::move(filter));
       return result;
     },
     [=](endpoint::stream_type in) {
       BROKER_TRACE("add data_message input stream");
-      auto& mgr = *self->state.mgr;
-      mgr.add_unchecked_inbound_path(in);
+      add_unchecked_inbound_path(in);
     },
     [=](stream<node_message::value_type> in) {
       BROKER_TRACE("add node_message::value_type input stream");
-      auto& mgr = *self->state.mgr;
-      mgr.add_unchecked_inbound_path(in);
+      add_unchecked_inbound_path(in);
     },
     [=](atom::publish, data_message& x) {
       BROKER_TRACE(BROKER_ARG(x));
-      self->state.mgr->push(std::move(x));
+      push(std::move(x));
     },
     [=](atom::publish, command_message& x) {
       BROKER_TRACE(BROKER_ARG(x));
-      self->state.mgr->push(std::move(x));
+      push(std::move(x));
     },
     // --- communication to local actors only, i.e., never forward to peers ----
     [=](atom::publish, atom::local, data_message& x) {
       BROKER_TRACE(BROKER_ARG(x));
-      self->state.mgr->local_push(std::move(x));
+      local_push(std::move(x));
     },
     [=](atom::publish, atom::local, command_message& x) {
       BROKER_TRACE(BROKER_ARG(x));
-      self->state.mgr->local_push(std::move(x));
+      local_push(std::move(x));
     },
     // --- "one-to-one" communication that bypasses streaming entirely ---------
     [=](atom::publish, endpoint_info& e, data_message& x) {
       BROKER_TRACE(BROKER_ARG(e) << BROKER_ARG(x));
-      auto& mgr = *self->state.mgr;
       actor hdl;
       if (e.network) {
-        auto tmp = mgr.cache.find(*e.network);
+        auto tmp = cache().find(*e.network);
         if (tmp)
           hdl = std::move(*tmp);
       }
       if (!hdl) {
         auto predicate = [&](const actor& x) { return x.node() == e.node; };
-        hdl = mgr.find_output_peer_hdl(std::move(predicate));
+        hdl = find_output_peer_hdl(std::move(predicate));
         if (!hdl) {
           BROKER_ERROR("no node found for endpoint info" << e);
           return;
         }
       }
-      self->send(hdl, atom::publish_v, atom::local_v, std::move(x));
+      self()->send(hdl, atom::publish_v, atom::local_v, std::move(x));
     },
     // --- data store management -----------------------------------------------
     [=](atom::store, atom::master, atom::attach, const std::string& name,
@@ -450,18 +317,17 @@ caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
                    << BROKER_ARG(backend_type) << BROKER_ARG(opts));
       BROKER_INFO("attaching master:" << name);
       // Sanity check: this message must be a point-to-point message.
-      auto& cme = *self->current_mailbox_element();
+      auto& cme = *self()->current_mailbox_element();
       if (!cme.stages.empty()) {
         BROKER_WARNING("received a master attach message with stages");
         return ec::unspecified;
       }
-      auto& mgr = *self->state.mgr;
-      auto i = mgr.masters.find(name);
-      if (i != mgr.masters.end()) {
+      auto i = masters_.find(name);
+      if (i != masters_.end()) {
         BROKER_INFO("found local master");
         return i->second;
       }
-      if (mgr.has_remote_master(name)) {
+      if (has_remote_master(name)) {
         BROKER_WARNING("remote master with same name exists already");
         return ec::master_exists;
       }
@@ -469,22 +335,22 @@ caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
       auto ptr = detail::make_backend(backend_type, std::move(opts));
       BROKER_ASSERT(ptr);
       BROKER_INFO("spawning new master");
-      auto ms = self->spawn<caf::linked + caf::lazy_init>(
-              detail::master_actor, self, name, std::move(ptr), clock);
-      mgr.masters.emplace(name, ms);
+      auto ms = self()->spawn<caf::linked + caf::lazy_init>(
+        detail::master_actor, self(), name, std::move(ptr), clock_);
+      masters_.emplace(name, ms);
       // Initiate stream handshake and add subscriber to the manager.
       using value_type = store::stream_type::value_type;
-      auto slot = mgr.add_unchecked_outbound_path<value_type>(ms);
+      auto slot = add_unchecked_outbound_path<value_type>(ms);
       if (slot == invalid_stream_slot) {
         BROKER_ERROR("attaching master failed");
         return caf::sec::cannot_add_downstream;
       }
       // Subscribe to messages directly targeted at the master.
       filter_type filter{name / topics::master_suffix};
-      mgr.add_to_filter(filter);
+      add_to_filter(filter);
       // Move the slot to the stores downstream manager and set filter.
-      mgr.out().assign<core_manager::core_manager::store_trait::manager>(slot);
-      mgr.store_manager().set_filter(slot, std::move(filter));
+      out().assign<core_manager::core_manager::store_trait::manager>(slot);
+      store_manager().set_filter(slot, std::move(filter));
       // Done.
       return ms;
     },
@@ -492,41 +358,40 @@ caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
         double resync_interval, double stale_interval,
         double mutation_buffer_interval) -> caf::result<caf::actor> {
       BROKER_INFO("attaching clone:" << name);
-      auto& mgr = *self->state.mgr;
-      auto i = mgr.masters.find(name);
-      if (i != mgr.masters.end() && self->node() == i->second->node()) {
+      auto i = masters_.find(name);
+      if (i != masters_.end() && self()->node() == i->second->node()) {
         BROKER_WARNING("attempted to run clone & master on the same endpoint");
         return ec::no_such_master;
       }
       // Sanity check: this message must be a point-to-point message.
-      auto& cme = *self->current_mailbox_element();
+      auto& cme = *self()->current_mailbox_element();
       if (!cme.stages.empty())
         return ec::unspecified;
       // Fetch clone from the map or spin up a new one.
       auto stages = std::move(cme.stages);
-      if (auto i = mgr.clones.find(name); i != mgr.clones.end()) {
+      if (auto i = clones_.find(name); i != clones_.end()) {
         BROKER_INFO("re-use existing clone");
         return i->second;
       }
       BROKER_INFO("spawning new clone");
-      auto clone = self->spawn<linked + lazy_init>(
-              detail::clone_actor, self, name, resync_interval, stale_interval,
-              mutation_buffer_interval, clock);
+      auto clone = self()->spawn<linked + lazy_init>(
+        detail::clone_actor, self(), name, resync_interval, stale_interval,
+        mutation_buffer_interval, clock_);
       auto cptr = actor_cast<strong_actor_ptr>(clone);
-      mgr.clones.emplace(name, clone);
+      clones_.emplace(name, clone);
       // Subscribe to updates.
       using value_type = store::stream_type::value_type;
-      auto slot = mgr.add_unchecked_outbound_path<value_type>(clone);
+      auto slot = add_unchecked_outbound_path<value_type>(clone);
       if (slot == invalid_stream_slot) {
         BROKER_ERROR("attaching master failed");
         return caf::sec::cannot_add_downstream;
       }
       // Subscribe to messages directly targeted at the clone.
       filter_type filter{name / topics::clone_suffix};
-      mgr.add_to_filter(filter);
+      add_to_filter(filter);
       // Move the slot to the stores downstream manager and set filter.
-      mgr.out().assign<core_manager::store_trait::manager>(slot);
-      mgr.store_manager().set_filter(slot, std::move(filter));
+      out().assign<core_manager::store_trait::manager>(slot);
+      store_manager().set_filter(slot, std::move(filter));
       return clone;
       /* FIXME:
       auto spawn_clone = [=](const caf::actor& master) -> caf::actor {
@@ -589,39 +454,35 @@ caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
     [=](atom::store, atom::master, atom::snapshot, const std::string& name,
         caf::actor& clone) {
       // Instruct master to generate a snapshot.
-      self->state.mgr->push(make_command_message(
+      push(make_command_message(
         name / topics::master_suffix,
-        make_internal_command<snapshot_command>(self, std::move(clone))));
+        make_internal_command<snapshot_command>(self(), std::move(clone))));
     },
     [=](atom::store, atom::master, atom::get,
         const std::string& name) -> result<actor> {
-      auto& mgr = *self->state.mgr;
-      auto i = mgr.masters.find(name);
-      if (i != mgr.masters.end())
+      if (auto i = masters_.find(name); i != masters_.end())
         return i->second;
       return ec::no_such_master;
     },
     [=](atom::store, atom::master, atom::resolve, std::string& name,
         actor& who_asked) {
-      auto& mgr = *self->state.mgr;
-      auto i = mgr.masters.find(name);
-      if (i != mgr.masters.end()) {
+      auto i = masters_.find(name);
+      if (i != masters_.end()) {
         BROKER_INFO("found local master, using direct link");
-        self->send(who_asked, atom::master_v, i->second);
+        self()->send(who_asked, atom::master_v, i->second);
       }
-      auto peers = self->state.mgr->get_peer_handles();
+      auto peers = get_peer_handles();
       if (peers.empty()) {
         BROKER_INFO("no peers to ask for the master");
-        self->send(who_asked, atom::master_v,
-                   make_error(ec::no_such_master, "no peers"));
+        self()->send(who_asked, atom::master_v,
+                     make_error(ec::no_such_master, "no peers"));
       }
-      auto resolv = self->spawn<caf::lazy_init>(detail::master_resolver);
-      self->send(resolv, std::move(peers), std::move(name),
-                 std::move(who_asked));
+      auto resolv = self()->spawn<caf::lazy_init>(detail::master_resolver);
+      self()->send(resolv, std::move(peers), std::move(name),
+                   std::move(who_asked));
     },
     // --- accessors -----------------------------------------------------------
     [=](atom::get, atom::peer) {
-      auto& mgr = *self->state.mgr;
       std::vector<peer_info> result;
       auto add = [&](actor hdl, peer_status status) {
         peer_info tmp;
@@ -629,18 +490,18 @@ caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
         tmp.flags = peer_flags::remote + peer_flags::inbound
                     + peer_flags::outbound;
         tmp.peer.node = hdl.node();
-        auto addrs = mgr.cache.find(hdl);
+        auto addrs = cache().find(hdl);
         // the peer_info only holds a single address, so ... pick first?
         if (addrs)
           tmp.peer.network = *addrs;
         result.emplace_back(std::move(tmp));
       };
       // collect connected peers
-      mgr.for_each_peer([&](const actor& hdl) {
+      for_each_peer([&](const actor& hdl) {
         add(hdl, peer_status::peered);
       });
       // collect pending peers
-      for (auto& [hdl, state] : mgr.pending_connections())
+      for (auto& [hdl, state] : pending_connections())
         if (state.slot != invalid_stream_slot)
           add(hdl, peer_status::connected);
         else
@@ -650,7 +511,7 @@ caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
     [=](atom::get, atom::peer, atom::subscriptions) {
       std::vector<topic> result;
       // Collect filters for all peers.
-      self->state.mgr->for_each_filter([&](const peer_filter& x) {
+      for_each_filter([&](const peer_filter& x) {
         result.insert(result.end(), x.second.begin(), x.second.end());
       });
       // Sort and drop duplicates.
@@ -661,25 +522,12 @@ caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
       return result;
     },
     // --- destructive state manipulations -------------------------------------
-    [=](atom::unpeer, network_info addr) {
-      auto& mgr = *self->state.mgr;
-      auto x = mgr.cache.find(addr);
-      if (!x || !mgr.remove_peer(*x, caf::none, false, true))
-        mgr.emit_error<ec::peer_invalid>(addr, "no such peer when unpeering");
-    },
-    [=](atom::unpeer, actor x) {
-      auto& mgr = *self->state.mgr;
-      if (!x || !mgr.remove_peer(x, caf::none, false, true))
-        mgr.emit_error<ec::peer_invalid>(x, "no such peer when unpeering");
-    },
-    [=](atom::no_events) {
-      // TODO: add extra state flag? Ingore?
-    },
+    [=](atom::unpeer, actor x) { unpeer(x); },
     [=](atom::shutdown) {
-      auto& peers = self->state.mgr->peer_manager();
+      auto& peers = peer_manager();
       peers.selector().active_sender = nullptr;
       peers.fan_out_flush();
-      self->quit(exit_reason::user_shutdown);
+      self()->quit(exit_reason::user_shutdown);
       /* -- To consider:
          -- Terminating the actor after receiving shutdown unconditionally can
          -- cause already published data to not getting forwarded. The
@@ -712,14 +560,40 @@ caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
     },
     [=](atom::shutdown, atom::store) {
       strong_actor_ptr dummy;
-      auto& mgr = *self->state.mgr;
-      for (auto& kvp : mgr.store_manager().paths())
-        self->send_exit(kvp.second->hdl, caf::exit_reason::user_shutdown);
+      for (auto& kvp : store_manager().paths())
+        self()->send_exit(kvp.second->hdl, caf::exit_reason::user_shutdown);
     },
     [=](atom::add, atom::status, caf::actor& ss) {
-      auto& mgr = *self->state.mgr;
-      mgr.status_subscribers.emplace(std::move(ss));
-    }};
+      status_subscribers_.emplace(std::move(ss));
+    });
+}
+
+caf::behavior core_actor(core_actor_type* self, filter_type filter,
+                         broker_options options, endpoint::clock* clock) {
+  auto& st = self->state;
+  st.mgr = caf::make_counted<core_manager>(self, filter, options, clock);
+  // We monitor remote inbound peerings and local outbound peerings.
+  self->set_down_handler([self](const caf::down_msg& down) {
+    if (!down.source) {
+      // Ignore bogus message.
+      return;
+    }
+    // Only required because the initial `peer` message can get lost.
+    auto& mgr = *self->state.mgr;
+    auto hdl = caf::actor_cast<caf::actor>(down.source);
+    if (!hdl) {
+      // We store strong pointers in pending_connections_. Hence, this cast can
+      // never fail for actors we still care about.
+      return;
+    }
+    auto i = mgr.pending_connections().find(hdl);
+    if (i != mgr.pending_connections().end()) {
+      self->state.mgr->peer_unavailable(hdl.node(), hdl, down.reason);
+      i->second.rp.deliver(down.reason);
+      mgr.pending_connections().erase(i);
+    }
+  });
+  return st.mgr->make_behavior();
 }
 
 } // namespace broker

--- a/src/detail/core_recorder.cc
+++ b/src/detail/core_recorder.cc
@@ -1,0 +1,71 @@
+#include "broker/detail/core_recorder.hh"
+
+#include <caf/actor_system_config.hpp>
+#include <caf/config_value.hpp>
+#include <caf/local_actor.hpp>
+#include <caf/node_id.hpp>
+
+#include "broker/defaults.hh"
+#include "broker/detail/filesystem.hh"
+#include "broker/logger.hh"
+
+namespace broker::detail {
+
+core_recorder::core_recorder(caf::local_actor* self) {
+  auto& cfg = self->config();
+  auto meta_dir = get_or(cfg, "broker.recording-directory",
+                         defaults::recording_directory);
+  if (!meta_dir.empty() && detail::is_directory(meta_dir)) {
+    if (!open_file(topics_file_, meta_dir + "/topics.txt"))
+      return;
+    if (!open_file(topics_file_, meta_dir + "/peers.txt"))
+      return;
+    std::ofstream id_file;
+    if (!open_file(id_file, meta_dir + "/id.txt"))
+      return;
+    id_file << to_string(self->node()) << '\n';
+    auto messages_file_name = meta_dir + "/messages.dat";
+    writer_ = make_generator_file_writer(messages_file_name);
+    if (writer_ == nullptr) {
+      BROKER_WARNING("cannot open recording file" << messages_file_name);
+    } else {
+      BROKER_DEBUG("opened file for recording:" << messages_file_name);
+      remaining_records_ = get_or(cfg, "broker.output-generator-file-cap",
+                                  defaults::output_generator_file_cap);
+    }
+  }
+}
+
+void core_recorder::record_subscription(const filter_type& what) {
+  BROKER_TRACE(BROKER_ARG(what));
+  if (!topics_file_)
+    return;
+  // Simply append to topics without de-duplication.
+  if (topics_file_.is_open()) {
+    for (const auto& x : what) {
+      if (!(topics_file_ << x.string() << '\n')) {
+        BROKER_WARNING("failed to write to topics file");
+        topics_file_.close();
+        break;
+      }
+    }
+    topics_file_.flush();
+  }
+}
+
+void core_recorder::record_peer(const caf::node_id& peer_id) {
+  if (peers_file_)
+    peers_file_ << to_string(peer_id) << std::endl;
+}
+
+bool core_recorder::open_file(std::ofstream& fs, std::string file_name) {
+  fs.open(file_name);
+  if (fs.is_open()) {
+    BROKER_DEBUG("opened file for recording:" << file_name);
+    return true;
+  }
+  BROKER_WARNING("cannot open recording file:" << file_name);
+  return false;
+}
+
+} // namespace broker::detail


### PR DESCRIPTION
More refactoring (followup to #112) that moves logic for connecting, notifying, etc. from the core actor into mixins. This splits the currently tightly coupled code pieces into functional blocks that are easier to read/test individually.