### PR TITLE
Improve logging for stale store expiry reminders

### DIFF
--- a/src/detail/master_actor.cc
+++ b/src/detail/master_actor.cc
@@ -63,9 +63,9 @@ void master_state::remind(timespan expiry, const data& key) {
 void master_state::expire(data& key) {
   BROKER_INFO("EXPIRE" << key);
   if (auto result = backend->expire(key, clock->now()); !result) {
-    BROKER_ERROR("failed to expire key:" << to_string(result.error()));
+    BROKER_ERROR("EXPIRE" << key << "(FAILED)" << to_string(result.error()));
   } else if (!*result) {
-    BROKER_WARNING("ignoring stale expiration reminder");
+    BROKER_INFO("EXPIRE" << key << "(IGNORE/STALE)");
   } else {
     expire_command cmd{std::move(key), publisher_id{self->node(), self->id()}};
     emit_expire_event(cmd);

--- a/src/detail/memory_backend.cc
+++ b/src/detail/memory_backend.cc
@@ -60,7 +60,7 @@ expected<void> memory_backend::clear() {
 expected<bool> memory_backend::expire(const data& key, timestamp ts) {
   auto i = store_.find(key);
   if (i == store_.end())
-    return ec::no_such_key;
+    return false;
   if (!i->second.second || ts < i->second.second)
     return false;
   store_.erase(i);


### PR DESCRIPTION
Changed the logging of stale expiry attempts from WARNING to INFO,
since these are not unusual situations: they're expected to be possible
and the logic accounts for it when it does happen.

Also, changed the memory-backend to return "false" instead of
"no-such-key" as the later triggers an ERROR to be logged.  The reason
again is that this is not an exceptional situation.  i.e. the
abstract_backend::expire() return values have these meanings:

  * True: the key existed, was due to expire, and was removed
  * False: the key didn't exist or wasn't due to expire
  * Error: the backend encountered a problem that prevents resolving
    the call to either of the above true/false results

Fixes #129 