### PR TITLE
Implement origin-based credit strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ set(BROKER_SRC
   src/data.cc
   src/defaults.cc
   src/detail/abstract_backend.cc
+  src/detail/central_dispatcher.cc
   src/detail/clone_actor.cc
   src/detail/core_recorder.cc
   src/detail/data_generator.cc
@@ -322,6 +323,7 @@ set(BROKER_SRC
   src/detail/prefix_matcher.cc
   src/detail/sqlite_backend.cc
   src/detail/store_actor.cc
+  src/detail/unipath_manager.cc
   src/endpoint.cc
   src/endpoint_info.cc
   src/error.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,9 @@ set(BROKER_SRC
   src/detail/flare_actor.cc
   src/detail/generator_file_reader.cc
   src/detail/generator_file_writer.cc
+  src/detail/item.cc
+  src/detail/item_allocator.cc
+  src/detail/item_stash.cc
   src/detail/make_backend.cc
   src/detail/master_actor.cc
   src/detail/master_resolver.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,7 @@ set(BROKER_SRC
   src/detail/generator_file_writer.cc
   src/detail/item.cc
   src/detail/item_allocator.cc
+  src/detail/item_scope.cc
   src/detail/item_stash.cc
   src/detail/make_backend.cc
   src/detail/master_actor.cc

--- a/include/broker/alm/stream_transport.hh
+++ b/include/broker/alm/stream_transport.hh
@@ -23,9 +23,11 @@
 #include "broker/data.hh"
 #include "broker/defaults.hh"
 #include "broker/detail/assert.hh"
+#include "broker/detail/central_dispatcher.hh"
 #include "broker/detail/filesystem.hh"
 #include "broker/detail/generator_file_writer.hh"
 #include "broker/detail/prefix_matcher.hh"
+#include "broker/detail/unipath_manager.hh"
 #include "broker/error.hh"
 #include "broker/filter_type.hh"
 #include "broker/internal_command.hh"
@@ -40,8 +42,14 @@ namespace broker::alm {
 /// Sets up a configurable stream manager to act as a distribution tree for
 /// Broker.
 template <class Derived, class PeerId>
-class stream_transport : public caf::stream_manager {
+class stream_transport : public detail::unipath_manager::observer {
 public:
+  // -- constants --------------------------------------------------------------
+
+  /// Configures how many (additional) items the stream transport caches for
+  /// published events that bypass streaming.
+  static constexpr size_t item_stash_replenish_size = 32;
+
   // -- member types -----------------------------------------------------------
 
   using peer_id_type = PeerId;
@@ -50,70 +58,23 @@ public:
 
   using communication_handle_type = caf::actor;
 
+  using manager_ptr = detail::unipath_manager_ptr;
+
   struct pending_connection {
-    caf::stream_slot slot;
+    manager_ptr mgr;
     caf::response_promise rp;
   };
 
-  /// Type to store a TTL for messages forwarded to peers.
-  using ttl = uint16_t;
+  /// Maps peer actor handles to their stream managers.
+  using hdl_to_mgr_map = std::unordered_map<caf::actor, manager_ptr>;
 
-  /// Helper trait for defining streaming-related types for local actors
-  /// (workers and stores).
-  template <class T>
-  struct local_trait {
-    /// Type of a single element in the stream.
-    using element = caf::cow_tuple<topic, T>;
-
-    /// Type of a full batch in the stream.
-    using batch = std::vector<element>;
-
-    /// Type of the downstream_manager that broadcasts data to local actors.
-    using manager = caf::broadcast_downstream_manager<element, filter_type,
-                                                      detail::prefix_matcher>;
-  };
-
-  /// Streaming-related types for workers.
-  using worker_trait = local_trait<data>;
-
-  /// Streaming-related types for stores.
-  using store_trait = local_trait<internal_command>;
-
-  /// Streaming-related types for sources that produce both types of messages.
-  struct var_trait {
-    using batch = std::vector<typename message_type::value_type>;
-  };
-
-  /// Streaming-related types for peers.
-  struct peer_trait {
-    /// Type of a single element in the stream.
-    using element = message_type;
-
-    using batch = std::vector<element>;
-
-    /// Type of the downstream_manager that broadcasts data to local actors.
-    using manager = caf::broadcast_downstream_manager<element, peer_filter,
-                                                      peer_filter_matcher>;
-  };
-
-  /// Composed downstream_manager type for bundled dispatching.
-  using downstream_manager_type
-    = caf::fused_downstream_manager<typename peer_trait::manager,
-                                    typename worker_trait::manager,
-                                    typename store_trait::manager>;
-
-  /// Maps actor handles to path IDs.
-  using hdl_to_slot_map = std::unordered_map<caf::actor, caf::stream_slot>;
-
-  /// Maps path IDs to actor handles.
-  using slot_to_hdl_map = std::unordered_map<caf::stream_slot, caf::actor>;
+  /// Maps stream managers to peer actor handles.
+  using mgr_to_hdl_map = std::unordered_map<manager_ptr, caf::actor>;
 
   // -- constructors, destructors, and assignment operators --------------------
 
   stream_transport(caf::event_based_actor* self, const filter_type& filter)
-    : caf::stream_manager(self), out_(this), remaining_records_(0) {
-    continuous(true);
-    // TODO: use filter
+    : self_(self), dispatcher_(self) {
     using caf::get_or;
     auto& cfg = self->system().config();
     auto meta_dir = get_or(cfg, "broker.recording-directory",
@@ -129,6 +90,7 @@ public:
                                     defaults::output_generator_file_cap);
       }
     }
+    stash_ = dispatcher_.new_item_stash(0);
   }
 
   // -- initialization ---------------------------------------------------------
@@ -141,118 +103,71 @@ public:
   // -- properties -------------------------------------------------------------
 
   caf::event_based_actor* self() noexcept {
-    // Our only constructor accepts an event-based actor. Hence, we know for
-    // sure that this case is safe, even though the base type stores self_ as a
-    // scheduled_actor pointer.
-    return static_cast<caf::event_based_actor*>(this->self_);
+    return self_;
   }
 
   auto& pending_connections() noexcept {
     return pending_connections_;
   }
 
-  /// Returns the downstream_manager for peer traffic.
-  auto& peer_manager() noexcept {
-    return out().template get<typename peer_trait::manager>();
-  }
-
-  /// Returns the downstream_manager for worker traffic.
-  auto& worker_manager() noexcept {
-    return out().template get<typename worker_trait::manager>();
-  }
-
-  /// Returns the downstream_manager for data store traffic.
-  auto& store_manager() noexcept {
-    return out().template get<typename store_trait::manager>();
-  }
-
-  // -- streaming helper functions ---------------------------------------------
-
-  void ack_open_success(caf::stream_slot slot,
-                        const caf::actor_addr& rebind_from,
-                        caf::strong_actor_ptr rebind_to) {
-    BROKER_TRACE(BROKER_ARG(slot)
-                 << BROKER_ARG(rebind_from) << BROKER_ARG(rebind_to));
-    if (rebind_from != rebind_to) {
-      BROKER_DEBUG("rebind occurred" << BROKER_ARG(slot)
-                                     << BROKER_ARG(rebind_from)
-                                     << BROKER_ARG(rebind_to));
-      peer_manager().filter(slot).first
-        = caf::actor_cast<caf::actor_addr>(rebind_to);
-    }
-  }
-
-  void ack_open_failure(caf::stream_slot slot,
-                        const caf::actor_addr& rebind_from,
-                        caf::strong_actor_ptr rebind_to) {
-    BROKER_TRACE(BROKER_ARG(slot)
-                 << BROKER_ARG(rebind_from) << BROKER_ARG(rebind_to));
-    CAF_IGNORE_UNUSED(rebind_from);
-    CAF_IGNORE_UNUSED(rebind_to);
-    auto i = ostream_to_peer_.find(slot);
-    if (i != ostream_to_peer_.end()) {
-      auto hdl = i->second;
-      remove_peer(hdl, make_error(caf::sec::invalid_stream_state), false,
-                  false);
-    }
-  }
-
-  void push_to_substreams(std::vector<caf::message> xs) {
-    // Dispatch on the content of `xs`.
-    for (auto& x : xs) {
-      if (x.match_elements<topic, data>()) {
-        x.force_unshare();
-        worker_manager().push(std::move(x.get_mutable_as<topic>(0)),
-                              std::move(x.get_mutable_as<data>(1)));
-      } else if (x.match_elements<topic, internal_command>()) {
-        x.force_unshare();
-        store_manager().push(std::move(x.get_mutable_as<topic>(0)),
-                             std::move(x.get_mutable_as<internal_command>(1)));
-      }
-    }
-    worker_manager().emit_batches();
-    store_manager().emit_batches();
+  uint16_t ttl() const noexcept {
+    return dref().options().ttl;
   }
 
   // -- peer management --------------------------------------------------------
 
   /// Queries whether `hdl` is a known peer.
-  bool connected_to(const caf::actor& hdl) const {
-    return hdl_to_ostream_.count(hdl) != 0 || hdl_to_istream_.count(hdl) != 0;
+  [[nodiscard]] bool connected_to(const caf::actor& hdl) const {
+    return hdl_to_mgr_.count(hdl) != 0;
   }
 
-  /// Block peer messages from being handled.  They are buffered until unblocked.
-  void block_peer(caf::actor peer) {
-    blocked_peers.emplace(std::move(peer));
-  }
-
-  /// Unblock peer messages and flush any buffered messages immediately.
-  void unblock_peer(caf::actor peer) {
-    blocked_peers.erase(peer);
-    auto it = blocked_msgs.find(peer);
-    if (it == blocked_msgs.end())
-      return;
-    auto pit = hdl_to_istream_.find(peer);
-    if (pit == hdl_to_istream_.end()) {
-      blocked_msgs.erase(it);
-      BROKER_DEBUG(
-        "dropped batches after unblocking peer: path no longer exists" << peer);
-      return;
+  /// Drops a peer either due to an error or due to a graceful disconnect.
+  void drop_peer(const caf::actor& hdl, bool graceful, const error& reason) {
+    if (auto i = hdl_to_mgr_.find(hdl); i != hdl_to_mgr_.end()) {
+      auto mgr = i->second;
+      mgr_to_hdl_.erase(mgr);
+      hdl_to_mgr_.erase(i);
+      if (graceful)
+        BROKER_DEBUG(hdl.node() << "disconnected gracefully");
+      else
+        BROKER_DEBUG(hdl.node() << "disconnected abnormally:" << reason);
+      dref().peer_disconnected(hdl.node(), hdl, reason);
+    } else if (auto j = pending_connections_.find(hdl);
+               j != pending_connections_.end()) {
+      BROKER_DEBUG("peer failed to connect");
+      auto err = make_error(ec::peer_disconnect_during_handshake);
+      j->second.rp.deliver(err);
+      pending_connections_.erase(j);
+      dref().peer_unavailable(hdl.node(), hdl, err);
     }
-    auto& slot = pit->second;
-    auto sap = caf::actor_cast<caf::strong_actor_ptr>(peer);
-    for (auto& batch : it->second) {
-      BROKER_DEBUG("handle blocked batch" << peer);
-      handle_batch(sap, batch);
-    }
-    blocked_msgs.erase(it);
+    // Shut down when the last peer stops listening.
+    if (dref().shutting_down() && pending_connections_.empty()
+        && hdl_to_mgr_.empty())
+      self()->quit(caf::exit_reason::user_shutdown);
   }
 
   /// Disconnects a peer by demand of the user.
   void unpeer(const peer_id_type& peer_id, const caf::actor& hdl) {
     BROKER_TRACE(BROKER_ARG(peer_id) << BROKER_ARG(hdl));
-    if (!remove_peer(hdl, caf::none, false, true))
-      dref().cannot_remove_peer(peer_id, hdl);
+    if (auto i = hdl_to_mgr_.find(hdl); i != hdl_to_mgr_.end()) {
+      auto mgr = i->second;
+      mgr->unobserve();
+      mgr->stop();
+      mgr_to_hdl_.erase(mgr);
+      hdl_to_mgr_.erase(i);
+      dref().peer_removed(hdl.node(), hdl);
+    } else if (auto j = pending_connections_.find(hdl);
+               j != pending_connections_.end()) {
+      auto mgr = j->second.mgr;
+      mgr->unobserve();
+      mgr->stop();
+      j->second.rp.deliver(make_error(ec::peer_disconnect_during_handshake));
+      pending_connections_.erase(j);
+    }
+    // Shut down when the last peer stops listening.
+    if (dref().shutting_down() && pending_connections_.empty()
+        && mgr_to_hdl_.empty())
+      self()->quit(caf::exit_reason::user_shutdown);
   }
 
   /// Disconnects a peer by demand of the user.
@@ -273,24 +188,39 @@ public:
   template <bool SendOwnFilter>
   auto start_handshake(const caf::actor& peer_hdl, filter_type peer_filter) {
     BROKER_TRACE(BROKER_ARG(peer_hdl) << BROKER_ARG(peer_filter));
-    // Token for static dispatch of add().
-    std::integral_constant<bool, SendOwnFilter> send_own_filter_token;
+    using result_type = std::conditional_t<
+      SendOwnFilter,
+      caf::outbound_stream_slot<node_message, filter_type, caf::actor>,
+      caf::outbound_stream_slot<node_message, atom::ok, caf::actor>>;
     // Check whether we already send outbound traffic to the peer. Could use
     // `CAF_ASSERT` instead, because this must'nt get called for known peers.
-    using result_type = decltype(add(send_own_filter_token, peer_hdl));
-    if (hdl_to_ostream_.count(peer_hdl) != 0) {
+    if (hdl_to_mgr_.count(peer_hdl) != 0) {
       BROKER_ERROR("peer already connected");
       return result_type{};
     }
     // Add outbound path to the peer.
-    auto slot = add(send_own_filter_token, peer_hdl);
-    // Make sure the peer receives the correct traffic.
-    out().template assign<typename peer_trait::manager>(slot);
-    peer_manager().set_filter(
-      slot, std::make_pair(peer_hdl.address(), std::move(peer_filter)));
-    // Add bookkeeping state for our new peer.
-    add_opath(slot, peer_hdl);
-    return slot;
+    auto self_hdl = caf::actor_cast<caf::actor>(self());
+    if constexpr (SendOwnFilter) {
+      if (auto i = pending_connections_.count(peer_hdl) == 0) {
+        auto mgr = detail::make_peer_manager(&dispatcher_, this);
+        mgr->filter(std::move(peer_filter));
+        pending_connections_[peer_hdl].mgr = mgr;
+        return mgr->template add_unchecked_outbound_path<node_message>(
+          peer_hdl, std::make_tuple(dref().filter(), std::move(self_hdl)));
+      } else {
+        BROKER_ERROR("already connecting to peer");
+        return result_type{};
+      }
+    } else if (auto i = pending_connections_.find(peer_hdl);
+               i != pending_connections_.end()) {
+      auto mgr = i->second.mgr;
+      mgr->filter(std::move(peer_filter));
+      return mgr->template add_unchecked_outbound_path<node_message>(
+        peer_hdl, std::make_tuple(atom::ok_v, std::move(self_hdl)));
+    } else {
+      BROKER_ERROR("received handshake #2 from unknown peer");
+      return result_type{};
+    }
   }
 
   /// Initiates peering between this peer and `remote_peer`.
@@ -300,7 +230,7 @@ public:
     // Sanity checking.
     if (remote_peer == nullptr) {
       rp.deliver(caf::sec::invalid_argument);
-      return ;
+      return;
     }
     // Ignore repeated peering requests without error.
     if (pending_connections().count(remote_peer) > 0
@@ -309,8 +239,9 @@ public:
       return;
     }
     // Create necessary state and send message to remote core.
+    auto mgr = make_peer_manager(&dispatcher_, this);
     pending_connections().emplace(remote_peer,
-                                  pending_connection{0, std::move(rp)});
+                                  pending_connection{mgr, std::move(rp)});
     self()->send(self() * remote_peer, atom::peer_v, dref().filter(), self());
     self()->monitor(remote_peer);
   }
@@ -319,87 +250,62 @@ public:
   /// @param peer_hdl Handle to the peering (remote) core actor.
   /// @returns `false` if the peer is already connected, `true` otherwise.
   /// @pre Current message is an `open_stream_msg`.
-  void ack_peering(const caf::stream<message_type>& in,
+  bool ack_peering(const caf::stream<message_type>& in,
                    const caf::actor& peer_hdl) {
     BROKER_TRACE(BROKER_ARG(peer_hdl));
-    // Check whether we already receive inbound traffic from the peer. Could use
-    // `CAF_ASSERT` instead, because this must'nt get called for known peers.
-    if (hdl_to_istream_.count(peer_hdl) != 0) {
-      BROKER_ERROR("peer already connected");
-      return;
-    }
-    // Add inbound path for our peer.
-    auto slot = this->add_unchecked_inbound_path(in);
-    add_ipath(slot, peer_hdl);
-  }
-
-  /// Queries whether we have an outbound path to `hdl`.
-  bool has_outbound_path_to(const caf::actor& peer_hdl) {
-    return hdl_to_ostream_.count(peer_hdl) != 0;
-  }
-
-  /// Queries whether we have an inbound path from `hdl`.
-  bool has_inbound_path_from(const caf::actor& peer_hdl) {
-    return hdl_to_istream_.count(peer_hdl) != 0;
-  }
-
-  /// Removes a peer, aborting any stream to and from that peer.
-  bool remove_peer(const caf::actor& hdl, caf::error reason, bool silent,
-                   bool graceful_removal) {
-    BROKER_TRACE(BROKER_ARG(hdl));
-    int performed_erases = 0;
-    { // lifetime scope of first iterator pair
-      auto e = hdl_to_ostream_.end();
-      auto i = hdl_to_ostream_.find(hdl);
-      if (i != e) {
-        BROKER_DEBUG("remove outbound path to peer:" << hdl);
-        ++performed_erases;
-        out().remove_path(i->second, reason, silent);
-        ostream_to_peer_.erase(i->second);
-        hdl_to_ostream_.erase(i);
+    BROKER_ASSERT(hdl_to_mgr_.count(peer_hdl) == 0);
+    if (auto i = pending_connections_.find(peer_hdl);
+        i != pending_connections_.end()) {
+      if (!i->second.mgr->has_inbound_path()) {
+        i->second.mgr->add_unchecked_inbound_path(in);
+        return true;
+      } else {
+        BROKER_ERROR("ack_peering called, but an inbound path already exists");
+        return false;
       }
-    }
-    { // lifetime scope of second iterator pair
-      auto e = hdl_to_istream_.end();
-      auto i = hdl_to_istream_.find(hdl);
-      if (i != e) {
-        BROKER_DEBUG("remove inbound path to peer:" << hdl);
-        ++performed_erases;
-        this->remove_input_path(i->second, reason, silent);
-        istream_to_hdl_.erase(i->second);
-        hdl_to_istream_.erase(i);
-      }
-    }
-    if (performed_erases == 0) {
-      BROKER_DEBUG("no path was removed for peer:" << hdl);
+    } else {
+      BROKER_ERROR("ack_peering but no peering started yet");
       return false;
     }
-    if (graceful_removal)
-      dref().peer_removed(hdl.node(), hdl);
-    else
-      dref().peer_disconnected(hdl.node(), hdl, reason);
-    dref().cache().remove(hdl);
-    if (dref().shutting_down() && hdl_to_ostream_.empty()) {
-      // Shutdown when the last peer stops listening.
-      self()->quit(caf::exit_reason::user_shutdown);
-    } else {
-      // See whether we can make progress without that peer in the mix.
-      this->push();
-    }
-    return true;
   }
 
   /// Updates the filter of an existing peer.
   bool update_peer(const caf::actor& hdl, filter_type filter) {
     BROKER_TRACE(BROKER_ARG(hdl) << BROKER_ARG(filter));
-    auto e = hdl_to_ostream_.end();
-    auto i = hdl_to_ostream_.find(hdl);
-    if (i == e) {
-      BROKER_DEBUG("cannot update filter on unknown peer");
+    if (auto i = hdl_to_mgr_.find(hdl); i != hdl_to_mgr_.end()) {
+      i->second->filter(std::move(filter));
+      return true;
+    } else {
+      BROKER_DEBUG("cannot update filter of unknown peer");
       return false;
     }
-    peer_manager().filter(i->second).second = std::move(filter);
-    return true;
+  }
+
+  void try_finalize_handshake(const caf::actor& hdl) {
+    if (auto i = pending_connections_.find(hdl);
+        i != pending_connections_.end()) {
+      if (auto mgr = i->second.mgr; mgr->fully_connected()) {
+        mgr->unblock_inputs();
+        dispatcher_.add(mgr);
+        hdl_to_mgr_.emplace(hdl, mgr);
+        mgr_to_hdl_.emplace(mgr, hdl);
+        i->second.rp.deliver(hdl);
+        pending_connections_.erase(i);
+        dref().peer_connected(hdl.node(), hdl);
+      }
+    }
+  }
+
+  // -- filter management ------------------------------------------------------
+
+  void set_filter(caf::stream_slot out_slot, filter_type filter) {
+    auto i = std::find_if(dispatcher_.managers().begin(),
+                          dispatcher_.managers().end(),
+                          [out_slot](const auto& ptr) {
+                            return ptr->outbound_path_slot() == out_slot;
+                          });
+    if (i != dispatcher_.managers().end())
+      (*i)->filter(std::move(filter));
   }
 
   // -- management of worker and storage streams -------------------------------
@@ -407,86 +313,75 @@ public:
   /// Adds the sender of the current message as worker by starting an output
   /// stream to it.
   /// @pre `current_sender() != nullptr`
-  caf::outbound_stream_slot<typename worker_trait::element>
-  add_worker(filter_type filter) {
+  auto add_worker(filter_type filter) {
     BROKER_TRACE(BROKER_ARG(filter));
-    auto slot = this->template add_unchecked_outbound_path<
-      typename worker_trait::element>();
-    if (slot != caf::invalid_stream_slot) {
-      out().template assign<typename worker_trait::manager>(slot);
-      worker_manager().set_filter(slot, std::move(filter));
-    }
-    return slot;
+    dref().subscribe(filter);
+    auto mgr = make_data_sink(&dispatcher_, std::move(filter));
+    auto res = mgr->template add_unchecked_outbound_path<data_message>();
+    BROKER_ASSERT(res != caf::invalid_stream_slot);
+    return res;
   }
 
   /// Subscribes `self->sender()` to `store_manager()`.
-  auto add_sending_store(const filter_type& filter) {
-    using element_type = typename store_trait::element;
-    using result_type = caf::outbound_stream_slot<element_type>;
-    auto slot = add_unchecked_outbound_path<element_type>();
-    if (slot != caf::invalid_stream_slot) {
-      dref().subscribe(filter);
-      out_.template assign<typename store_trait::manager>(slot);
-      store_manager().set_filter(slot, filter);
-    }
-    return result_type{slot};
+  auto add_sending_store(filter_type filter) {
+    BROKER_TRACE(BROKER_ARG(filter));
+    dref().subscribe(filter);
+    auto mgr = make_command_sink(&dispatcher_, std::move(filter));
+    auto res = mgr->template add_unchecked_outbound_path<command_message>();
+    BROKER_ASSERT(res != caf::invalid_stream_slot);
+    return res;
   }
 
   /// Subscribes `hdl` to `store_manager()`.
   caf::error add_store(const caf::actor& hdl, const filter_type& filter) {
-    using element_type = typename store_trait::element;
-    auto slot = add_unchecked_outbound_path<element_type>(hdl);
-    if (slot == caf::invalid_stream_slot)
+    BROKER_TRACE(BROKER_ARG(hdl) << BROKER_ARG(filter));
+    auto mgr = make_command_sink(&dispatcher_, std::move(filter));
+    auto res = mgr->template add_unchecked_outbound_path<command_message>(hdl);
+    if (res != caf::invalid_stream_slot) {
+      dref().subscribe(filter);
+      return caf::none;
+    } else {
       return caf::sec::cannot_add_downstream;
-    dref().subscribe(filter);
-    out_.template assign<typename store_trait::manager>(slot);
-    store_manager().set_filter(slot, filter);
-    return caf::none;
+    }
   }
 
   // -- selectively pushing data into the streams ------------------------------
 
-  /// Pushes data to workers without forwarding it to peers.
-  void local_push(data_message x) {
-    BROKER_TRACE(BROKER_ARG(x)
-                 << BROKER_ARG2("num_paths", worker_manager().num_paths()));
-    if (worker_manager().num_paths() > 0) {
-      worker_manager().push(std::move(x));
-      worker_manager().emit_batches();
-    }
+  /// Pushes messages to local subscribers without forwarding it to peers.
+  template <class T>
+  void local_push(T msg) {
+    BROKER_TRACE(BROKER_ARG(msg));
+    if (stash_->empty())
+      stash_->replenish(item_stash_replenish_size);
+    dispatcher_.enqueue(stash_->next_item(std::move(msg), ttl(), nullptr,
+                                          detail::item_scope::local));
   }
 
-  /// Pushes data to stores without forwarding it to peers.
-  void local_push(command_message x) {
-    BROKER_TRACE(BROKER_ARG(x)
-                 << BROKER_ARG2("num_paths", store_manager().num_paths()));
-    if (store_manager().num_paths() > 0) {
-      store_manager().push(std::move(x));
-      store_manager().emit_batches();
-    }
-  }
-
-  /// Pushes data to peers only without forwarding it to local substreams.
+  /// Pushes messages to peers without forwarding it to local subscribers.
   void remote_push(message_type msg) {
     BROKER_TRACE(BROKER_ARG(msg));
-    peer_manager().push(std::move(msg));
-    peer_manager().emit_batches();
+    if (stash_->empty())
+      stash_->replenish(item_stash_replenish_size);
+    dispatcher_.enqueue(stash_->next_item(std::move(msg.content), msg.ttl,
+                                          nullptr, detail::item_scope::remote));
   }
-
-  using caf::stream_manager::push;
 
   /// Pushes data to peers and workers.
   void push(data_message msg) {
     BROKER_TRACE(BROKER_ARG(msg));
-    remote_push(make_node_message(std::move(msg), dref().options().ttl));
-    // local_push(std::move(x), std::move(y));
+    if (stash_->empty())
+      stash_->replenish(item_stash_replenish_size);
+    dispatcher_.enqueue(
+      stash_->next_item(msg, ttl(), nullptr, detail::item_scope::remote));
   }
 
   /// Pushes data to peers and stores.
   void push(command_message msg) {
     BROKER_TRACE(BROKER_ARG(msg));
-    remote_push(make_node_message(std::move(msg), dref().options().ttl));
-    // local_push(std::move(x), std::move(y));
+    if (stash_->empty())
+      stash_->replenish(item_stash_replenish_size);
+    dispatcher_.enqueue(
+      stash_->next_item(msg, ttl(), nullptr, detail::item_scope::remote));
   }
 
   /// Pushes data to peers and stores.
@@ -519,156 +414,23 @@ public:
     visit([this](auto& x) { dref().ship(x); }, msg);
   }
 
+  // -- unipath manager callbacks ----------------------------------------------
+
+  void closing(detail::unipath_manager* ptr, bool graceful,
+               const error& reason) override {
+    drop_peer(ptr->hdl(), graceful, reason);
+  }
+
+  void downstream_connected(detail::unipath_manager*,
+                            const caf::actor& hdl) override {
+    try_finalize_handshake(hdl);
+  }
+
   // -- overridden member functions of caf::stream_manager ---------------------
-
-  void handle_batch(const caf::strong_actor_ptr& hdl, caf::message& xs) {
-    BROKER_TRACE(BROKER_ARG(hdl) << BROKER_ARG(xs));
-    // If there's anything in the central buffer at this point, it's stuff that
-    // we're sending out ourselves (as opposed to forwarding), so we flush it
-    // out to each path's own cache now to make sure the subsequent flush in
-    // after_handle_batch doesn't accidentally filter out messages where the
-    // outband path of previously-buffered messagesi happens to match the path
-    // of the inbound data we are handling here.
-    BROKER_ASSERT(peer_manager().selector().active_sender == nullptr);
-    auto& d = dref();
-    peer_manager().fan_out_flush();
-    peer_manager().selector().active_sender = caf::actor_cast<caf::actor_addr>(hdl);
-    auto guard = caf::detail::make_scope_guard([this] {
-      // Make sure the content of the buffer is pushed to the outbound paths
-      // while the sender filter is still active.
-      peer_manager().fan_out_flush();
-      peer_manager().selector().active_sender = nullptr;
-    });
-    // Handle received batch.
-    if (xs.match_elements<typename peer_trait::batch>()) {
-      auto peer_actor = caf::actor_cast<caf::actor>(hdl);
-      auto it = blocked_peers.find(peer_actor);
-      if (it != blocked_peers.end()) {
-        BROKER_DEBUG("buffer batch from blocked peer" << hdl);
-        auto& bmsgs = blocked_msgs[peer_actor];
-        bmsgs.emplace_back(std::move(xs));
-        return;
-      }
-      auto num_workers = worker_manager().num_paths();
-      auto num_stores = store_manager().num_paths();
-      BROKER_DEBUG("forward batch from peers;" << BROKER_ARG(num_workers)
-                                               << BROKER_ARG(num_stores));
-      // Only received from other peers. Extract content for to local workers
-      // or stores and then forward to other peers.
-      for (auto& msg : xs.get_mutable_as<typename peer_trait::batch>(0)) {
-        const topic* t;
-        // Dispatch to local workers or stores messages.
-        if (is_data_message(msg)) {
-          auto& dm = get<data_message>(msg.content);
-          t = &get_topic(dm);
-          if (num_workers > 0)
-            worker_manager().push(dm);
-        } else {
-          auto& cm = get<command_message>(msg.content);
-          t = &get_topic(cm);
-          if (num_stores > 0)
-            store_manager().push(cm);
-        }
-        // Check if forwarding is on.
-        if (!dref().options().forward)
-          continue;
-        // Somewhat hacky, but don't forward data store clone messages.
-        auto ends_with = [](const std::string& s, const std::string& ending) {
-          if (ending.size() > s.size())
-            return false;
-          return std::equal(ending.rbegin(), ending.rend(), s.rbegin());
-        };
-        if (ends_with(t->string(), topics::clone_suffix.string()))
-          continue;
-        // Either decrease TTL if message has one already, or add one.
-        if (--msg.ttl == 0) {
-          BROKER_WARNING("dropped a message with expired TTL");
-          continue;
-        }
-        // Forward to other peers.
-        d.publish(std::move(msg));
-      }
-      return;
-    }
-    auto try_publish = [&](auto trait) {
-      using batch_type = typename decltype(trait)::batch;
-      if (xs.template match_elements<batch_type>()) {
-        for (auto& x : xs.template get_mutable_as<batch_type>(0))
-          d.publish(x);
-        return true;
-      }
-      return false;
-    };
-    if (try_publish(worker_trait{}) || try_publish(store_trait{})
-        || try_publish(var_trait{}))
-      return;
-    BROKER_ERROR("unexpected batch:" << deep_to_string(xs));
-  }
-
-  void handle(caf::inbound_path* path,
-              caf::downstream_msg::batch& batch) override {
-    handle_batch(path->hdl, batch.xs);
-  }
-
-  void handle(caf::inbound_path* path, caf::downstream_msg::close& x) override {
-    BROKER_TRACE(BROKER_ARG(path) << BROKER_ARG(x));
-    auto slot = path->slots.receiver;
-    remove_cb(slot, istream_to_hdl_, hdl_to_istream_, hdl_to_ostream_, caf::none);
-  }
-
-  void handle(caf::inbound_path* path,
-              caf::downstream_msg::forced_close& x) override {
-    BROKER_TRACE(BROKER_ARG(path) << BROKER_ARG(x));
-    auto slot = path->slots.receiver;
-    remove_cb(slot, istream_to_hdl_, hdl_to_istream_, hdl_to_ostream_,
-              std::move(x.reason));
-  }
-
-  void handle(caf::stream_slots slots, caf::upstream_msg::drop& x) override {
-    BROKER_TRACE(BROKER_ARG(slots) << BROKER_ARG(x));
-    caf::stream_manager::handle(slots, x);
-  }
-
-  void handle(caf::stream_slots slots,
-              caf::upstream_msg::forced_drop& x) override {
-    BROKER_TRACE(BROKER_ARG(slots) << BROKER_ARG(x));
-    auto slot = slots.receiver;
-    if (out_.remove_path(slots.receiver, x.reason, true))
-      remove_cb(slot, ostream_to_peer_, hdl_to_ostream_, hdl_to_istream_,
-                std::move(x.reason));
-  }
-
-  bool handle(caf::stream_slots slots,
-              caf::upstream_msg::ack_open& x) override {
-    BROKER_TRACE(BROKER_ARG(slots) << BROKER_ARG(x));
-    auto rebind_from = x.rebind_from;
-    auto rebind_to = x.rebind_to;
-    if (caf::stream_manager::handle(slots, x)) {
-      ack_open_success(slots.receiver, rebind_from, rebind_to);
-      return true;
-    }
-    ack_open_failure(slots.receiver, rebind_from, rebind_to);
-    return false;
-  }
-
-  bool done() const override {
-    return !continuous() && pending_handshakes_ == 0 && inbound_paths_.empty()
-           && out_.clean();
-  }
-
-  bool idle() const noexcept override {
-    // Same as `stream_stage<...>`::idle().
-    return out_.stalled() || (out_.clean() && this->inbound_paths_idle());
-  }
-
-  downstream_manager_type& out() override {
-    return out_;
-  }
 
   /// Applies `f` to each peer.
   template <class F>
   void for_each_peer(F f) {
-    // visit all peers that have at least one path still connected
     auto peers = peer_handles();
     std::for_each(peers.begin(), peers.end(), std::move(f));
   }
@@ -676,23 +438,15 @@ public:
   /// Returns all known peers.
   auto peer_handles() {
     std::vector<caf::actor> peers;
-    for (auto& kvp : hdl_to_ostream_)
+    for (auto& kvp : hdl_to_mgr_)
       peers.emplace_back(kvp.first);
-    for (auto& kvp : hdl_to_istream_)
-      peers.emplace_back(kvp.first);
-    auto b = peers.begin();
-    auto e = peers.end();
-    std::sort(b, e);
-    auto p = std::unique(b, e);
-    if (p != e)
-      peers.erase(p, e);
     return peers;
   }
 
   /// Finds the first peer handle that satisfies the predicate.
   template <class Predicate>
   caf::actor find_output_peer_hdl(Predicate pred) {
-    for (auto& kvp : hdl_to_ostream_)
+    for (auto& kvp : hdl_to_mgr_)
       if (pred(kvp.first))
         return kvp.first;
     return nullptr;
@@ -701,9 +455,19 @@ public:
   /// Applies `f` to each filter.
   template <class F>
   void for_each_filter(F f) {
-    for (auto& kvp : peer_manager().states()) {
-      f(kvp.second.filter);
-    }
+    for (auto& kvp : mgr_to_hdl_)
+      if (kvp.first->message_type() == caf::type_id_v<node_message>)
+        f(kvp.first->filter());
+  }
+
+  /// Checks whether the predicate `f` holds for any @ref unicast_manager object
+  /// that represents a remote peer.
+  template <class Predicate>
+  bool any_peer_manager(Predicate f) {
+    for (auto& kvp : mgr_to_hdl_)
+      if (f(kvp.first))
+        return true;
+    return false;
   }
 
   // -- fallback implementations to enable forwarding chains -------------------
@@ -787,101 +551,42 @@ public:
   }
 
 protected:
-  /// Returns the initial TTL value when publishing data.
-  ttl initial_ttl() {
-    return static_cast<ttl>(dref().options().ttl);
+  manager_ptr mgr_by_hdl(const caf::actor& hdl) {
+    if (auto i = hdl_to_mgr_.find(hdl); i != hdl_to_mgr_.end())
+      return i->second;
+    else if (auto j = pending_connections_.find(hdl);
+             j != pending_connections_.end())
+      return j->second.mgr;
+    else
+      return nullptr;
   }
 
-  /// Adds entries to `hdl_to_istream_` and `istream_to_hdl_`.
-  void add_ipath(caf::stream_slot slot, const caf::actor& peer_hdl) {
-    BROKER_TRACE(BROKER_ARG(slot) << BROKER_ARG(peer_hdl));
-    if (slot == caf::invalid_stream_slot) {
-      BROKER_ERROR("tried to add an invalid inbound path");
-      return;
-    }
-    if (!istream_to_hdl_.emplace(slot, peer_hdl).second) {
-      BROKER_ERROR("ipath_to_peer entry already exists");
-      return;
-    }
-    if (!hdl_to_istream_.emplace(peer_hdl, slot).second) {
-      BROKER_ERROR("peer_to_ipath entry already exists");
-      return;
-    }
+  caf::actor hdl_by_mgr(const manager_ptr& mgr) {
+    if (auto i = mgr_to_hdl_.find(mgr); i != mgr_to_hdl_.end())
+      return i->second;
+    else if (auto j = pending_connections_.find(mgr);
+             j != pending_connections_.end())
+      return j->second.mgr;
+    else
+      return nullptr;
   }
 
-  /// Adds entries to `hdl_to_ostream_` and `ostream_to_peer_`.
-  void add_opath(caf::stream_slot slot, const caf::actor& peer_hdl) {
-    BROKER_TRACE(BROKER_ARG(slot) << BROKER_ARG(peer_hdl));
-    if (slot == caf::invalid_stream_slot) {
-      BROKER_ERROR("tried to add an invalid outbound path");
-      return;
-    }
-    if (!ostream_to_peer_.emplace(slot, peer_hdl).second) {
-      BROKER_ERROR("opath_to_peer entry already exists");
-      return;
-    }
-    if (!hdl_to_ostream_.emplace(peer_hdl, slot).second) {
-      BROKER_ERROR("peer_to_opath entry already exists");
-      return;
-    }
-  }
+  /// Pointer to the actor that owns this state.
+  caf::event_based_actor* self_;
 
-  /// Path `slot` in `xs` was dropped or closed. Removes the entry in `xs` as
-  /// well as the associated entry in `ys`. Also removes the entries from `as`
-  /// and `bs` if `reason` is not default constructed. Calls `remove_peer` if
-  /// no entry for a peer exists afterwards.
-  void remove_cb(caf::stream_slot slot, slot_to_hdl_map& xs,
-                 hdl_to_slot_map& ys, hdl_to_slot_map& zs, caf::error reason) {
-    BROKER_TRACE(BROKER_ARG(slot));
-    auto i = xs.find(slot);
-    if (i == xs.end()) {
-      BROKER_DEBUG("no entry in xs found for slot" << slot);
-      return;
-    }
-    auto peer_hdl = i->second;
-    remove_peer(peer_hdl, std::move(reason), true, false);
-  }
+  /// Our dispatcher "singleton" that holds the item allocator as well as
+  /// pointers to all active unipath managers for outbound traffic.
+  detail::central_dispatcher dispatcher_;
 
-  /// Sends a handshake with filter in step #1.
-  auto add(std::true_type send_own_filter, const caf::actor& hdl) {
-    auto xs
-      = std::make_tuple(dref().filter(), caf::actor_cast<caf::actor>(self()));
-    return this->template add_unchecked_outbound_path<node_message>(
-      hdl, std::move(xs));
-  }
+  /// Stash for generating items that users publish directly on the core instead
+  /// of going through a publisher.
+  detail::item_stash_ptr stash_;
 
-  /// Sends a handshake with 'ok' in step #2.
-  auto add(std::false_type send_own_filter, const caf::actor& hdl) {
-#if CAF_VERSION < 1800
-    caf::atom_value ok = atom::ok_v;
-    auto xs = std::make_tuple(ok, caf::actor_cast<caf::actor>(self()));
-#else
-    auto xs = std::make_tuple(atom::ok_v, caf::actor_cast<caf::actor>(self()));
-#endif
-    return this->template add_unchecked_outbound_path<node_message>(
-      hdl, std::move(xs));
-  }
+  /// Maps peer handles to their respective unipath manager.
+  hdl_to_mgr_map hdl_to_mgr_;
 
-  /// Organizes downstream communication to peers as well as local subscribers.
-  downstream_manager_type out_;
-
-  /// Maps peer handles to output path IDs.
-  hdl_to_slot_map hdl_to_ostream_;
-
-  /// Maps output path IDs to peer handles.
-  slot_to_hdl_map ostream_to_peer_;
-
-  /// Maps peer handles to input path IDs.
-  hdl_to_slot_map hdl_to_istream_;
-
-  /// Maps input path IDs to peer handles.
-  slot_to_hdl_map istream_to_hdl_;
-
-  /// Peers that are currently blocked (messages buffered until unblocked).
-  std::unordered_set<caf::actor> blocked_peers;
-
-  /// Messages that are currently buffered.
-  std::unordered_map<caf::actor, std::vector<caf::message>> blocked_msgs;
+  /// Maps unipath managers to their respective peer handle.
+  mgr_to_hdl_map mgr_to_hdl_;
 
   /// Maps pending peer handles to output IDs. An invalid stream ID indicates
   /// that only "step #0" was performed so far. An invalid stream ID corresponds
@@ -894,11 +599,15 @@ protected:
   detail::generator_file_writer_ptr recorder_;
 
   /// Counts down when using a `recorder_` to cap maximum file entries.
-  size_t remaining_records_;
+  size_t remaining_records_ = 0;
 
 private:
   Derived& dref() {
     return static_cast<Derived&>(*this);
+  }
+
+  const Derived& dref() const {
+    return static_cast<const Derived&>(*this);
   }
 };
 

--- a/include/broker/configuration.hh
+++ b/include/broker/configuration.hh
@@ -2,6 +2,8 @@
 
 #include <caf/actor_system_config.hpp>
 
+#include "broker/defaults.hh"
+
 namespace broker {
 
 struct broker_options {
@@ -15,7 +17,7 @@ struct broker_options {
   /// they have traversed more than this many hops. Note that the 1st
   /// receiver inserts the TTL (not the sender!). The 1st receiver does
   /// already count against the TTL.
-  unsigned int ttl = 20;
+  unsigned int ttl = defaults::ttl;
 
   /// Whether to use real/wall clock time for data store time-keeping
   /// tasks or whether the application will simulate time on its own.

--- a/include/broker/configuration.hh
+++ b/include/broker/configuration.hh
@@ -67,8 +67,9 @@ public:
 
   static constexpr skip_init_t skip_init = skip_init_t{};
 
-  /// Default-constructs a configuration.
   configuration();
+
+  configuration(configuration&&) = default;
 
   /// Constructs a configuration with non-default Broker options.
   explicit configuration(broker_options opts);

--- a/include/broker/core_actor.hh
+++ b/include/broker/core_actor.hh
@@ -32,12 +32,17 @@
 
 namespace broker {
 
-class core_manager
-  : public caf::extend<alm::stream_transport<core_manager, caf::node_id>,
-                       core_manager>:: //
+class core_state
+  : public caf::extend<alm::stream_transport<core_state, caf::node_id>,
+                       core_state>:: //
     with<mixin::connector, mixin::notifier, mixin::data_store_manager,
          mixin::recorder> {
 public:
+  // --- constants -------------------------------------------------------------
+
+  /// Gives this actor a recognizable name in log output.
+  static inline const char* name = "core";
+
   // --- member types ----------------------------------------------------------
 
   using super = extended_base;
@@ -49,8 +54,9 @@ public:
 
   // --- construction ----------------------------------------------------------
 
-  core_manager(caf::event_based_actor* ptr, const filter_type& filter,
-               broker_options opts, endpoint::clock* ep_clock);
+  core_state(caf::event_based_actor* ptr, const filter_type& filter,
+             broker_options opts = broker_options{},
+             endpoint::clock* ep_clock = nullptr);
 
   // --- initialization --------------------------------------------------------
 
@@ -58,15 +64,15 @@ public:
 
   // --- properties ------------------------------------------------------------
 
-  const auto& filter() const {
+  const auto& filter() const noexcept {
     return filter_;
   }
 
-  const auto& options() const {
+  const auto& options() const noexcept {
     return options_;
   }
 
-  bool shutting_down() const {
+  bool shutting_down() const noexcept {
     return shutting_down_;
   }
 
@@ -109,21 +115,6 @@ private:
   std::unordered_map<caf::actor, size_t> peers_awaiting_status_sync_;
 };
 
-struct core_state {
-  /// Establishes all invariants.
-  void init(filter_type initial_filter, broker_options opts,
-            endpoint::clock* ep_clock);
-
-  /// Multiplexes local streams and streams for peers.
-  caf::intrusive_ptr<core_manager> mgr;
-
-  /// Gives this actor a recognizable name in log output.
-  static inline const char* name = "core";
-};
-
 using core_actor_type = caf::stateful_actor<core_state>;
-
-caf::behavior core_actor(core_actor_type* self, filter_type initial_filter,
-                         broker_options opts, endpoint::clock* clock);
 
 } // namespace broker

--- a/include/broker/defaults.hh
+++ b/include/broker/defaults.hh
@@ -11,6 +11,10 @@ extern const caf::string_view recording_directory;
 
 extern const size_t output_generator_file_cap;
 
+constexpr uint16_t ttl = 20;
+
+constexpr size_t max_pending_inputs_per_source = 512;
+
 } // namespace broker::defaults
 
 namespace broker::defaults::store {

--- a/include/broker/detail/central_dispatcher.hh
+++ b/include/broker/detail/central_dispatcher.hh
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <vector>
+
+#include <caf/fwd.hpp>
+
+#include "broker/detail/item_allocator.hh"
+#include "broker/detail/item_stash.hh"
+#include "broker/detail/unipath_manager.hh"
+#include "broker/fwd.hh"
+
+namespace broker::detail {
+
+/// Central point for all `unipath_manager` instances to enqueue items.
+class central_dispatcher {
+public:
+  explicit central_dispatcher(caf::scheduled_actor* self);
+
+  /// Enqueues given items to all nested output paths.
+  void enqueue(caf::span<const item_ptr> ptrs);
+
+  /// Tries to emit batches on all nested output paths.
+  void ship();
+
+  /// Adds a new output path to the dispatcher.
+  void add(unipath_manager_ptr out);
+
+  /// Creates a new item stash to generate items for this dispatcher.
+  item_stash_ptr new_item_stash(size_t size);
+
+  auto self() const noexcept {
+    return self_;
+  }
+
+private:
+  std::vector<unipath_manager_ptr> nested_;
+  item_allocator_ptr alloc_;
+  caf::scheduled_actor* self_;
+};
+
+} // namespace broker::detail

--- a/include/broker/detail/central_dispatcher.hh
+++ b/include/broker/detail/central_dispatcher.hh
@@ -19,6 +19,8 @@ public:
   /// Enqueues given items to all nested output paths.
   void enqueue(caf::span<const item_ptr> ptrs);
 
+  void enqueue(const item_ptr& ptr);
+
   /// Tries to emit batches on all nested output paths.
   void ship();
 
@@ -30,6 +32,10 @@ public:
 
   auto self() const noexcept {
     return self_;
+  }
+
+  const auto& managers() const noexcept {
+    return nested_;
   }
 
 private:

--- a/include/broker/detail/item.hh
+++ b/include/broker/detail/item.hh
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <caf/stream_manager.hpp>
+
+#include "broker/detail/item_stash.hh"
+#include "broker/fwd.hh"
+#include "broker/message.hh"
+
+namespace broker::detail {
+
+/// @warning the embedded reference count is *not* thread-safe by design! Items
+///          as well as the stash and its allocator are local to a single actor.
+class item {
+public:
+  // -- friends ----------------------------------------------------------------
+
+  friend item_stash;
+
+  // -- intrusive_ptr support --------------------------------------------------
+
+  friend void intrusive_ptr_release(item*) noexcept;
+
+  friend void intrusive_ptr_add_ref(item*) noexcept;
+
+  // -- properties -------------------------------------------------------------
+
+  bool is_data_message() const noexcept;
+
+  bool is_command_message() const noexcept;
+
+  uint16_t ttl() const noexcept {
+    return msg_ttl_;
+  }
+
+  const caf::stream_manager_ptr& origin() const noexcept {
+    return origin_;
+  }
+
+private:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  item(data_message&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
+       item_stash* owner);
+
+  item(command_message&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
+       item_stash* owner);
+
+  // -- member variables -------------------------------------------------------
+
+  size_t ref_count_ = 1;
+  caf::variant<data_message, command_message> msg_;
+  uint16_t msg_ttl_;
+  caf::stream_manager_ptr origin_;
+  item_stash_ptr owner_;
+};
+
+using item_ptr = caf::intrusive_ptr<item>;
+
+} // namespace broker::detail

--- a/include/broker/detail/item.hh
+++ b/include/broker/detail/item.hh
@@ -16,6 +16,10 @@ public:
 
   friend item_stash;
 
+  // -- member types -----------------------------------------------------------
+
+  using variant_type = caf::variant<data_message, command_message>;
+
   // -- intrusive_ptr support --------------------------------------------------
 
   friend void intrusive_ptr_release(item*) noexcept;
@@ -24,9 +28,31 @@ public:
 
   // -- properties -------------------------------------------------------------
 
-  bool is_data_message() const noexcept;
+  bool is_data_message() const noexcept {
+    return caf::holds_alternative<data_message>(msg_);
+  }
 
-  bool is_command_message() const noexcept;
+  bool is_command_message() const noexcept {
+    return caf::holds_alternative<command_message>(msg_);
+  }
+
+  /// @pre `is_data_message()`
+  const auto& as_data_message() const noexcept {
+    return caf::get<data_message>(msg_);
+  }
+
+  /// @pre `is_command_message()`
+  const auto& as_command_message() const noexcept {
+    return caf::get<command_message>(msg_);
+  }
+
+  const auto& msg() const noexcept {
+    return msg_;
+  }
+
+  bool unique() const noexcept {
+    return ref_count_ == 1;
+  }
 
   uint16_t ttl() const noexcept {
     return msg_ttl_;
@@ -39,16 +65,20 @@ public:
 private:
   // -- constructors, destructors, and assignment operators --------------------
 
-  item(data_message&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
-       item_stash* owner);
-
-  item(command_message&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
-       item_stash* owner);
+  template <class T>
+  item(T&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
+       item_stash* owner)
+    : msg_(std::forward<T>(msg)),
+      msg_ttl_(msg_ttl),
+      origin_(origin),
+      owner_(owner) {
+    // nop
+  }
 
   // -- member variables -------------------------------------------------------
 
   size_t ref_count_ = 1;
-  caf::variant<data_message, command_message> msg_;
+  variant_type msg_;
   uint16_t msg_ttl_;
   caf::stream_manager_ptr origin_;
   item_stash_ptr owner_;

--- a/include/broker/detail/item.hh
+++ b/include/broker/detail/item.hh
@@ -2,6 +2,7 @@
 
 #include <caf/stream_manager.hpp>
 
+#include "broker/detail/item_scope.hh"
 #include "broker/detail/item_stash.hh"
 #include "broker/fwd.hh"
 #include "broker/message.hh"
@@ -15,10 +16,6 @@ public:
   // -- friends ----------------------------------------------------------------
 
   friend item_stash;
-
-  // -- member types -----------------------------------------------------------
-
-  using variant_type = caf::variant<data_message, command_message>;
 
   // -- intrusive_ptr support --------------------------------------------------
 
@@ -58,6 +55,10 @@ public:
     return msg_ttl_;
   }
 
+  item_scope scope() const noexcept {
+    return scope_;
+  }
+
   const caf::stream_manager_ptr& origin() const noexcept {
     return origin_;
   }
@@ -67,9 +68,10 @@ private:
 
   template <class T>
   item(T&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
-       item_stash* owner)
+       item_stash* owner, item_scope scope)
     : msg_(std::forward<T>(msg)),
       msg_ttl_(msg_ttl),
+      scope_(scope),
       origin_(origin),
       owner_(owner) {
     // nop
@@ -78,8 +80,9 @@ private:
   // -- member variables -------------------------------------------------------
 
   size_t ref_count_ = 1;
-  variant_type msg_;
+  node_message_content msg_;
   uint16_t msg_ttl_;
+  item_scope scope_;
   caf::stream_manager_ptr origin_;
   item_stash_ptr owner_;
 };

--- a/include/broker/detail/item_allocator.hh
+++ b/include/broker/detail/item_allocator.hh
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include <caf/intrusive_ptr.hpp>
+#include <caf/span.hpp>
+
+#include "broker/fwd.hh"
+
+namespace broker::detail {
+
+/// Allocates items for internal bookkeeping in the core actor. Never releases
+/// its memory until destroyed, but memory usage is bound by the maximum number
+/// of peers plus local publishers.
+/// @warning the allocator releases all of its memory when destroyed. Hence,
+///          clients must make sure return all
+/// @warning the embedded reference count is *not* thread-safe!
+class item_allocator {
+public:
+  // -- constants --------------------------------------------------------------
+
+  static constexpr size_t memory_chunk_size = 4'096;
+
+  // -- intrusive_ptr support --------------------------------------------------
+
+  friend void intrusive_ptr_release(item_allocator* ptr) noexcept {
+    if (--ptr->ref_count_ == 0)
+      delete ptr;
+  }
+
+  friend void intrusive_ptr_add_ref(item_allocator* ptr) noexcept {
+    ++ptr->ref_count_;
+  }
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  item_allocator(const item_allocator&) = delete;
+  item_allocator& operator=(const item_allocator&) = delete;
+
+  ~item_allocator() noexcept;
+
+  static caf::intrusive_ptr<item_allocator> make();
+
+  // -- interface --------------------------------------------------------------
+
+  /// Returns an *uninitialized* item.
+  [[nodiscard]] item* allocate();
+
+  /// Fills given range with *uninitialized* items.
+  void allocate(caf::span<item*> ptrs);
+
+  /// Puts an *uninitialized* item back to the internal free list.
+  void deallocate(item* ptr) noexcept;
+
+  /// Puts all *uninitialized* items back to the internal free list.
+  void deallocate(caf::span<item*> ptrs) noexcept;
+
+  /// Returns the total number of bytes held by this allocator.
+  size_t allocated_bytes() const noexcept;
+
+  /// Returns the total number of items allocated so far.
+  size_t allocated_items() const noexcept;
+
+  /// Returns the number of items that are currently in the free list.
+  size_t available_items() const noexcept {
+    return free_list_.size();
+  }
+
+private:
+  item_allocator() = default;
+
+  [[nodiscard]] item* force_allocate();
+
+  size_t ref_count_ = 1;
+  std::vector<item*> free_list_;
+  std::vector<void*> memory_chunks_;
+};
+
+using item_allocator_ptr = caf::intrusive_ptr<item_allocator>;
+
+} // namespace broker::detail

--- a/include/broker/detail/item_scope.hh
+++ b/include/broker/detail/item_scope.hh
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace broker::detail {
+
+/// Denotes the visibility scope of an @ref item.
+enum class item_scope : uint8_t {
+  global, /// Marks an item as visible to local subscribers and peers.
+  local,  /// Marks an item as visible to local subscribers only.
+  remote, /// Marks an item as visible to peers only.
+};
+
+/// @relates item_scope
+std::string to_string(item_scope);
+
+} // namespace broker::detail

--- a/include/broker/detail/item_stash.hh
+++ b/include/broker/detail/item_stash.hh
@@ -9,6 +9,10 @@ namespace broker::detail {
 
 class item_stash {
 public:
+  // -- member types -----------------------------------------------------------
+
+  using variant_type = caf::variant<data_message, command_message>;
+
   // -- intrusive_ptr support --------------------------------------------------
 
   friend void intrusive_ptr_release(item*) noexcept;
@@ -36,6 +40,9 @@ public:
                      caf::stream_manager* origin);
 
   item_ptr next_item(command_message&& msg, uint16_t msg_ttl,
+                     caf::stream_manager* origin);
+
+  item_ptr next_item(variant_type&& msg, uint16_t msg_ttl,
                      caf::stream_manager* origin);
 
 private:

--- a/include/broker/detail/item_stash.hh
+++ b/include/broker/detail/item_stash.hh
@@ -4,15 +4,13 @@
 #include <vector>
 
 #include "broker/detail/item_allocator.hh"
+#include "broker/detail/item_scope.hh"
+#include "broker/fwd.hh"
 
 namespace broker::detail {
 
 class item_stash {
 public:
-  // -- member types -----------------------------------------------------------
-
-  using variant_type = caf::variant<data_message, command_message>;
-
   // -- intrusive_ptr support --------------------------------------------------
 
   friend void intrusive_ptr_release(item*) noexcept;
@@ -28,22 +26,34 @@ public:
   static caf::intrusive_ptr<item_stash> make(item_allocator_ptr allocator,
                                              size_t size);
 
+  // -- size management --------------------------------------------------------
+
+  /// Makes `n` more items available to the stash.
+  void replenish(size_t n);
+
   // -- properties -------------------------------------------------------------
 
   size_t available() const noexcept {
     return stash_.size();
   }
 
+  bool empty() const noexcept {
+    return stash_.empty();
+  }
+
   // -- item factory functions -------------------------------------------------
 
   item_ptr next_item(data_message&& msg, uint16_t msg_ttl,
-                     caf::stream_manager* origin);
+                     caf::stream_manager* origin,
+                     item_scope scope = item_scope::global);
 
   item_ptr next_item(command_message&& msg, uint16_t msg_ttl,
-                     caf::stream_manager* origin);
+                     caf::stream_manager* origin,
+                     item_scope scope = item_scope::global);
 
-  item_ptr next_item(variant_type&& msg, uint16_t msg_ttl,
-                     caf::stream_manager* origin);
+  item_ptr next_item(node_message_content&& msg, uint16_t msg_ttl,
+                     caf::stream_manager* origin,
+                     item_scope scope = item_scope::global);
 
 private:
   // -- constructors, destructors, and assignment operators --------------------
@@ -61,6 +71,7 @@ private:
   size_t ref_count_ = 1;
   std::vector<item*> stash_;
   item_allocator_ptr allocator_;
+  size_t max_stash_size_ = 0;
 };
 
 using item_stash_ptr = caf::intrusive_ptr<item_stash>;

--- a/include/broker/detail/item_stash.hh
+++ b/include/broker/detail/item_stash.hh
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "broker/detail/item_allocator.hh"
+
+namespace broker::detail {
+
+class item_stash {
+public:
+  // -- intrusive_ptr support --------------------------------------------------
+
+  friend void intrusive_ptr_release(item*) noexcept;
+
+  friend void intrusive_ptr_release(item_stash*) noexcept;
+
+  friend void intrusive_ptr_add_ref(item_stash* ptr) noexcept {
+    ++ptr->ref_count_;
+  }
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  static caf::intrusive_ptr<item_stash> make(item_allocator_ptr allocator,
+                                             size_t size);
+
+  // -- properties -------------------------------------------------------------
+
+  size_t available() const noexcept {
+    return stash_.size();
+  }
+
+  // -- item factory functions -------------------------------------------------
+
+  item_ptr next_item(data_message&& msg, uint16_t msg_ttl,
+                     caf::stream_manager* origin);
+
+  item_ptr next_item(command_message&& msg, uint16_t msg_ttl,
+                     caf::stream_manager* origin);
+
+private:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  item_stash() = default;
+
+  // -- item management --------------------------------------------------------
+
+  [[nodiscard]] item* next();
+
+  void reclaim(item* ptr) noexcept;
+
+  // -- member variables -------------------------------------------------------
+
+  size_t ref_count_ = 1;
+  std::vector<item*> stash_;
+  item_allocator_ptr allocator_;
+};
+
+using item_stash_ptr = caf::intrusive_ptr<item_stash>;
+
+} // namespace broker::detail

--- a/include/broker/detail/master_actor.hh
+++ b/include/broker/detail/master_actor.hh
@@ -36,6 +36,7 @@ public:
 
   template <class T>
   void broadcast_cmd_to_clones(T cmd) {
+    BROKER_DEBUG("broadcast" << cmd << "to" << clones.size() << "clones");
     if (!clones.empty())
       broadcast(internal_command{std::move(cmd)});
   }

--- a/include/broker/detail/prefix_matcher.hh
+++ b/include/broker/detail/prefix_matcher.hh
@@ -5,11 +5,11 @@
 
 #include <caf/cow_tuple.hpp>
 #include <caf/message.hpp>
+#include <caf/variant.hpp>
 
 #include "broker/topic.hh"
 
-namespace broker {
-namespace detail {
+namespace broker::detail {
 
 struct prefix_matcher {
   using filter_type = std::vector<topic>;
@@ -22,6 +22,4 @@ struct prefix_matcher {
   }
 };
 
-
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/include/broker/detail/unipath_manager.hh
+++ b/include/broker/detail/unipath_manager.hh
@@ -8,6 +8,16 @@
 namespace broker::detail {
 
 /// A stream manager with at most one inbound and at most one outbound path.
+///
+/// Unlike CAF's regular stream managers, this manager does *not* forward data
+/// from its inbound paths to its outbound paths. In this design, all inbound
+/// paths feed into the central dispatcher. The dispatcher then pushes data into
+/// the outbound paths of *all* unipath managers. Further, manager implicitly
+/// filter out all items created by themselves. This is because our only use
+/// case for managers with in- and outbound paths is modeling Broker peers.
+/// We keep both paths to a single peer in one stream manager to model a
+/// bidirectional connection. Hence, forwarding from the in- to the outbound
+/// path would in our case send messages received from a peer back to itself.
 class unipath_manager : public caf::stream_manager {
 public:
   using super = caf::stream_manager;
@@ -18,11 +28,25 @@ public:
 
   using super::handle;
 
+  /// Pushes items downstream.
   virtual ptrdiff_t enqueue(caf::span<const item_ptr> ptrs) = 0;
 
+  /// Returns the filter that this manager applies to enqueued items.
   virtual filter_type filter() = 0;
 
+  /// Sets the filter that this manager applies to enqueued items.
   virtual void filter(filter_type) = 0;
+
+  /// Causes the manager to cache incoming batches until `unblock_inputs()` gets
+  /// called.
+  virtual void block_inputs();
+
+  /// Release all currently blocked batches and allow processing of batches
+  /// again.
+  virtual void unblock_inputs();
+
+  /// Returns whether this manager currently blocks incoming batches.
+  virtual bool blocks_inputs();
 
 protected:
   central_dispatcher* dispatcher_;
@@ -40,7 +64,8 @@ unipath_manager_ptr make_data_sink(central_dispatcher* dispatcher,
 unipath_manager_ptr make_command_sink(central_dispatcher* dispatcher,
                                       filter_type filter);
 
-// Peer managers always have one inbound and one outbound path.
+/// Peer managers always have one inbound and one outbound path.
+/// @note the returned manager returns `true` for `blocks_inputs()`.
 unipath_manager_ptr make_peer_manager(central_dispatcher* dispatcher);
 
 } // namespace broker::detail

--- a/include/broker/detail/unipath_manager.hh
+++ b/include/broker/detail/unipath_manager.hh
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <caf/fwd.hpp>
+#include <caf/stream_manager.hpp>
+
+#include "broker/fwd.hh"
+
+namespace broker::detail {
+
+/// A stream manager with at most one inbound and at most one outbound path.
+class unipath_manager : public caf::stream_manager {
+public:
+  using super = caf::stream_manager;
+
+  explicit unipath_manager(central_dispatcher* dispatcher);
+
+  ~unipath_manager() override;
+
+  using super::handle;
+
+  virtual ptrdiff_t enqueue(caf::span<const item_ptr> ptrs) = 0;
+
+  virtual filter_type filter() = 0;
+
+  virtual void filter(filter_type) = 0;
+
+protected:
+  central_dispatcher* dispatcher_;
+};
+
+using unipath_manager_ptr = caf::intrusive_ptr<unipath_manager>;
+
+unipath_manager_ptr make_data_source(central_dispatcher* dispatcher);
+
+unipath_manager_ptr make_command_source(central_dispatcher* dispatcher);
+
+unipath_manager_ptr make_data_sink(central_dispatcher* dispatcher,
+                                   filter_type filter);
+
+unipath_manager_ptr make_command_sink(central_dispatcher* dispatcher,
+                                      filter_type filter);
+
+// Peer managers always have one inbound and one outbound path.
+unipath_manager_ptr make_peer_manager(central_dispatcher* dispatcher);
+
+} // namespace broker::detail

--- a/include/broker/detail/unipath_manager.hh
+++ b/include/broker/detail/unipath_manager.hh
@@ -93,6 +93,8 @@ public:
 
   // -- overrides --------------------------------------------------------------
 
+  bool congested(const caf::inbound_path&) const noexcept override;
+
   void handle(caf::inbound_path*, caf::downstream_msg::close&) override;
 
   void handle(caf::inbound_path*, caf::downstream_msg::forced_close&) override;

--- a/include/broker/detail/unipath_manager.hh
+++ b/include/broker/detail/unipath_manager.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include <caf/fwd.hpp>
 #include <caf/stream_manager.hpp>
 
@@ -22,7 +24,13 @@ class unipath_manager : public caf::stream_manager {
 public:
   using super = caf::stream_manager;
 
-  explicit unipath_manager(central_dispatcher* dispatcher);
+  struct observer {
+    virtual ~observer();
+    virtual void closing(unipath_manager*, bool, const caf::error&) = 0;
+    virtual void downstream_connected(unipath_manager*, const caf::actor&) = 0;
+  };
+
+  explicit unipath_manager(central_dispatcher*, observer*);
 
   ~unipath_manager() override;
 
@@ -37,6 +45,10 @@ public:
   /// Sets the filter that this manager applies to enqueued items.
   virtual void filter(filter_type) = 0;
 
+  /// Checks whether the filter of this manager accepts messages for the given
+  /// topic.
+  [[nodiscard]] virtual bool accepts(const topic&) const noexcept = 0;
+
   /// Causes the manager to cache incoming batches until `unblock_inputs()` gets
   /// called.
   virtual void block_inputs();
@@ -48,8 +60,52 @@ public:
   /// Returns whether this manager currently blocks incoming batches.
   virtual bool blocks_inputs();
 
+  /// Returns the type ID of the message type accepted by this manager.
+  virtual caf::type_id_t message_type() const noexcept = 0;
+
+  /// Returns whether this manager has exactly one inbound path.
+  bool has_inbound_path() const noexcept;
+
+  /// Returns whether this manager has exactly one outbound path.
+  bool has_outbound_path() const noexcept;
+
+  /// Returns the slot for the inbound path or `caf::invalid_stream_slot` if
+  /// none exists.
+  caf::stream_slot inbound_path_slot() const noexcept;
+
+  /// Returns the slot for the outbound path or `caf::invalid_stream_slot` if
+  /// none exists.
+  caf::stream_slot outbound_path_slot() const noexcept;
+
+  /// Returns the connected actor.
+  caf::actor hdl() const noexcept;
+
+  /// Returns whether this manager has exactly one inbound and exactly one
+  /// outbound path.
+  bool fully_connected() const noexcept {
+    return has_inbound_path() && has_outbound_path();
+  }
+
+  /// Removes the observer, thereby discarding all future events.
+  void unobserve() {
+    observer_ = nullptr;
+  }
+
+  // -- overrides --------------------------------------------------------------
+
+  void handle(caf::inbound_path*, caf::downstream_msg::close&) override;
+
+  void handle(caf::inbound_path*, caf::downstream_msg::forced_close&) override;
+
+  void handle(caf::stream_slots, caf::upstream_msg::drop&) override;
+
+  void handle(caf::stream_slots, caf::upstream_msg::forced_drop&) override;
+
 protected:
+  void closing(bool graceful, const caf::error& reason);
+
   central_dispatcher* dispatcher_;
+  observer* observer_ = nullptr;
 };
 
 using unipath_manager_ptr = caf::intrusive_ptr<unipath_manager>;
@@ -58,6 +114,15 @@ unipath_manager_ptr make_data_source(central_dispatcher* dispatcher);
 
 unipath_manager_ptr make_command_source(central_dispatcher* dispatcher);
 
+unipath_manager_ptr make_source(central_dispatcher* dispatcher,
+                                caf::stream<data_message> in);
+
+unipath_manager_ptr make_source(central_dispatcher* dispatcher,
+                                caf::stream<command_message> in);
+
+unipath_manager_ptr make_source(central_dispatcher* dispatcher,
+                                caf::stream<node_message_content> in);
+
 unipath_manager_ptr make_data_sink(central_dispatcher* dispatcher,
                                    filter_type filter);
 
@@ -65,7 +130,22 @@ unipath_manager_ptr make_command_sink(central_dispatcher* dispatcher,
                                       filter_type filter);
 
 /// Peer managers always have one inbound and one outbound path.
-/// @note the returned manager returns `true` for `blocks_inputs()`.
-unipath_manager_ptr make_peer_manager(central_dispatcher* dispatcher);
+/// @note the returned manager returns `true` for `blocks_inputs()` and Broker
+///       does *not* automatically add the manager to `dispatcher`.
+unipath_manager_ptr make_peer_manager(central_dispatcher* dispatcher,
+                                      unipath_manager::observer* observer);
 
 } // namespace broker::detail
+
+namespace std {
+
+template <>
+struct hash<broker::detail::unipath_manager_ptr> {
+  using argument_type = broker::detail::unipath_manager_ptr;
+  size_t operator()(const argument_type& x) const noexcept {
+    hash<broker::detail::unipath_manager*> f;
+    return f(x.get());
+  }
+};
+
+} // namespace std

--- a/include/broker/fwd.hh
+++ b/include/broker/fwd.hh
@@ -110,7 +110,15 @@ namespace broker::detail {
 struct retry_state;
 
 class flare_actor;
+class item;
+class item_allocator;
+class item_stash;
 class mailbox;
+
+void intrusive_ptr_release(item*) noexcept;
+void intrusive_ptr_add_ref(item*) noexcept;
+
+using item_ptr = caf::intrusive_ptr<item>;
 
 } // namespace broker::detail
 
@@ -120,7 +128,7 @@ class mailbox;
   using name = caf::name##_atom;                                               \
   constexpr auto name##_v = caf::name##_atom_v;
 
-namespace broker::atom{
+namespace broker::atom {
 
 BROKER_CAF_ATOM_ALIAS(add)
 BROKER_CAF_ATOM_ALIAS(connect)

--- a/include/broker/fwd.hh
+++ b/include/broker/fwd.hh
@@ -109,11 +109,13 @@ namespace broker::detail {
 
 struct retry_state;
 
+class central_dispatcher;
 class flare_actor;
 class item;
 class item_allocator;
 class item_stash;
 class mailbox;
+class unipath_manager;
 
 void intrusive_ptr_release(item*) noexcept;
 void intrusive_ptr_add_ref(item*) noexcept;

--- a/include/broker/message.hh
+++ b/include/broker/message.hh
@@ -140,16 +140,29 @@ inline topic&& move_topic(node_message& x) {
   return move_topic(x.content);
 }
 
-
-/// Retrieves the data from a ::data_message.
+/// Retrieves the data from a @ref data_message.
 inline const data& get_data(const data_message& x) {
   return get<1>(x);
 }
 
-/// Moves the data out of a ::data_message. Causes `x` to make a lazy copy of
-/// its content if other ::data_message objects hold references to it.
+/// Moves the data out of a @ref data_message. Causes `x` to make a lazy copy of
+/// its content if other @ref data_message objects hold references to it.
 inline data&& move_data(data_message& x) {
   return std::move(get<1>(x.unshared()));
+}
+
+/// Unboxes the content of `x` and calls `get_data` on the nested
+/// @ref data_message.
+/// @pre `is_data_message(x)`
+inline const data& get_data(const node_message& x) {
+  return get_data(get<data_message>(x.content));
+}
+
+/// Unboxes the content of `x` and calls `move_data` on the nested
+/// @ref data_message.
+/// @pre `is_data_message(x)`
+inline data&& move_data(node_message& x) {
+  return move_data(get<data_message>(x.content));
 }
 
 /// Retrieves the command content from a ::command_message.

--- a/include/broker/mixin/data_store_manager.hh
+++ b/include/broker/mixin/data_store_manager.hh
@@ -177,7 +177,7 @@ public:
       });
   }
 
-private:
+protected:
   // -- CRTP scaffold ----------------------------------------------------------
 
   Subtype& dref() {

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -111,6 +111,7 @@ configuration::configuration(skip_init_t) {
 configuration::configuration(broker_options opts) : configuration(skip_init) {
   options_ = opts;
   set("broker.ttl", opts.ttl);
+  put(content, "broker.forward", opts.forward);
   init(0, nullptr);
 }
 

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -110,6 +110,7 @@ configuration::configuration(skip_init_t) {
 
 configuration::configuration(broker_options opts) : configuration(skip_init) {
   options_ = opts;
+  set("broker.ttl", opts.ttl);
   init(0, nullptr);
 }
 

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -88,7 +88,9 @@ configuration::configuration(skip_init_t) {
     .add<std::string>("recording-directory",
                       "path for storing recorded meta information")
     .add<size_t>("output-generator-file-cap",
-                 "maximum number of entries when recording published messages");
+                 "maximum number of entries when recording published messages")
+    .add<size_t>("max-pending-inputs-per-source",
+                 "maximum number of items we buffer per peer or publisher");
   // Ensure that we're only talking to compatible Broker instances.
   std::vector<std::string> ids{"broker.v" + std::to_string(version::protocol)};
   // Override CAF defaults.

--- a/src/detail/central_dispatcher.cc
+++ b/src/detail/central_dispatcher.cc
@@ -1,0 +1,38 @@
+#include "broker/detail/central_dispatcher.hh"
+
+#include "broker/detail/item_stash.hh"
+#include "broker/logger.hh"
+
+namespace broker::detail {
+
+central_dispatcher::central_dispatcher(caf::scheduled_actor* self)
+  : alloc_(item_allocator::make()), self_(self) {
+  // nop
+}
+
+void central_dispatcher::enqueue(caf::span<const item_ptr> ptrs) {
+  BROKER_DEBUG("central enqueue" << BROKER_ARG2("ptrs.size", ptrs.size())
+                                 << BROKER_ARG2("nested.size", nested_.size()));
+  auto i = nested_.begin();
+  while (i != nested_.end()) {
+    if ((*i)->enqueue(ptrs) >= 0)
+      ++i;
+    else
+      i = nested_.erase(i);
+  }
+}
+
+void central_dispatcher::ship() {
+  for (auto& ptr : nested_)
+    ptr->push();
+}
+
+void central_dispatcher::add(unipath_manager_ptr out) {
+  nested_.emplace_back(std::move(out));
+}
+
+item_stash_ptr central_dispatcher::new_item_stash(size_t size) {
+  return item_stash::make(alloc_, size);
+}
+
+} // namespace broker::detail

--- a/src/detail/central_dispatcher.cc
+++ b/src/detail/central_dispatcher.cc
@@ -22,6 +22,10 @@ void central_dispatcher::enqueue(caf::span<const item_ptr> ptrs) {
   }
 }
 
+void central_dispatcher::enqueue(const item_ptr& ptr) {
+  enqueue(caf::make_span(&ptr, 1));
+}
+
 void central_dispatcher::ship() {
   for (auto& ptr : nested_)
     ptr->push();

--- a/src/detail/item.cc
+++ b/src/detail/item.cc
@@ -1,0 +1,29 @@
+#include "broker/detail/item.hh"
+
+namespace broker::detail {
+
+item::item(data_message&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
+           item_stash* owner)
+  : msg_(std::move(msg)), msg_ttl_(msg_ttl), origin_(origin), owner_(owner) {
+  // nop
+}
+
+item::item(command_message&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
+           item_stash* owner)
+  : msg_(std::move(msg)), msg_ttl_(msg_ttl), origin_(origin), owner_(owner) {
+  // nop
+}
+
+void intrusive_ptr_release(item* ptr) noexcept {
+  if (--ptr->ref_count_ == 0) {
+    auto owner = std::move(ptr->owner_);
+    ptr->~item();
+    owner->reclaim(ptr);
+  }
+}
+
+void intrusive_ptr_add_ref(item* ptr) noexcept {
+  ++ptr->ref_count_;
+}
+
+} // namespace broker::detail

--- a/src/detail/item.cc
+++ b/src/detail/item.cc
@@ -2,18 +2,6 @@
 
 namespace broker::detail {
 
-item::item(data_message&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
-           item_stash* owner)
-  : msg_(std::move(msg)), msg_ttl_(msg_ttl), origin_(origin), owner_(owner) {
-  // nop
-}
-
-item::item(command_message&& msg, uint16_t msg_ttl, caf::stream_manager* origin,
-           item_stash* owner)
-  : msg_(std::move(msg)), msg_ttl_(msg_ttl), origin_(origin), owner_(owner) {
-  // nop
-}
-
 void intrusive_ptr_release(item* ptr) noexcept {
   if (--ptr->ref_count_ == 0) {
     auto owner = std::move(ptr->owner_);

--- a/src/detail/item_allocator.cc
+++ b/src/detail/item_allocator.cc
@@ -1,0 +1,105 @@
+#include "broker/detail/item_allocator.hh"
+
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <new>
+
+#include "broker/detail/assert.hh"
+#include "broker/detail/item.hh"
+
+namespace broker::detail {
+
+namespace {
+
+constexpr size_t padded_item_size
+  = ((sizeof(item) / alignof(item))
+     + static_cast<size_t>(sizeof(item) % alignof(item) != 0))
+    * alignof(item);
+
+static_assert(padded_item_size >= sizeof(item));
+
+constexpr size_t items_per_memory_chunk
+  = item_allocator::memory_chunk_size / padded_item_size;
+
+static_assert(items_per_memory_chunk > 1);
+
+item* item_at_offset(void* chunk, size_t offset) {
+  auto ptr = static_cast<void*>(static_cast<char*>(chunk) + offset);
+  return static_cast<item*>(ptr);
+}
+
+} // namespace
+
+item_allocator::~item_allocator() noexcept {
+  BROKER_ASSERT(free_list_.size() == allocated_items());
+  for (auto chunk : memory_chunks_)
+    free(chunk);
+}
+
+caf::intrusive_ptr<item_allocator> item_allocator::make() {
+  return {new item_allocator, false};
+}
+
+item* item_allocator::allocate() {
+  if (!free_list_.empty()) {
+    auto result = free_list_.back();
+    free_list_.pop_back();
+    return result;
+  } else {
+    return force_allocate();
+  }
+}
+
+void item_allocator::allocate(caf::span<item*> ptrs) {
+  BROKER_ASSERT(!ptrs.empty());
+  while (free_list_.size() < ptrs.size()) {
+    auto tail = force_allocate();
+    free_list_.push_back(tail);
+  }
+  auto last = free_list_.end();
+  auto first = last - ptrs.size();
+  std::copy(first, last, ptrs.begin());
+  free_list_.erase(first, last);
+}
+
+void item_allocator::deallocate(item* ptr) noexcept {
+  BROKER_ASSERT(free_list_.capacity() > free_list_.size());
+  free_list_.push_back(ptr);
+}
+
+void item_allocator::deallocate(caf::span<item*> ptrs) noexcept {
+  BROKER_ASSERT(!ptrs.empty());
+  BROKER_ASSERT(free_list_.capacity() >= free_list_.size() + ptrs.size());
+  free_list_.insert(free_list_.end(), ptrs.begin(), ptrs.end());
+}
+
+size_t item_allocator::allocated_bytes() const noexcept {
+  return memory_chunks_.size() * memory_chunk_size;
+}
+
+size_t item_allocator::allocated_items() const noexcept {
+  return memory_chunks_.size() * items_per_memory_chunk;
+}
+
+item* item_allocator::force_allocate() {
+  // Call potentially throwing functions upfront.
+  free_list_.reserve((memory_chunks_.size() + 1) * items_per_memory_chunk);
+  memory_chunks_.push_back(nullptr);
+  if (auto chunk = malloc(memory_chunk_size)) {
+    // Fill free_list_ in reverse order. We dequeue from the back, so clients
+    // will actually use memory in the 'correct' order again.
+    memory_chunks_.back() = chunk;
+    auto offset = items_per_memory_chunk * padded_item_size; // Past the end!
+    do {
+      offset -= padded_item_size;
+      free_list_.push_back(item_at_offset(chunk, offset));
+    } while (offset > padded_item_size);
+    return item_at_offset(chunk, 0);
+  } else {
+    memory_chunks_.pop_back();
+    throw std::bad_alloc();
+  }
+}
+
+} // namespace broker::detail

--- a/src/detail/item_scope.cc
+++ b/src/detail/item_scope.cc
@@ -1,0 +1,19 @@
+#include "broker/detail/item_scope.hh"
+
+namespace broker::detail {
+
+namespace {
+
+constexpr const char* item_scope_strings[] = {
+  "global",
+  "local",
+  "remote",
+};
+
+} // namespace
+
+std::string to_string(item_scope x) {
+  return item_scope_strings[static_cast<uint8_t>(x)];
+}
+
+} // namespace broker::detail

--- a/src/detail/item_stash.cc
+++ b/src/detail/item_stash.cc
@@ -31,6 +31,12 @@ item_ptr item_stash::next_item(command_message&& msg, uint16_t msg_ttl,
   return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this), false};
 }
 
+item_ptr item_stash::next_item(variant_type&& msg, uint16_t msg_ttl,
+                               caf::stream_manager* origin) {
+  auto ptr = next();
+  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this), false};
+}
+
 item* item_stash::next() {
   if (!stash_.empty()) {
     auto result = stash_.back();

--- a/src/detail/item_stash.cc
+++ b/src/detail/item_stash.cc
@@ -1,0 +1,58 @@
+#include "broker/detail/item_stash.hh"
+
+#include <new>
+
+#include "broker/detail/assert.hh"
+#include "broker/detail/item.hh"
+
+namespace broker::detail {
+
+caf::intrusive_ptr<item_stash> item_stash::make(item_allocator_ptr allocator,
+                                                size_t size) {
+  using std::swap;
+  std::vector<item*> items;
+  items.resize(size);
+  allocator->allocate(items);
+  item_stash_ptr result{new item_stash, false};
+  swap(result->stash_, items);
+  swap(result->allocator_, allocator);
+  return result;
+}
+
+item_ptr item_stash::next_item(data_message&& msg, uint16_t msg_ttl,
+                               caf::stream_manager* origin) {
+  auto ptr = next();
+  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this), false};
+}
+
+item_ptr item_stash::next_item(command_message&& msg, uint16_t msg_ttl,
+                               caf::stream_manager* origin) {
+  auto ptr = next();
+  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this), false};
+}
+
+item* item_stash::next() {
+  if (!stash_.empty()) {
+    auto result = stash_.back();
+    stash_.pop_back();
+    return result;
+  } else {
+    throw std::out_of_range("item_stash::next called with available() == 0");
+  }
+}
+
+void item_stash::reclaim(item* ptr) noexcept {
+  BROKER_ASSERT(stash_.capacity() > stash_.size());
+  stash_.push_back(ptr);
+}
+
+void intrusive_ptr_release(item_stash* ptr) noexcept {
+  if (--ptr->ref_count_ == 0) {
+    auto items = std::move(ptr->stash_);
+    auto alloc = std::move(ptr->allocator_);
+    delete ptr;
+    alloc->deallocate(items);
+  }
+}
+
+} // namespace broker::detail

--- a/src/detail/item_stash.cc
+++ b/src/detail/item_stash.cc
@@ -10,31 +10,53 @@ namespace broker::detail {
 caf::intrusive_ptr<item_stash> item_stash::make(item_allocator_ptr allocator,
                                                 size_t size) {
   using std::swap;
-  std::vector<item*> items;
-  items.resize(size);
-  allocator->allocate(items);
-  item_stash_ptr result{new item_stash, false};
-  swap(result->stash_, items);
-  swap(result->allocator_, allocator);
-  return result;
+  if (size > 0) {
+    std::vector<item*> items;
+    items.resize(size);
+    allocator->allocate(items);
+    item_stash_ptr result{new item_stash, false};
+    swap(result->stash_, items);
+    swap(result->allocator_, allocator);
+    result->max_stash_size_ = size;
+    return result;
+  } else {
+    item_stash_ptr result{new item_stash, false};
+    swap(result->allocator_, allocator);
+    return result;
+  }
+}
+
+void item_stash::replenish(size_t n) {
+  stash_.reserve(max_stash_size_ + n);
+  auto i = stash_.insert(stash_.end(), n, nullptr);
+  try {
+    allocator_->allocate(caf::make_span(std::addressof(*i), n));
+    max_stash_size_ += n;
+  } catch (...) {
+    stash_.erase(i, stash_.end());
+    throw;
+  }
 }
 
 item_ptr item_stash::next_item(data_message&& msg, uint16_t msg_ttl,
-                               caf::stream_manager* origin) {
+                               caf::stream_manager* origin, item_scope scope) {
   auto ptr = next();
-  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this), false};
+  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this, scope),
+                  false};
 }
 
 item_ptr item_stash::next_item(command_message&& msg, uint16_t msg_ttl,
-                               caf::stream_manager* origin) {
+                               caf::stream_manager* origin, item_scope scope) {
   auto ptr = next();
-  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this), false};
+  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this, scope),
+                  false};
 }
 
-item_ptr item_stash::next_item(variant_type&& msg, uint16_t msg_ttl,
-                               caf::stream_manager* origin) {
+item_ptr item_stash::next_item(node_message_content&& msg, uint16_t msg_ttl,
+                               caf::stream_manager* origin, item_scope scope) {
   auto ptr = next();
-  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this), false};
+  return item_ptr{new (ptr) item(std::move(msg), msg_ttl, origin, this, scope),
+                  false};
 }
 
 item* item_stash::next() {
@@ -57,7 +79,8 @@ void intrusive_ptr_release(item_stash* ptr) noexcept {
     auto items = std::move(ptr->stash_);
     auto alloc = std::move(ptr->allocator_);
     delete ptr;
-    alloc->deallocate(items);
+    if (!items.empty())
+      alloc->deallocate(items);
   }
 }
 

--- a/src/detail/unipath_manager.cc
+++ b/src/detail/unipath_manager.cc
@@ -64,7 +64,7 @@ public:
           if constexpr (std::is_same<T, node_message>::value) {
             // Somewhat hacky, but don't forward data store clone messages.
             if (ptr->scope() != item_scope::local
-                && ptr->ttl() > 1
+                && ptr->ttl() > 0
                 && accept(filter_, msg)) {
               cache_.emplace_back(make_node_message(msg, ptr->ttl() - 1));
               items_.emplace_back(ptr);

--- a/src/detail/unipath_manager.cc
+++ b/src/detail/unipath_manager.cc
@@ -1,0 +1,400 @@
+#include "broker/detail/unipath_manager.hh"
+
+#include <type_traits>
+
+#include <caf/actor_system_config.hpp>
+#include <caf/downstream_manager.hpp>
+#include <caf/outbound_path.hpp>
+#include <caf/scheduled_actor.hpp>
+#include <caf/settings.hpp>
+#include <caf/typed_message_view.hpp>
+
+#include "broker/defaults.hh"
+#include "broker/detail/assert.hh"
+#include "broker/detail/central_dispatcher.hh"
+#include "broker/detail/item.hh"
+#include "broker/detail/prefix_matcher.hh"
+#include "broker/logger.hh"
+#include "broker/message.hh"
+
+namespace broker::detail {
+
+namespace {
+
+// A downstream manager with at most one outbound path.
+template <class T>
+class unipath_downstream : public caf::downstream_manager {
+public:
+  using super = downstream_manager;
+
+  using output_type = T;
+
+  using buffer_type = std::deque<output_type>;
+
+  using unique_path_ptr = std::unique_ptr<caf::outbound_path>;
+
+  using super::super;
+
+  ptrdiff_t enqueue(caf::span<const item_ptr> ptrs) {
+    BROKER_DEBUG(BROKER_ARG2("ptrs.size", ptrs.size())
+                 << BROKER_ARG2("has_path", has_path()));
+    if (path_) {
+      prefix_matcher accept;
+      ptrdiff_t accepted = 0;
+      for (auto&& ptr : ptrs) {
+        const auto& msg = ptr->msg();
+        if (ptr->origin() != super::parent()) {
+          if constexpr (std::is_same<T, node_message>::value) {
+            if (ptr->ttl() > 1 && accept(filter_, msg)) {
+              cache_.emplace_back(make_node_message(msg, ptr->ttl() - 1));
+              items_.emplace_back(ptr);
+              ++accepted;
+            }
+          } else if (caf::holds_alternative<T>(msg)) {
+            const auto& unboxed = caf::get<T>(msg);
+            if (accept(filter_, unboxed)) {
+              cache_.emplace_back(unboxed);
+              items_.emplace_back(ptr);
+              ++accepted;
+            }
+          }
+        }
+      }
+      return accepted;
+    } else {
+      return -1;
+    }
+  }
+
+  bool has_path() const noexcept {
+    return path_ != nullptr;
+  }
+
+  const caf::outbound_path* get_path() const noexcept {
+    return path_.get();
+  }
+
+  size_t num_paths() const noexcept override {
+    return path_ ? 1 : 0;
+  }
+
+  bool remove_path(caf::stream_slot x, caf::error reason,
+                   bool silent) noexcept override {
+    if (is_this_slot(x)) {
+      super::about_to_erase(path_.get(), silent, &reason);
+      path_.reset();
+      cache_.clear();
+      items_.clear();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  super::path_ptr path(caf::stream_slot x) noexcept override {
+    return is_this_slot(x) ? path_.get() : nullptr;
+  }
+
+  void emit_batches_impl(bool forced) {
+    if (!cache_.empty()) {
+      BROKER_DEBUG(BROKER_ARG2("cache.size", cache_.size()));
+      BROKER_ASSERT(path_ != nullptr);
+      auto old_size = cache_.size();
+      path_->emit_batches(super::self(), cache_, forced || path_->closing);
+      if (auto delta = old_size - cache_.size(); delta > 0)
+        items_.erase(items_.begin(), items_.begin() + delta);
+    }
+  }
+
+  void emit_batches() override {
+    emit_batches_impl(false);
+  }
+
+  void force_emit_batches() override {
+    emit_batches_impl(true);
+  }
+
+  void clear_paths() override {
+    path_.reset();
+  }
+
+  bool terminal() const noexcept override {
+    return false;
+  }
+
+  size_t capacity() const noexcept override {
+    // Our goal is to cache up to 2 full batches.
+    if (path_) {
+      auto want = static_cast<size_t>(path_->desired_batch_size) * 2;
+      auto got = cache_.size();
+      return want > got ? want - got : size_t{0};
+    } else {
+      return 0;
+    }
+  }
+
+  size_t buffered() const noexcept override {
+    return cache_.size();
+  }
+
+  size_t buffered(caf::stream_slot x) const noexcept override {
+    return is_this_slot(x) ? cache_.size() : 0;
+  }
+
+  bool insert_path(unique_path_ptr ptr) override {
+    using std::swap;
+    if (!path_) {
+      swap(path_, ptr);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  void for_each_path_impl(super::path_visitor& f) override {
+    if (path_)
+      f(*path_);
+  }
+
+  bool check_paths_impl(super::path_algorithm algo,
+                        super::path_predicate& pred) const noexcept override {
+    if (path_) {
+      switch (algo) {
+        default:
+          // all_of or any_of
+          return pred(*path_);
+        case super::path_algorithm::none_of:
+          return !pred(*path_);
+      }
+    } else {
+      return super::check_paths_impl(algo, pred);
+    }
+  }
+
+  bool is_this_slot(caf::stream_slot x) const noexcept {
+    return path_ && path_->slots.sender == x;
+  }
+
+  unique_path_ptr path_;
+  filter_type filter_;
+  std::vector<T> cache_;
+  std::vector<item_ptr> items_;
+};
+
+template <class T>
+class unipath_manager_out : public unipath_manager {
+public:
+  using super = unipath_manager;
+
+  explicit unipath_manager_out(central_dispatcher* dispatcher)
+    : super(dispatcher), out_(this) {
+    // nop
+  }
+
+  template <class Filter>
+  unipath_manager_out(central_dispatcher* dispatcher, Filter&& filter)
+    : super(dispatcher), out_(this) {
+    out_.filter_ = std::forward<Filter>(filter);
+  }
+
+  ptrdiff_t enqueue(caf::span<const item_ptr> ptrs) override {
+    return out_.enqueue(ptrs);
+  }
+
+  filter_type filter() override {
+    return out_.filter_;
+  }
+
+  void filter(filter_type new_filter) override {
+    out_.filter_ = std::move(new_filter);
+  }
+
+  caf::downstream_manager& out() override {
+    return out_;
+  }
+
+  bool done() const override {
+    return !out_.has_path();
+  }
+
+  bool idle() const noexcept override {
+    // A source is idle if it can't make any progress on its downstream or if
+    // it's not producing new data despite having credit.
+    if (auto ptr = out_.get_path()) {
+      return out_.stalled() || (out_.buffered() == 0 && ptr->open_credit > 0);
+    } else {
+      return true;
+    }
+  }
+
+protected:
+  unipath_downstream<T> out_;
+};
+
+class unipath_manager_in_only : public unipath_manager {
+public:
+  using super = unipath_manager;
+
+  unipath_manager_in_only(central_dispatcher* dispatcher)
+    : super(dispatcher), out_(this) {
+    // nop
+  }
+
+  ptrdiff_t enqueue(caf::span<const item_ptr>) override {
+    return -1;
+  }
+
+  filter_type filter() override {
+    return {};
+  }
+
+  void filter(filter_type) override {
+    // nop
+  }
+
+  caf::downstream_manager& out() override {
+    return out_;
+  }
+
+  bool done() const override {
+    return !continuous() && inbound_paths_.empty();
+  }
+
+  bool idle() const noexcept override {
+    return inbound_paths_idle();
+  }
+
+protected:
+  caf::downstream_manager out_;
+};
+
+template <class T, class Base = unipath_manager_in_only>
+class unipath_manager_in : public Base {
+public:
+  using super = Base;
+
+  template <class... Ts>
+  explicit unipath_manager_in(central_dispatcher* dispatcher, Ts&&... xs)
+    : super(dispatcher, std::forward<Ts>(xs)...) {
+    auto sptr = super::self();
+    auto& cfg = sptr->system().config();
+    auto stash_size = caf::get_or(cfg, "broker.max-pending-inputs-per-source",
+                                  defaults::max_pending_inputs_per_source);
+    stash_ = dispatcher->new_item_stash(stash_size);
+    if (caf::get_or(cfg, "broker.forward", true)) {
+      ttl_ = caf::get_or(cfg, "broker.ttl", defaults::ttl);
+    } else {
+      // Limit TTL to 1 when forwarding was disabled. This causes all peer
+      // managers to drop node messages instead of forwarding them.
+      ttl_ = 1;
+    }
+  }
+
+  bool done() const override {
+    if constexpr (std::is_same<Base, unipath_manager_in_only>::value)
+      return super::done();
+    else
+      return !this->continuous() && this->inbound_paths_.empty()
+             && this->pending_handshakes_ == 0 && this->out_.clean();
+  }
+
+  bool idle() const noexcept override {
+    if constexpr (std::is_same<Base, unipath_manager_in_only>::value) {
+      return super::idle();
+    } else {
+      auto& dm = this->out_;
+      return dm.stalled() || (dm.clean() && this->inbound_paths_idle());
+    }
+  }
+
+  using super::handle;
+
+  void handle(caf::inbound_path*, caf::downstream_msg::batch& x) override {
+    BROKER_DEBUG(BROKER_ARG2("batch.size", x.xs_size));
+    if (auto view = caf::make_typed_message_view<std::vector<T>>(x.xs)) {
+      auto& vec = get<0>(view);
+      if (vec.size() <= stash_->available()) {
+        items_.reserve(vec.size());
+        for (auto& x : vec) {
+          item_ptr ptr;
+          if constexpr (std::is_same<T, node_message>::value) {
+            auto ttl = std::min(ttl_, x.ttl);
+            ptr = stash_->next_item(std::move(x.content), ttl, this);
+          } else {
+            ptr = stash_->next_item(std::move(x), ttl_, this);
+          }
+          items_.emplace_back(std::move(ptr));
+        }
+        super::dispatcher_->enqueue(items_);
+        super::dispatcher_->ship();
+        items_.clear();
+      } else {
+        BROKER_ERROR("received more data then we have allowed!");
+      }
+    } else {
+      BROKER_ERROR("received unexpected batch type (dropped)");
+    }
+  }
+
+  int32_t acquire_credit(caf::inbound_path* in, int32_t desired) override {
+    auto available = static_cast<int32_t>(stash_->available());
+    BROKER_ASSERT(in->assigned_credit <= available);
+    auto total = in->assigned_credit + desired;
+    if (total <= available)
+      return desired;
+    else
+      return available - in->assigned_credit;
+  }
+
+private:
+  item_stash_ptr stash_;
+  std::vector<item_ptr> items_;
+  uint16_t ttl_;
+};
+
+} // namespace
+
+unipath_manager::unipath_manager(central_dispatcher* dispatcher)
+  : super(dispatcher->self()), dispatcher_(dispatcher) {
+  // nop
+}
+
+unipath_manager::~unipath_manager() {
+  // nop
+}
+
+unipath_manager_ptr make_data_source(central_dispatcher* dispatcher) {
+  using impl_t = unipath_manager_in<data_message>;
+  return caf::make_counted<impl_t>(dispatcher);
+}
+
+unipath_manager_ptr make_command_source(central_dispatcher* dispatcher) {
+  using impl_t = unipath_manager_in<command_message>;
+  return caf::make_counted<impl_t>(dispatcher);
+}
+
+unipath_manager_ptr make_data_sink(central_dispatcher* dispatcher,
+                                   filter_type filter) {
+  using impl_t = unipath_manager_out<data_message>;
+  auto result = caf::make_counted<impl_t>(dispatcher, std::move(filter));
+  dispatcher->add(result);
+  return result;
+}
+
+unipath_manager_ptr make_command_sink(central_dispatcher* dispatcher,
+                                      filter_type filter) {
+  using impl_t = unipath_manager_out<command_message>;
+  auto result = caf::make_counted<impl_t>(dispatcher, std::move(filter));
+  dispatcher->add(result);
+  return result;
+}
+
+unipath_manager_ptr make_peer_manager(central_dispatcher* dispatcher) {
+  using base_t = unipath_manager_out<node_message>;
+  using impl_t = unipath_manager_in<node_message, base_t>;
+  auto result = caf::make_counted<impl_t>(dispatcher);
+  dispatcher->add(result);
+  return result;
+}
+
+} // namespace broker::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
   cpp/data.cc
   cpp/detail/data_generator.cc
   cpp/detail/generator_file_writer.cc
+  cpp/detail/item.cc
   cpp/detail/meta_command_writer.cc
   cpp/detail/meta_data_writer.cc
   cpp/error.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
   cpp/backend.cc
   cpp/core.cc
   cpp/data.cc
+  cpp/detail/central_dispatcher.cc
   cpp/detail/data_generator.cc
   cpp/detail/generator_file_writer.cc
   cpp/detail/item.cc

--- a/tests/cpp/core.cc
+++ b/tests/cpp/core.cc
@@ -23,7 +23,7 @@ struct driver_state {
   using buf_type = std::vector<element_type>;
   bool restartable = false;
   buf_type xs;
-  static const char* name;
+  static inline const char* name = "driver";
   void reset() {
     xs = data_msgs({{"a", 0}, {"b", true}, {"a", 1}, {"a", 2}, {"b", false},
                     {"b", true}, {"a", 3}, {"b", false}, {"a", 4}, {"a", 5}});
@@ -32,8 +32,6 @@ struct driver_state {
     reset();
   }
 };
-
-const char* driver_state::name = "driver";
 
 caf::behavior driver(caf::stateful_actor<driver_state>* self,
                      const caf::actor& sink, bool restartable) {
@@ -133,8 +131,8 @@ CAF_TEST(local_peers) {
   // Spawn core actors and disable events.
   broker_options options;
   options.disable_ssl = true;
-  auto core1 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
-  auto core2 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
+  auto core1 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"}, options);
+  auto core2 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"}, options);
   anon_send(core1, atom::no_events_v);
   anon_send(core2, atom::no_events_v);
   run();
@@ -247,9 +245,9 @@ CAF_TEST(triangle_peering) {
   // Spawn core actors and disable events.
   broker_options options;
   options.disable_ssl = true;
-  auto core1 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
-  auto core2 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
-  auto core3 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
+  auto core1 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"}, options);
+  auto core2 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"}, options);
+  auto core3 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"}, options);
   anon_send(core1, atom::no_events_v);
   anon_send(core2, atom::no_events_v);
   anon_send(core3, atom::no_events_v);
@@ -367,9 +365,9 @@ CAF_TEST(sequenced_peering) {
   // Spawn core actors and disable events.
   broker_options options;
   options.disable_ssl = true;
-  auto core1 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
-  auto core2 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
-  auto core3 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
+  auto core1 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"}, options);
+  auto core2 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"}, options);
+  auto core3 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"}, options);
   CAF_MESSAGE(BROKER_ARG(core1));
   CAF_MESSAGE(BROKER_ARG(core2));
   CAF_MESSAGE(BROKER_ARG(core3));
@@ -473,8 +471,8 @@ struct error_signaling_fixture : base_fixture {
     core1 = ep.core();
     CAF_MESSAGE(BROKER_ARG(core1));
     anon_send(core1, atom::subscribe_v, filter_type{"a", "b", "c"});
-    core2 = sys.spawn(core_actor, filter_type{"a", "b", "c"},
-                      ep.config().options(), nullptr);
+    core2 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"},
+                                       ep.config().options());
     CAF_MESSAGE(BROKER_ARG(core2));
     run();
     CAF_MESSAGE("init done");
@@ -557,7 +555,7 @@ CAF_TEST(failed_handshake_stage2) {
   CAF_MESSAGE("run remaining messages");
   run();
   CAF_MESSAGE("check log of the event subscriber");
-  BROKER_CHECK_LOG(es.poll(), sc::peer_added, sc::peer_lost);
+  BROKER_CHECK_LOG(es.poll(), ec::peer_unavailable);
 }
 
 // Simulates a connection abort after receiving stage #1 handshake.

--- a/tests/cpp/detail/central_dispatcher.cc
+++ b/tests/cpp/detail/central_dispatcher.cc
@@ -28,6 +28,7 @@ caf::behavior testee_impl(testee_actor* self){
       auto& st = self->state;
       if (st.in == nullptr) {
         st.in = make_data_source(&st.dispatcher);
+        CHECK(!st.in->blocks_inputs());
         st.in->add_unchecked_inbound_path(handshake);
         return caf::unit;
       } else {

--- a/tests/cpp/detail/central_dispatcher.cc
+++ b/tests/cpp/detail/central_dispatcher.cc
@@ -1,0 +1,129 @@
+#define SUITE detail.central_dispatcher
+
+#include "broker/detail/central_dispatcher.hh"
+
+#include "test.hh"
+
+using namespace broker;
+
+namespace {
+
+struct testee_state {
+  detail::central_dispatcher dispatcher;
+  detail::unipath_manager_ptr in;
+  detail::unipath_manager_ptr out;
+  detail::unipath_manager_ptr inout;
+
+  testee_state(caf::scheduled_actor* self) : dispatcher(self) {
+    // nop
+  }
+};
+
+using testee_actor = caf::stateful_actor<testee_state>;
+
+caf::behavior testee_impl(testee_actor* self){
+  using namespace broker::detail;
+  return {
+    [self](caf::stream<data_message> handshake) -> caf::result<void> {
+      auto& st = self->state;
+      if (st.in == nullptr) {
+        st.in = make_data_source(&st.dispatcher);
+        st.in->add_unchecked_inbound_path(handshake);
+        return caf::unit;
+      } else {
+        return make_error(caf::sec::runtime_error, "only one input allowed");
+      }
+    },
+    [self](atom::publish, caf::actor publisher) -> caf::result<void> {
+      auto& st = self->state;
+      if (st.out == nullptr) {
+        st.out = make_data_sink(&st.dispatcher, {"test"});
+        st.out->add_unchecked_outbound_path<data_message>(publisher);
+        return caf::unit;
+      } else {
+        return make_error(caf::sec::runtime_error, "only one output allowed");
+      }
+    },
+  };
+}
+
+struct consumer_state {
+  std::vector<data> buf;
+};
+
+using consumer_actor = caf::stateful_actor<consumer_state>;
+
+caf::behavior consumer_impl(consumer_actor* self, caf::actor testee) {
+  self->send(testee, atom::publish_v, self);
+  return {
+    [self](caf::stream<data_message> in) {
+      caf::attach_stream_sink(
+        self, in,
+        // Initialization step.
+        [](caf::unit_t&) {},
+        // Processing step.
+        [self](caf::unit_t&, data_message x) {
+          auto& buf = self->state.buf;
+          buf.emplace_back(get_data(x));
+          if (buf.size() % 100 == 0)
+            MESSAGE("consumed " << buf.size() << " data message");
+        });
+    },
+  };
+}
+
+void producer_impl(consumer_actor* self, caf::actor testee) {
+  caf::attach_stream_source(
+    self, testee, [self](size_t& pos) { pos = 0; },
+    [self](size_t& pos, caf::downstream<data_message>& out, size_t hint) {
+      auto n = std::min(hint, 500 - pos);
+      MESSAGE("produce " << n << " more data message");
+      for (size_t i = 0; i < n; ++i)
+        out.push(make_data_message("test", data{static_cast<count>(pos++)}));
+    },
+    [](const size_t& pos) { return pos >= 500; });
+}
+
+struct config : caf::actor_system_config {
+public:
+  config() {
+    configuration::add_message_types(*this);
+    put(content, "broker.max-pending-inputs-per-source", 16);
+  }
+};
+
+struct fixture : test_coordinator_fixture<config> {
+  caf::actor aut;
+
+  fixture() {
+    aut = sys.spawn(testee_impl);
+  }
+
+  ~fixture() {
+    anon_send_exit(aut, caf::exit_reason::user_shutdown);
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(central_dispatcher_tests, fixture)
+
+TEST(producers and consumers are connected through the central dispatcher) {
+  MESSAGE("spin up consumer and producer");
+  auto consumer = sys.spawn(consumer_impl, aut);
+  run();
+  REQUIRE(deref<testee_actor>(aut).state.out != nullptr);
+  auto producer = sys.spawn(producer_impl, aut);
+  MESSAGE("run, but give the consumer a low priority to force credit shortage");
+  do {
+    while (sched.has_job()) {
+      sched.prioritize(producer) || sched.prioritize(aut);
+      sched.try_run_once();
+    }
+  } while (sched.trigger_timeout());
+  run();
+  CHECK_EQUAL(deref<consumer_actor>(consumer).state.buf.size(), 500);
+  anon_send_exit(consumer, caf::exit_reason::user_shutdown);
+}
+
+FIXTURE_SCOPE_END()

--- a/tests/cpp/detail/item.cc
+++ b/tests/cpp/detail/item.cc
@@ -6,6 +6,10 @@
 
 #include <exception>
 
+namespace broker::detail {
+
+} // namespace broker::detail
+
 using namespace broker;
 
 namespace {

--- a/tests/cpp/detail/item.cc
+++ b/tests/cpp/detail/item.cc
@@ -1,0 +1,65 @@
+#define SUITE detail.item
+
+#include "broker/detail/item.hh"
+
+#include "test.hh"
+
+#include <exception>
+
+using namespace broker;
+
+namespace {
+
+struct fixture {
+  detail::item_allocator_ptr alloc;
+
+  fixture() {
+    alloc = detail::item_allocator::make();
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(item_tests, fixture)
+
+TEST(items return to their stash when ref count reaches 0) {
+  MESSAGE("given a stash with up to 8 items");
+  auto stash = detail::item_stash::make(alloc, 8);
+  auto available_after_stash_construction = alloc->available_items();
+  CHECK_EQUAL(stash->available(), 8u);
+  MESSAGE("when taking five items out of the stash");
+  auto next_item = [&stash](auto&& t, auto&& d) {
+    return stash->next_item(make_data_message(t, d), 1, nullptr);
+  };
+  std::vector<detail::item_ptr> items;
+  for (int i = 0; i < 5; ++i)
+    items.emplace_back(next_item(topic{"foo/bar"}, data{i}));
+  CHECK_EQUAL(stash->available(), 3u);
+  MESSAGE("then all items return to the stash once their ref count drops to 0");
+  items.clear();
+  CHECK_EQUAL(stash->available(), 8u);
+  MESSAGE("and all items return to the allocator when destroying the stash");
+  stash = nullptr;
+  CHECK_EQUAL(alloc->available_items(), available_after_stash_construction + 8);
+}
+
+TEST(a stash throws when running out of available items) {
+  auto stash = detail::item_stash::make(alloc, 8);
+  auto next_item = [&stash](auto&& t, auto&& d) {
+    return stash->next_item(make_data_message(t, d), 1, nullptr);
+  };
+  std::vector<detail::item_ptr> items;
+  for (int i = 0; i < 8; ++i)
+    items.emplace_back(next_item(topic{"foo/bar"}, data{i}));
+  CHECK_EQUAL(stash->available(), 0u);
+  std::exception_ptr eptr;
+  try {
+    items.emplace_back(next_item(topic{"you/cannot/pass"}, data{666}));
+  } catch (...) {
+    eptr = std::current_exception();
+  }
+  CHECK(items.size(), 8u);
+  CHECK(eptr != nullptr);
+}
+
+FIXTURE_SCOPE_END()

--- a/tests/cpp/master.cc
+++ b/tests/cpp/master.cc
@@ -242,6 +242,8 @@ TEST(master_with_clone) {
   run_until_idle();
   MESSAGE("once clone and master are idle, they are in sync");
   earth.sched.inline_next_enqueue();
+  CHECK_EQUAL(value_of(ds_earth.get("test")), data{123});
+  earth.sched.inline_next_enqueue();
   CHECK_EQUAL(value_of(ds_earth.get("user")), data{"neverlord"});
   mars.sched.inline_next_enqueue();
   CHECK_EQUAL(value_of(ds_mars.get("test")), data{123});

--- a/tests/cpp/publisher.cc
+++ b/tests/cpp/publisher.cc
@@ -81,7 +81,7 @@ CAF_TEST(blocking_publishers) {
   broker_options options;
   options.disable_ssl = true;
   auto core1 = ep.core();
-  auto core2 = sys.spawn(core_actor, filter_type{"a"}, options, nullptr);
+  auto core2 = sys.spawn<core_actor_type>(filter_type{"a"}, options, nullptr);
   anon_send(core1, atom::subscribe_v, filter_type{"a"});
   anon_send(core1, atom::no_events_v);
   anon_send(core2, atom::no_events_v);
@@ -136,7 +136,8 @@ CAF_TEST(nonblocking_publishers) {
   broker_options options;
   options.disable_ssl = true;
   auto core1 = ep.core();
-  auto core2 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
+  auto core2 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"},
+                                          options, nullptr);
   anon_send(core1, atom::subscribe_v, filter_type{"a", "b", "c"});
   anon_send(core1, atom::no_events_v);
   anon_send(core2, atom::no_events_v);

--- a/tests/cpp/subscriber.cc
+++ b/tests/cpp/subscriber.cc
@@ -65,7 +65,8 @@ CAF_TEST(blocking_subscriber) {
   // Spawn/get/configure core actors.
   broker_options options;
   options.disable_ssl = true;
-  auto core1 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
+  auto core1 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"},
+                                          options, nullptr);
   auto core2 = ep.core();
   anon_send(core2, atom::subscribe_v, filter_type{"a", "b", "c"});
   anon_send(core1, atom::no_events_v);
@@ -103,7 +104,8 @@ CAF_TEST(nonblocking_subscriber) {
   // Spawn/get/configure core actors.
   broker_options options;
   options.disable_ssl = true;
-  auto core1 = sys.spawn(core_actor, filter_type{"a", "b", "c"}, options, nullptr);
+  auto core1 = sys.spawn<core_actor_type>(filter_type{"a", "b", "c"},
+                                          options, nullptr);
   auto core2 = ep.core();
   anon_send(core1, atom::no_events_v);
   anon_send(core2, atom::no_events_v);


### PR DESCRIPTION
# Intro

Fixes #165 by implementing the "origin-based credit" discussed in the issue. Before going into implementation details, here's a quick sanity check regarding peformance I did with the recordings provided by @timwoj that revealed the deadlock in the first place. I mentioned that the buffer bloat is detrimental to the performance. Mostly due to tons of unnecessary heap allocations and shoving around memory rather than doing actual work. So the natural question is: how bad is it?

This is with the workaround that increases buffer size to 512MB:

```
$ ./build/release/bin/broker-cluster-benchmark --cluster-config-file=cluster.conf
zeek-recording-manager (sending): 1.14407s
zeek-recording-logger (sending): 1.14525s
zeek-recording-proxy (sending): 2.705s
zeek-recording-worker (receiving): 11.6331s
zeek-recording-worker (sending): 12.5222s
zeek-recording-manager (receiving): 28.3079s
zeek-recording-proxy (receiving): 28.9676s
zeek-recording-logger (receiving): 40.3836s
system: 40.383s
```

This is with the new code:

```
$ ./build/release/bin/broker-cluster-benchmark --cluster-config-file=cluster.conf
zeek-recording-logger (sending): 0.000706025s
zeek-recording-manager (sending): 4.13644s
zeek-recording-proxy (sending): 5.79104s
zeek-recording-worker (receiving): 5.80058s
zeek-recording-proxy (receiving): 13.5511s
zeek-recording-manager (receiving): 13.5536s
zeek-recording-worker (sending): 14.0481s
zeek-recording-logger (receiving): 15.5469s
system: 15.5463s
```

YMMV. These numbers are from an AMD Opteron(tm) 6376 1.4GHz with 32 physical cores (64 HW threads).

# Key Concepts

This PR touches a lot of code for a "bugfix". It's fixing a design bug in Broker, though. To read the code, there is a bit of CAF knowledge necessary that I'll cover here first.

## Streaming

Streams provide a back-pressued data channel. Usually connecting two or more actors:

![stream](https://user-images.githubusercontent.com/651128/103875950-55a30280-50d3-11eb-989c-26c8bdd73ed4.png)

To understand how this maps to actor messages, we also need to take a closer look at message processing. The mailbox of an actor is more than a simple queue. Regular actor-to-actor messages get processed in the order they arrive in according to their priority. But there are two more cases for streaming traffic: downstream messages (for transmitting batches) and upstream messages (for communicating demand). Here's a conceptual view of a mailbox:

![mailbox](https://user-images.githubusercontent.com/651128/103875390-a82fef00-50d2-11eb-8f2e-da65b6dec55d.png)

WDRR stands for Weighted Deficit Round Robin. The takeaway here is that actors multiplex streaming traffic. Streams use `downstream_msg` and `upstream_msg` to allow the actors to put them into the right queues.

## Slots and Paths

Actors can multiplex up to 65k "connections" (max value for an `uint16_t`). Just like TCP uses *ports*, actors use *slots*. Since data only flows in one direction, CAF assigns either an `inbound_path` or an `outbound_path` to each of its slots. These are simple C++ object that keep track of the current state: available/assigned credit, current batch number, batch size, etc.

## Stream Managers

Stream mangers represent a single logical instance of a stream where data arrives on one end (any number of inbound paths) and flows down the other end (any number of outbound paths managed by a `downstream_manager`). In the default model, this is where the backpressure comes in. The stream manager keeps track of how much credit is available downstream and limits credit for the inbound paths based on that.

# How Broker uses Streams Now

The default model does not work for Broker, because we actually have bidirectional communication between peers and our topology includes loops (that we break at a higher level via forwarding flags and TTL). So Broker uses the machinery in CAF for establishing multiplexed message flows with backpressure, but we implement a different credit strategy.

As discussed in #165, we only need to keep track of how many items we currently have in the system per input source (local publisher or peer). The idea is to give each peer X tokens. It may send us that many items and we keep track of the items (each item represents one token). Once we are done with the item (i.e., forwarded it to all subscribers), we can give the peer another token. So the first thing we do with every input is to wrap it into an `item` that tells us where we got this from. To avoid allocating memory for these items over and over again, I've implemented `item_allocator` and `item_stash`. The former allocates blocks of memory for holding some amount of `item` objects. The latter caches up to X items per inbound path. This accomplishes two things: the size of the stash represents the maximum amount of tokens (and what's currently left) and we re-use the same memory every time.

The last piece is the new `unipath_manager`. This is a `caf::stream_manager`, but it only allows at most one inbound path and at most one outbound path. The paths are *not* connected in the usual way, though. The core actor has a single `central_dispatcher` object. All items from all unipath managers get enqueued to the dispatcher. From here, the dispatcher pushes the items to all unicast managers with outbound paths (local subscribers and peers). We hold onto the items until they were shipped to all the right receivers. When the reference count of an item drops to 0, it returns to its stash and we check whether we can give some more credit upstream now.

A stash uses the size `max_pending_inputs_per_source` by default. This is 512 until overriden by a user. This should be plenty. When I played a bit with the recorded data, I usually saw single-digit sized batches and CAF settles at a maximum credit per source ≤ 350. We may need to tweak the default again when we disable the Zeek-side batching.

# Next Steps

So far I've tested the branch using the cluster benchmark and locally with Zeek's btest suites. All changes are internal to Broker, so no API changes. The new way Broker now keeps track of peers makes it easier to keep track of the current handshaking status. As a result, Broker reports errors during handshakes a bit different from before (distinguishes more cases now), which currently causes some Zeek tests for Broker to fail. I'm looking into that to see if we only need to update the baseline. It's still a large diff, so I can understand if you go with the workaround for 4.0 and merge this later. Let me know if this overview is enough to review the changes. When we move forward with this, I'll integrate the new unicast managers into the ALM branch and update the developer guide accordingly.