### PR TITLE
Remove explicit use of config mode for finding CAF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,11 +201,11 @@ if ( TARGET CAF::core )
 elseif ( CAF_ROOT )
   # TODO: drop < 3.12 compatibility check when raising the minimum CMake version
   if (CMAKE_VERSION VERSION_LESS 3.12)
-    find_package(CAF ${CAF_VERSION_MIN_REQUIRED} REQUIRED CONFIG
+    find_package(CAF ${CAF_VERSION_MIN_REQUIRED} REQUIRED
                  COMPONENTS openssl test io core
                  PATHS "${CAF_ROOT}")
   else()
-    find_package(CAF ${CAF_VERSION_MIN_REQUIRED} REQUIRED CONFIG
+    find_package(CAF ${CAF_VERSION_MIN_REQUIRED} REQUIRED
                  COMPONENTS openssl test io core)
   endif()
   message(STATUS "Using system CAF version ${CAF_VERSION}")


### PR DESCRIPTION
CAF 0.18 comes with CMake package files, so we can remove the custom find script in our cmake submodule and drop the `CONFIG` qualifier to skip it.