### PR TITLE
Update Cirrus CI naming update for MacOS images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,14 +121,14 @@ ubuntu16_task:
 # Apple doesn't publish official long-term support timelines.
 # We aim to support both the current and previous macOS release.
 macos_big_sur_task:
-  osx_instance:
+  macos_instance:
     image: big-sur-base
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_RESOURCES_TEMPLATE
 
 macos_catalina_task:
-  osx_instance:
+  macos_instance:
     image: catalina-base
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE


### PR DESCRIPTION
The docs on https://cirrus-ci.org/guide/macOS/ changed from "osx_instance" to "macos_instance", so let's reflect that.