### PR TITLE
Add store ID to insert, update and erase events

### DIFF
--- a/include/broker/store_event.hh
+++ b/include/broker/store_event.hh
@@ -24,6 +24,7 @@ public:
   /// ```
   /// [
   ///   "insert",
+  ///   store_id: string,
   ///   key: data,
   ///   value: data,
   ///   expiry: optional<timespan>,
@@ -52,23 +53,27 @@ public:
       return xs_ != nullptr;
     }
 
-    const data& key() const noexcept {
-      return (*xs_)[1];
+    const std::string& store_id() const noexcept {
+      return get<std::string>((*xs_)[1]);
     }
 
-    const data& value() const noexcept {
+    const data& key() const noexcept {
       return (*xs_)[2];
     }
 
+    const data& value() const noexcept {
+      return (*xs_)[3];
+    }
+
     caf::optional<timespan> expiry() const noexcept {
-      if (auto value = get_if<timespan>((*xs_)[3]))
+      if (auto value = get_if<timespan>((*xs_)[4]))
         return *value;
       return nil;
     }
 
     publisher_id publisher() const noexcept {
-      if (auto value = to<caf::node_id>((*xs_)[4])) {
-        return {std::move(*value), get<uint64_t>((*xs_)[5])};
+      if (auto value = to<caf::node_id>((*xs_)[5])) {
+        return {std::move(*value), get<uint64_t>((*xs_)[6])};
       }
       return {};
     }
@@ -83,7 +88,17 @@ public:
 
   /// A view into a ::data object representing a `update` event.
   /// Broker encodes `update` events as
-  /// `["update", key: data, value: data, expiry: optional<timespan>]`.
+  /// ```
+  /// [
+  ///   "update",
+  ///   store_id: string,
+  ///   key: data,
+  ///   value: data,
+  ///   expiry: optional<timespan>
+  ///   publisher_endpoint: caf::node_id,
+  ///   publisher_object: uint64_t
+  /// ]`.
+  /// ```
   class update {
   public:
     update(const update&) noexcept = default;
@@ -102,27 +117,31 @@ public:
       return xs_ != nullptr;
     }
 
-    const data& key() const noexcept {
-      return (*xs_)[1];
+    const std::string& store_id() const noexcept {
+      return get<std::string>((*xs_)[1]);
     }
 
-    const data& old_value() const noexcept {
+    const data& key() const noexcept {
       return (*xs_)[2];
     }
 
-    const data& new_value() const noexcept {
+    const data& old_value() const noexcept {
       return (*xs_)[3];
     }
 
+    const data& new_value() const noexcept {
+      return (*xs_)[4];
+    }
+
     caf::optional<timespan> expiry() const noexcept {
-      if (auto value = get_if<timespan>((*xs_)[4]))
+      if (auto value = get_if<timespan>((*xs_)[5]))
         return *value;
       return nil;
     }
 
     publisher_id publisher() const noexcept {
-      if (auto value = to<caf::node_id>((*xs_)[5])) {
-        return {*value, get<uint64_t>((*xs_)[6])};
+      if (auto value = to<caf::node_id>((*xs_)[6])) {
+        return {*value, get<uint64_t>((*xs_)[7])};
       }
       return {};
     }
@@ -136,7 +155,16 @@ public:
   };
 
   /// A view into a ::data object representing an `erase` event.
-  /// Broker encodes `erase` events as `["erase", key: data]`.
+  /// Broker encodes `erase` events as
+  /// ```
+  /// [
+  ///   "erase",
+  ///   store_id: string,
+  ///   key: data,
+  ///   publisher_endpoint: caf::node_id,
+  ///   publisher_object: uint64_t
+  /// ]
+  /// ```
   class erase {
   public:
     erase(const erase&) noexcept = default;
@@ -155,13 +183,17 @@ public:
       return xs_ != nullptr;
     }
 
+    const std::string& store_id() const noexcept {
+      return get<std::string>((*xs_)[1]);
+    }
+
     const data& key() const noexcept {
-      return (*xs_)[1];
+      return (*xs_)[2];
     }
 
     publisher_id publisher() const noexcept {
-      if (auto value = to<caf::node_id>((*xs_)[2])) {
-        return {*value, get<uint64_t>((*xs_)[3])};
+      if (auto value = to<caf::node_id>((*xs_)[3])) {
+        return {*value, get<uint64_t>((*xs_)[4])};
       }
       return {};
     }

--- a/src/detail/store_actor.cc
+++ b/src/detail/store_actor.cc
@@ -62,7 +62,7 @@ void store_actor_state::emit_insert_event(const data& key, const data& value,
                                           const optional<timespan>& expiry,
                                           const publisher_id& publisher) {
   vector xs;
-  fill_vector(xs, "insert"s, key, value, expiry, publisher);
+  fill_vector(xs, "insert"s, id, key, value, expiry, publisher);
   self->send(core, atom::publish_v, atom::local_v,
              make_data_message(topics::store_events, data{std::move(xs)}));
 }
@@ -73,7 +73,7 @@ void store_actor_state::emit_update_event(const data& key,
                                           const optional<timespan>& expiry,
                                           const publisher_id& publisher) {
   vector xs;
-  fill_vector(xs, "update"s, key, old_value, new_value, expiry, publisher);
+  fill_vector(xs, "update"s, id, key, old_value, new_value, expiry, publisher);
   self->send(core, atom::publish_v, atom::local_v,
              make_data_message(topics::store_events, data{std::move(xs)}));
 }
@@ -81,7 +81,7 @@ void store_actor_state::emit_update_event(const data& key,
 void store_actor_state::emit_erase_event(const data& key,
                                          const publisher_id& publisher) {
   vector xs;
-  fill_vector(xs, "erase"s, key, publisher);
+  fill_vector(xs, "erase"s, id, key, publisher);
   self->send(core, atom::publish_v, atom::local_v,
              make_data_message(topics::store_events, data{std::move(xs)}));
 }

--- a/src/store_event.cc
+++ b/src/store_event.cc
@@ -20,27 +20,30 @@ bool is_publisher_id(const vector& xs, size_t endpoint_index,
 } // namespace
 
 store_event::insert store_event::insert::make(const vector& xs) noexcept {
-  return insert{xs.size() == 6
+  return insert{xs.size() == 7
                && to<store_event::type>(xs[0]) == store_event::type::insert
-               && (is<none>(xs[3]) || is<timespan>(xs[3]))
-               && is_publisher_id(xs, 4, 5)
-             ? &xs
-             : nullptr};
-}
-
-store_event::update store_event::update::make(const vector& xs) noexcept {
-  return update{xs.size() == 7
-               && to<store_event::type>(xs[0]) == store_event::type::update
+               && is<std::string>(xs[1])
                && (is<none>(xs[4]) || is<timespan>(xs[4]))
                && is_publisher_id(xs, 5, 6)
              ? &xs
              : nullptr};
 }
 
+store_event::update store_event::update::make(const vector& xs) noexcept {
+  return update{xs.size() == 8
+               && to<store_event::type>(xs[0]) == store_event::type::update
+               && is<std::string>(xs[1])
+               && (is<none>(xs[5]) || is<timespan>(xs[5]))
+               && is_publisher_id(xs, 6, 7)
+             ? &xs
+             : nullptr};
+}
+
 store_event::erase store_event::erase::make(const vector& xs) noexcept {
-  return erase{xs.size() == 4
+  return erase{xs.size() == 5
                  && to<store_event::type>(xs[0]) == store_event::type::erase
-                 && is_publisher_id(xs, 2, 3)
+                 && is<std::string>(xs[1])
+                 && is_publisher_id(xs, 3, 4)
                ? &xs
                : nullptr};
 }
@@ -51,6 +54,8 @@ const char* to_string(store_event::type code) noexcept {
 
 std::string to_string(const store_event::insert& x) {
   std::string result = "insert(";
+  result += x.store_id();
+  result += ", ";
   result += to_string(x.key());
   result += ", ";
   result += to_string(x.value());
@@ -64,6 +69,8 @@ std::string to_string(const store_event::insert& x) {
 
 std::string to_string(const store_event::update& x) {
   std::string result = "update(";
+  result += x.store_id();
+  result += ", ";
   result += to_string(x.key());
   result += ", ";
   result += to_string(x.old_value());
@@ -79,6 +86,8 @@ std::string to_string(const store_event::update& x) {
 
 std::string to_string(const store_event::erase& x) {
   std::string result = "erase(";
+  result += x.store_id();
+  result += ", ";
   result += to_string(x.key());
   result += ", ";
   result += to_string(x.publisher());

--- a/tests/cpp/master.cc
+++ b/tests/cpp/master.cc
@@ -152,9 +152,9 @@ CAF_TEST(local_master) {
   CAF_CHECK_EQUAL(error_of(ds.get("hello")), caf::error{ec::no_such_key});
   // check log
   CHECK_EQUAL(log, pattern_list({
-                     "insert\\(hello, world, none, .+\\)",
-                     "update\\(hello, world, universe, none, .+\\)",
-                     "erase\\(hello, .+\\)",
+                     "insert\\(foo, hello, world, none, .+\\)",
+                     "update\\(foo, hello, world, universe, none, .+\\)",
+                     "erase\\(foo, hello, .+\\)",
                    }));
   // done
   anon_send_exit(core, exit_reason::user_shutdown);
@@ -273,8 +273,8 @@ CAF_TEST(master_with_clone) {
   // check log
   CHECK_EQUAL(mars.log, earth.log);
   CHECK_EQUAL(mars.log, pattern_list({
-                          "insert\\(test, 123, none, .+\\)",
-                          "insert\\(user, neverlord, none, .+\\)",
+                          "insert\\(foo, test, 123, none, .+\\)",
+                          "insert\\(foo, user, neverlord, none, .+\\)",
                         }));
 }
 

--- a/tests/cpp/store_event.cc
+++ b/tests/cpp/store_event.cc
@@ -11,6 +11,10 @@ using namespace std::string_literals;
 
 namespace {
 
+timespan operator""_ns(unsigned long long value) {
+  return timespan{static_cast<int64_t>(value)};
+}
+
 struct fixture {
   fixture() {
     if (auto err = caf::parse(node_str, node))
@@ -24,6 +28,12 @@ struct fixture {
 
 } // namespace
 
+#define CHECK_INVALID(kind, ...)                                               \
+  do {                                                                         \
+    vector tmp{__VA_ARGS__};                                                   \
+    CHECK(!store_event::kind::make(tmp));                                      \
+  } while (false)
+
 FIXTURE_SCOPE(store_event_tests, fixture)
 
 TEST(the event type is convertible to and from string) {
@@ -36,73 +46,78 @@ TEST(the event type is convertible to and from string) {
 }
 
 TEST(insert events consist of key value and expiry) {
-  MESSAGE("a timespan as fourth element denotes the expiry");
-  {
-    data x{vector{"insert"s, "foo"s, "bar"s, timespan{500}, nil, nil}};
-    auto view = store_event::insert::make(x);
-    REQUIRE(view);
-    CHECK_EQUAL(view.key(), "foo"s);
-    CHECK_EQUAL(view.value(), "bar"s);
-    CHECK_EQUAL(view.expiry(), timespan{500});
-    CHECK_EQUAL(view.publisher(), publisher_id{});
-  }
-  MESSAGE("nil as fourth element is interpreted as no expiry");
-  {
-    data x{vector{"insert"s, "foo"s, "bar"s, nil, nil, nil}};
-    auto view = store_event::insert::make(x);
-    REQUIRE(view);
-    CHECK_EQUAL(view.key(), "foo"s);
-    CHECK_EQUAL(view.value(), "bar"s);
-    CHECK_EQUAL(view.expiry(), nil);
-    CHECK_EQUAL(view.publisher(), publisher_id{});
-  }
-  MESSAGE("elements five and six denote the publisher");
-  {
-    data x{vector{"insert"s, "foo"s, "bar"s, nil, node_str, obj}};
-    auto view = store_event::insert::make(x);
-    REQUIRE(view);
-    CHECK_EQUAL(view.key(), "foo"s);
-    CHECK_EQUAL(view.value(), "bar"s);
-    CHECK_EQUAL(view.expiry(), nil);
-    CHECK_EQUAL(view.publisher(), (publisher_id{node, 42}));
-  }
-  MESSAGE("make returns an invalid view for malformed data");
-  {
-    CHECK(!store_event::insert::make(
-      vector{"update"s, "foo"s, "bar"s, nil, nil, nil}));
-    CHECK(!store_event::insert::make(vector{"insert"s, "foo"s, "bar"s, 42}));
-    CHECK(!store_event::insert::make(vector{"insert"s, "foo"s, "bar"s}));
-  }
-}
-
-TEST(update events consist of key value and expiry) {
   MESSAGE("a timespan as fifth element denotes the expiry");
   {
-    data x{vector{"update"s, "foo"s, "bar"s, "baz"s, timespan{500}, nil, nil}};
-    auto view = store_event::update::make(x);
+    data x{vector{"insert"s, "x"s, "foo"s, "bar"s, 500_ns, nil, nil}};
+    auto view = store_event::insert::make(x);
     REQUIRE(view);
+    CHECK_EQUAL(view.store_id(), "x"s);
     CHECK_EQUAL(view.key(), "foo"s);
-    CHECK_EQUAL(view.old_value(), "bar"s);
-    CHECK_EQUAL(view.new_value(), "baz"s);
-    CHECK_EQUAL(view.expiry(), timespan{500});
+    CHECK_EQUAL(view.value(), "bar"s);
+    CHECK_EQUAL(view.expiry(), 500_ns);
     CHECK_EQUAL(view.publisher(), publisher_id{});
   }
   MESSAGE("nil as fifth element is interpreted as no expiry");
   {
-    data x{vector{"update"s, "foo"s, "bar"s, "baz"s, nil, nil, nil}};
+    data x{vector{"insert"s, "x"s, "foo"s, "bar"s, nil, nil, nil}};
+    auto view = store_event::insert::make(x);
+    REQUIRE(view);
+    CHECK_EQUAL(view.store_id(), "x"s);
+    CHECK_EQUAL(view.key(), "foo"s);
+    CHECK_EQUAL(view.value(), "bar"s);
+    CHECK_EQUAL(view.expiry(), nil);
+    CHECK_EQUAL(view.publisher(), publisher_id{});
+  }
+  MESSAGE("elements six and seven denote the publisher");
+  {
+    data x{vector{"insert"s, "x"s, "foo"s, "bar"s, nil, node_str, obj}};
+    auto view = store_event::insert::make(x);
+    REQUIRE(view);
+    CHECK_EQUAL(view.store_id(), "x"s);
+    CHECK_EQUAL(view.key(), "foo"s);
+    CHECK_EQUAL(view.value(), "bar"s);
+    CHECK_EQUAL(view.expiry(), nil);
+    CHECK_EQUAL(view.publisher(), (publisher_id{node, 42}));
+  }
+  MESSAGE("make returns an invalid view for malformed data");
+  {
+    CHECK_INVALID(insert, "update"s, "x"s, "foo"s, "bar"s, nil, nil, nil);
+    CHECK_INVALID(insert, "insert"s, "x"s, "foo"s, "bar"s, 42);
+    CHECK_INVALID(insert, "insert"s, "x"s, "foo"s, "bar"s);
+  }
+}
+
+TEST(update events consist of key value and expiry) {
+  MESSAGE("a timespan as sixt element denotes the expiry");
+  {
+    data x{vector{"update"s, "x"s, "foo"s, "bar"s, "baz"s, 500_ns, nil, nil}};
     auto view = store_event::update::make(x);
     REQUIRE(view);
+    CHECK_EQUAL(view.store_id(), "x"s);
+    CHECK_EQUAL(view.key(), "foo"s);
+    CHECK_EQUAL(view.old_value(), "bar"s);
+    CHECK_EQUAL(view.new_value(), "baz"s);
+    CHECK_EQUAL(view.expiry(), 500_ns);
+    CHECK_EQUAL(view.publisher(), publisher_id{});
+  }
+  MESSAGE("nil as sixt element is interpreted as no expiry");
+  {
+    data x{vector{"update"s, "x"s, "foo"s, "bar"s, "baz"s, nil, nil, nil}};
+    auto view = store_event::update::make(x);
+    REQUIRE(view);
+    CHECK_EQUAL(view.store_id(), "x"s);
     CHECK_EQUAL(view.key(), "foo"s);
     CHECK_EQUAL(view.old_value(), "bar"s);
     CHECK_EQUAL(view.new_value(), "baz"s);
     CHECK_EQUAL(view.expiry(), nil);
     CHECK_EQUAL(view.publisher(), publisher_id{});
   }
-  MESSAGE("elements five and six denote the publisher");
+  MESSAGE("elements six and seven denote the publisher");
   {
-    data x{vector{"update"s, "foo"s, "bar"s, "baz"s, nil, node_str, obj}};
+    data x{vector{"update"s, "x"s, "foo"s, "bar"s, "baz"s, nil, node_str, obj}};
     auto view = store_event::update::make(x);
     REQUIRE(view);
+    CHECK_EQUAL(view.store_id(), "x"s);
     CHECK_EQUAL(view.key(), "foo"s);
     CHECK_EQUAL(view.old_value(), "bar"s);
     CHECK_EQUAL(view.new_value(), "baz"s);
@@ -111,33 +126,35 @@ TEST(update events consist of key value and expiry) {
   }
   MESSAGE("make returns an invalid view for malformed data");
   {
-    CHECK(!store_event::update::make(vector{"insert"s, "foo"s, "bar"s, nil}));
-    CHECK(!store_event::update::make(vector{"update"s, "foo"s, "bar"s, 42}));
-    CHECK(!store_event::update::make(vector{"update"s, "foo"s, "bar"s}));
+    CHECK_INVALID(update, "insert"s, "x"s, "foo"s, "bar"s, nil);
+    CHECK_INVALID(update, "update"s, "x"s, "foo"s, "bar"s, 42);
+    CHECK_INVALID(update, "update"s, "x"s, "foo"s, "bar"s);
   }
 }
 
 TEST(erase events contain the key and optionally a publisher ID) {
   MESSAGE("the key can have any value");
   {
-    data x{vector{"erase"s, "foo"s, nil, nil}};
+    data x{vector{"erase"s, "x"s, "foo"s, nil, nil}};
     auto view = store_event::erase::make(x);
     REQUIRE(view);
+    CHECK_EQUAL(view.store_id(), "x"s);
     CHECK_EQUAL(view.key(), "foo"s);
     CHECK_EQUAL(view.publisher(), publisher_id{});
   }
-  MESSAGE("elements two and three denote the publisher");
+  MESSAGE("elements three and four denote the publisher");
   {
-    data x{vector{"erase"s, "foo"s, node_str, obj}};
+    data x{vector{"erase"s, "x"s, "foo"s, node_str, obj}};
     auto view = store_event::erase::make(x);
     REQUIRE(view);
+    CHECK_EQUAL(view.store_id(), "x"s);
     CHECK_EQUAL(view.key(), "foo"s);
     CHECK_EQUAL(view.publisher(), (publisher_id{node, 42}));
   }
   MESSAGE("make returns an invalid view for malformed data");
   {
-    CHECK(!store_event::erase::make(vector{"insert"s, "foo"s, nil, nil}));
-    CHECK(!store_event::erase::make(vector{"erase"s, "foo"s, "bar"s, nil}));
+    CHECK_INVALID(erase, "insert"s, "foo"s, nil, nil);
+    CHECK_INVALID(erase, "erase"s, "foo"s, "bar"s, nil);
   }
 }
 


### PR DESCRIPTION
Closes #119.

Instead of including the store ID in the topic, I have added an additional fields to the event vector. This makes it easier to retrieve the ID and also is less prone to error (there are no restrictions to store IDs, which means the ID can contain a `/` and mess up topic semantics).