### PR TITLE
Fix build with CAF 0.18

### DIFF
--- a/include/broker/alm/stream_transport.hh
+++ b/include/broker/alm/stream_transport.hh
@@ -311,8 +311,7 @@ public:
     // Create necessary state and send message to remote core.
     pending_connections().emplace(remote_peer,
                                   pending_connection{0, std::move(rp)});
-    self()->send(self() * remote_peer, atom::peer::value, dref().filter(),
-                 self());
+    self()->send(self() * remote_peer, atom::peer_v, dref().filter(), self());
     self()->monitor(remote_peer);
   }
 
@@ -499,7 +498,7 @@ public:
   // -- communication that bypasses the streams --------------------------------
 
   void ship(data_message& msg, const communication_handle_type& hdl) {
-    self()->send(hdl, atom::publish::value, atom::local::value, std::move(msg));
+    self()->send(hdl, atom::publish_v, atom::local_v, std::move(msg));
   }
 
   template <class T>

--- a/tests/cpp/integration.cc
+++ b/tests/cpp/integration.cc
@@ -58,15 +58,17 @@ configuration make_config() {
   broker_options options;
   options.disable_ssl = true;
   configuration cfg(options);
+  cfg.parse(caf::test::engine::argc(), caf::test::engine::argv());
 #if CAF_VERSION < 1800
   using caf::atom;
-#else
-  auto atom = [](std::string x) { return x; };
-#endif
-  cfg.parse(caf::test::engine::argc(), caf::test::engine::argv());
   cfg.set("middleman.network-backend", atom("testing"));
   cfg.set("scheduler.policy", atom("testing"));
   cfg.set("logger.inline-output", true);
+#else
+  cfg.set("caf.middleman.network-backend", "testing");
+  cfg.set("caf.scheduler.policy", "testing");
+  cfg.set("caf.logger.inline-output", true);
+#endif
   return cfg;
 }
 

--- a/tests/cpp/ssl.cc
+++ b/tests/cpp/ssl.cc
@@ -19,21 +19,25 @@ using namespace broker;
 
 namespace {
 
+#if CAF_VERSION < 1800
+#define CFG_PREFIX
+#else
+#define CFG_PREFIX "caf."
+#endif
+
 configuration make_config(std::string cert_id) {
   configuration cfg;
   cfg.parse(caf::test::engine::argc(), caf::test::engine::argv());
-  // cfg.set("scheduler.policy", caf::atom("testing"));
-  cfg.set("logger.inline-output",  true);
-
-//  cfg.scheduler_policy = caf::atom("testing");
-  if ( cert_id.size() ) {
+  cfg.set(CFG_PREFIX "logger.inline-output", true);
+  if (cert_id.size()) {
     auto test_dir = getenv("BROKER_TEST_DIR");
     CAF_REQUIRE(test_dir);
     auto cd = std::string(test_dir) + "/cpp/certs/";
-    cfg.set("openssl.cafile", cd + "ca.pem");
-    cfg.set("openssl.certificate", cd + "cert." + cert_id + ".pem");
-    cfg.set("openssl.key", cd + "key." + cert_id + ".pem");
-    MESSAGE("using certififcate " << cfg.openssl_certificate << ", key " << cfg.openssl_key);
+    cfg.set(CFG_PREFIX "openssl.cafile", cd + "ca.pem");
+    cfg.set(CFG_PREFIX "openssl.certificate", cd + "cert." + cert_id + ".pem");
+    cfg.set(CFG_PREFIX "openssl.key", cd + "key." + cert_id + ".pem");
+    MESSAGE("using certififcate " << cfg.openssl_certificate << ", key "
+                                  << cfg.openssl_key);
   }
   return cfg;
 }
@@ -101,11 +105,6 @@ MESSAGE("prepare authenticated connection");
 
   MESSAGE("disconnect venus_auth from mercury_auth");
   venus_auth.ep.unpeer("mercury", 4040);
-  MESSAGE("venus_auth to shutdown");
-  venus_auth.ep.shutdown();
-  MESSAGE("mercury_auth to shutdown");
-  mercury_auth.ep.shutdown();
-  MESSAGE("all done");
 }
 
 CAF_TEST(authenticated_failure_no_ssl_peer) {
@@ -116,11 +115,6 @@ CAF_TEST(authenticated_failure_no_ssl_peer) {
   MESSAGE("venus_auth peer with earth_no_auth on port " << p);
   auto b = venus_auth.ep.peer("127.0.0.1", p, timeout::seconds(0));
   CAF_REQUIRE(not b);
-
-  MESSAGE("venus_auth to shutdown");
-  venus_auth.ep.shutdown();
-  MESSAGE("earth_no_auth to shutdown");
-  earth_no_auth.ep.shutdown();
 }
 
 CAF_TEST(authenticated_failure_wrong_ssl_peer) {
@@ -131,11 +125,6 @@ CAF_TEST(authenticated_failure_wrong_ssl_peer) {
   MESSAGE("venus_auth peer with earth_wrong_auth on port " << p);
   auto b = venus_auth.ep.peer("127.0.0.1", p, timeout::seconds(0));
   CAF_REQUIRE(not b);
-
-  MESSAGE("venus_auth to shutdown");
-  venus_auth.ep.shutdown();
-  MESSAGE("earth_wrong_auth to shutdown");
-  earth_wrong_auth.ep.shutdown();
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/tests/cpp/test.cc
+++ b/tests/cpp/test.cc
@@ -16,6 +16,12 @@
 #include "Winsock2.h"
 #endif
 
+#if CAF_VERSION < 1800
+#define CFG_PREFIX
+#else
+#define CFG_PREFIX "caf."
+#endif
+
 using namespace caf;
 using namespace broker;
 
@@ -25,7 +31,7 @@ base_fixture::base_fixture()
     self(sys),
     sched(dynamic_cast<scheduler_type&>(sys.scheduler())),
     credit_round_interval(
-      get_or(sys.config(), "stream.credit-round-interval",
+      get_or(sys.config(), CFG_PREFIX "stream.credit-round-interval",
              caf::defaults::stream::credit_round_interval)) {
   init_socket_api();
 }
@@ -59,11 +65,6 @@ configuration base_fixture::make_config() {
   options.disable_ssl = true;
   configuration cfg{options};
   test_coordinator_fixture<configuration>::init_config(cfg);
-#if CAF_VERSION < 1800
-  cfg.set("logger.verbosity", caf::atom("TRACE"));
-#else
-  cfg.set("logger.verbosity", "TRACE");
-#endif
   cfg.load<io::middleman, io::network::test_multiplexer>();
   return cfg;
 }


### PR DESCRIPTION
Aside from a couple missing `${atom}::value => ${atom}_v` renamings, most changes relate to CAF's restructured configuration names. Also, I found a heap-use-after-free error in `ssl.cc` that came from calling `shutdown` on the endpoints while variables on the stack still held references to actors. ASAN only complained with CAF 0.18 locally, but it's unsafe in general.