### PR TITLE
Call `ctest` instead of `make test` in CI builds

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,16 +1,26 @@
 #! /usr/bin/env bash
 
+# Prefer ctest3 over "regular" ctest (ctest == ctest2 on RHEL).
+if command -v ctest3 >/dev/null 2>&1 ; then
+  CTestCommand="ctest3"
+elif command -v ctest >/dev/null 2>&1 ; then
+  CTestCommand="ctest"
+else
+  echo "No ctest command found!"
+  exit 1
+fi
+
 set -e
 
 cd build
 
 if [[ -z "${BROKER_CI_MEMCHECK}" ]]; then
-    CTEST_OUTPUT_ON_FAILURE=1 make test
+    $CTestCommand --output-on-failure
 else
     # Python tests under ASan are problematic for various reasons, so skip
     # e.g. need LD_PRELOAD, some specific compiler packagings are
     # buggy when preloaded due to missing libasan compilation flag,
     # leaks are miss-reported so have to disable leak checking, and
     # finally most tests end up timing out when run under ASan anyway.
-    CTEST_OUTPUT_ON_FAILURE=1 ctest -E python
+    $CTestCommand --output-on-failure -E python
 fi


### PR DESCRIPTION
Setting `CTEST_OUTPUT_ON_FAILURE` and then calling `make test` seems to lose the flag at some point. Calling `ctest` directly and passing `--output-on-failure` makes sure that we actually get the test output in case of an error.

Here's an example for a build that should include error output but doesn't: https://cirrus-ci.com/task/5866556661956608.