### PR TITLE
Fix RocksDB backend

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,7 @@ memory: &MEMORY 6GB
 
 config: &CONFIG --build-type=release --enable-static
 memcheck_config: &MEMCHECK_CONFIG --build-type=debug --sanitizers=address
+macos_config: &MACOS_CONFIG --build-type=release --enable-static --with-rocksdb=/usr/local
 
 resources_template: &RESOURCES_TEMPLATE
   cpu: *CPUS
@@ -120,7 +121,7 @@ macos_task:
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   env:
-    BROKER_CI_CONFIGURE_FLAGS: *CONFIG
+    BROKER_CI_CONFIGURE_FLAGS: *MACOS_CONFIG
     BROKER_CI_CPUS: 4
     # No permission to write to default location of /broker
     CIRRUS_WORKING_DIR: /tmp/broker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ set(BROKER_SRC
   src/data.cc
   src/defaults.cc
   src/detail/abstract_backend.cc
+  src/detail/base64.cc
   src/detail/clone_actor.cc
   src/detail/core_recorder.cc
   src/detail/data_generator.cc

--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -5,4 +5,4 @@ sysctl hw.model hw.machine hw.ncpu hw.physicalcpu hw.logicalcpu
 set -e
 set -x
 
-brew install cmake openssl
+brew install cmake openssl rocksdb

--- a/include/broker/detail/base64.hh
+++ b/include/broker/detail/base64.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "broker/detail/blob.hh"
+
+namespace broker::detail {
+
+class base64 {
+public:
+  static void encode(const_blob_span in, std::string& out);
+  static bool decode(std::string_view in, blob_buffer& out);
+};
+
+} // namespace broker::detail

--- a/include/broker/detail/blob.hh
+++ b/include/broker/detail/blob.hh
@@ -1,39 +1,48 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include <caf/binary_deserializer.hpp>
 #include <caf/binary_serializer.hpp>
+#include <caf/span.hpp>
 
-namespace broker {
-namespace detail {
+#include "broker/detail/assert.hh"
 
-template <class T, class... Ts>
-auto to_blob(T&& x, Ts&&... xs) {
-  typename caf::binary_serializer::container_type buf;
+namespace broker::detail {
+
+using blob_buffer = caf::binary_serializer::container_type;
+
+using blob_span = caf::span<blob_buffer::value_type>;
+
+using const_blob_span = caf::span<const blob_buffer::value_type>;
+
+template <class T>
+void to_blob(const T& x, blob_buffer& buf) {
   caf::binary_serializer sink{nullptr, buf};
-  auto res = sink.apply_objects(std::forward<T>(x), std::forward<Ts>(xs)...);
-  // TODO: maybe throw? No other way to report errors here.
+  auto res = sink.apply(x);
+  BROKER_ASSERT(res);
   static_cast<void>(res);
+}
+
+template <class T>
+blob_buffer to_blob(const T& x) {
+  blob_buffer buf;
+  to_blob(x, buf);
   return buf;
 }
 
 template <class T>
 T from_blob(const void* buf, size_t size) {
-  caf::binary_deserializer source{nullptr, reinterpret_cast<const char*>(buf),
-                                  size};
+  caf::binary_deserializer source{nullptr, buf, size};
   auto result = T{};
-  auto res = source.apply_object(result);
-  // TODO: maybe throw? No other way to report errors here.
+  auto res = source.apply(result);
+  BROKER_ASSERT(res);
   static_cast<void>(res);
   return result;
 }
 
 template <class T, class Container>
 T from_blob(const Container& buf) {
-  return from_blob<T>(buf.data(), buf.size());
+  return from_blob<T>(buf.data(),
+                      buf.size() * sizeof(typename Container::value_type));
 }
 
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/src/detail/base64.cc
+++ b/src/detail/base64.cc
@@ -1,0 +1,91 @@
+#include "broker/detail/base64.hh"
+
+#include <cstdint>
+
+namespace broker::detail {
+
+// clang-format off
+
+namespace {
+
+constexpr uint8_t decoding_tbl[] = {
+/*       ..0 ..1 ..2 ..3 ..4 ..5 ..6 ..7 ..8 ..9 ..A ..B ..C ..D ..E ..F  */
+/* 0.. */  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+/* 1.. */  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+/* 2.. */  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 62,  0,  0,  0, 63,
+/* 3.. */ 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,  0,  0,  0,  0,  0,  0,
+/* 4.. */  0,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+/* 5.. */ 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,  0,  0,  0,  0,  0,
+/* 6.. */  0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+/* 7.. */ 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,  0,  0,  0,  0,  0};
+
+constexpr const char encoding_tbl[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                      "abcdefghijklmnopqrstuvwxyz"
+                                      "0123456789+/";
+
+} // namespace
+
+// clang-format on
+
+void base64::encode(const_blob_span in, std::string& out) {
+  using byte = blob_buffer::value_type;
+  // Consumes three characters from input at once.
+  auto consume = [&out](const byte* i) {
+    auto at = [i](size_t index) { return static_cast<int>(i[index]); };
+    int buf[] = {
+      (at(0) & 0xfc) >> 2,
+      ((at(0) & 0x03) << 4) + ((at(1) & 0xf0) >> 4),
+      ((at(1) & 0x0f) << 2) + ((at(2) & 0xc0) >> 6),
+      at(2) & 0x3f,
+    };
+    for (auto x : buf)
+      out += encoding_tbl[x];
+  };
+  // Iterate the input in chunks of three bytes.
+  auto i = in.begin();
+  for (; std::distance(i, in.end()) >= 3; i += 3)
+    consume(i);
+  if (i != in.end()) {
+    // Pad input with zeros.
+    byte buf[] = {byte{0}, byte{0}, byte{0}};
+    std::copy(i, in.end(), buf);
+    consume(buf);
+    // Override padded bytes (garbage) with '='.
+    for (auto j = out.end() - (3 - (in.size() % 3)); j != out.end(); ++j)
+      *j = '=';
+  }
+}
+
+bool base64::decode(std::string_view in, blob_buffer& out) {
+  using byte = blob_buffer::value_type;
+  // Short-circuit empty buffers.
+  if (in.empty())
+    return true;
+  // Base64 always produces character groups of size 4.
+  if (in.size() % 4 != 0)
+    return false;
+  // Consume four characters from the input at once.
+  auto val = [](char c) { return decoding_tbl[c & 0x7F]; };
+  for (auto i = in.begin(); i != in.end(); i += 4) {
+    // clang-format off
+    auto bits =   (val(i[0]) << 18)
+                | (val(i[1]) << 12)
+                | (val(i[2]) << 6)
+                | (val(i[3]));
+    // clang-format on
+    out.emplace_back(static_cast<byte>((bits & 0xFF0000) >> 16));
+    out.emplace_back(static_cast<byte>((bits & 0x00FF00) >> 8));
+    out.emplace_back(static_cast<byte>((bits & 0x0000FF)));
+  }
+  // Fix up the output buffer when the input contained padding.
+  auto s = in.size();
+  if (in[s - 2] == '=') {
+    out.pop_back();
+    out.pop_back();
+  } else if (in[s - 1] == '=') {
+    out.pop_back();
+  }
+  return true;
+}
+
+} // namespace broker::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
   cpp/backend.cc
   cpp/core.cc
   cpp/data.cc
+  cpp/detail/base64.cc
   cpp/detail/data_generator.cc
   cpp/detail/generator_file_writer.cc
   cpp/detail/meta_command_writer.cc

--- a/tests/cpp/detail/base64.cc
+++ b/tests/cpp/detail/base64.cc
@@ -1,0 +1,46 @@
+#define SUITE detail.base64
+
+#include "broker/detail/base64.hh"
+
+#include "test.hh"
+
+using namespace broker;
+
+namespace {
+
+template <class... Ts>
+auto bytes(Ts... xs) {
+  using byte = typename detail::blob_buffer::value_type;
+  detail::blob_buffer buf{static_cast<byte>(xs)...};
+  return buf;
+}
+
+template <class... Ts>
+auto encode(Ts... xs) {
+  auto buf = bytes(xs...);
+  std::string result;
+  detail::base64::encode(buf, result);
+  return result;
+}
+
+auto decode(std::string_view str) {
+  detail::blob_buffer result;
+  detail::base64::decode(str, result);
+  return result;
+}
+
+} // namespace
+
+TEST(base64 encoding converts byte sequences to strings) {
+  CHECK_EQUAL(encode(0xb3, 0x7a, 0x4f, 0x2c, 0xc0, 0x62, 0x4f, 0x16, 0x90, 0xf6,
+                     0x46, 0x06, 0xcf, 0x38, 0x59, 0x45, 0xb2, 0xbe, 0xc4,
+                     0xea),
+              "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+}
+
+TEST(base64 decoding converts strings to byte sequences) {
+  CHECK_EQUAL(decode("s3pPLMBiTxaQ9kYGzzhZRbK+xOo="),
+              bytes(0xb3, 0x7a, 0x4f, 0x2c, 0xc0, 0x62, 0x4f, 0x16, 0x90, 0xf6,
+                    0x46, 0x06, 0xcf, 0x38, 0x59, 0x45, 0xb2, 0xbe, 0xc4,
+                    0xea));
+}


### PR DESCRIPTION
Simply dumping the output of `caf::binary_serializer` into rocksdb is unsafe, because the resulting bytes may not be valid UTF-8/ASCII. The new code encodes the binary data to base64 before passing the result to rocksdb.

On a similar note, using CAF's binary serializers for `to_blob`/`from_blob` is also unsafe. The binary format is *not* designed for persistence and may change between CAF releases. We could switch to JSON if human-readable data in the database gives us any benefits or implement a binary serializer in Broker that allows us to control the bit layout and to embed versioning information.

This also bumps the CAF tag. A recent upstream commit deprecated `apply_object`, so I wrote the code against that recent version to avoid deprecation warnings down the line.