### PR TITLE
Change default console logging verbosity to "error"

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -130,13 +130,13 @@ configuration::configuration(skip_init_t) {
   set("logger.file-verbosity", atom("quiet"));
   set("logger.console-format", "[%c/%p] %d %m");
   // Enable console output (and color it if stdout is a TTY) but set verbosty to
-  // quiet. This allows users to only care about the environment variable
+  // errors-only. Users can still override via the environment variable
   // BROKER_CONSOLE_VERBOSITY.
   if (isatty(STDOUT_FILENO))
     set("logger.console", atom("colored"));
   else
     set("logger.console", atom("uncolored"));
-  set("logger.console-verbosity", atom("quiet"));
+  set("logger.console-verbosity", atom("error"));
   // Turn off all CAF output by default.
   std::vector<atom_value> blacklist{atom("caf"), atom("caf_io"),
                                     atom("caf_net"), atom("caf_flow"),


### PR DESCRIPTION
@Neverlord brief sanity/opinion check on this when you get time

As an example:

```python
# test.py
import broker
ep = broker.Endpoint()
m = ep.attach_master('mystore', broker.Backend.SQLite)
```

The `attach_master` call didn't pass in the required `backend_options` to specify the path to use for the database file, but the user only sees the following esoteric message:

```
$ PYTHONPATH=./python python test.py 
failed to get master expiries while initializing
```

Assuming log-level "error" is always going to be interesting to users, this is an improvement:

```
$ PYTHONPATH=./python python test.py 
[broker/ERROR] 2020-07-07T12:48:16.827 SQLite backend options are missing required 'path' string
failed to get master expiries while initializing
```