### PR TITLE
Improve error handling for data store backend creation failures

### DIFF
--- a/include/broker/detail/filesystem.hh
+++ b/include/broker/detail/filesystem.hh
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "broker/config.hh"
+#include "broker/logger.hh"
 
 #ifdef BROKER_HAS_STD_FILESYSTEM
 
@@ -13,16 +14,27 @@ namespace broker::detail {
 
 using path = std::filesystem::path;
 
-using std::filesystem::exists;
+inline bool exists(const path& p) {
+  std::error_code ec;
+  return std::filesystem::exists(p, ec);
+}
 
-using std::filesystem::is_directory;
+inline bool is_directory(const path& p) {
+  std::error_code ec;
+  return std::filesystem::is_directory(p, ec);
+}
 
 inline bool is_file(const path& p) {
-  return std::filesystem::is_regular_file(p);
+  std::error_code ec;
+  return std::filesystem::is_regular_file(p, ec);
 }
 
 inline bool mkdirs(const path& p) {
-  return std::filesystem::create_directories(p);
+  std::error_code ec;
+  auto rval = std::filesystem::create_directories(p, ec);
+  if ( ! rval )
+    BROKER_ERROR("failed to make directories: " << p.native() << ":" << ec.message());
+  return rval;
 }
 
 inline path dirname(path p) {
@@ -30,12 +42,20 @@ inline path dirname(path p) {
   return p;
 }
 
-using std::filesystem::remove;
+inline bool remove(const path& p) {
+  std::error_code ec;
+  auto rval = std::filesystem::remove(p, ec);
+  if ( ! rval )
+    BROKER_ERROR("failed to remove path: " << p.native() << ":" << ec.message());
+  return rval;
+}
 
 inline bool remove_all(const path& p) {
   std::error_code ec;
-  std::filesystem::remove_all(p, ec);
-  return static_cast<bool>(ec);
+  auto rval = std::filesystem::remove_all(p, ec);
+  if ( ! rval )
+    BROKER_ERROR("failed to recursively remove path: " << p.native() << ":" << ec.message());
+  return rval;
 }
 
 } // namespace broker::detail

--- a/include/broker/detail/sqlite_backend.hh
+++ b/include/broker/detail/sqlite_backend.hh
@@ -19,6 +19,8 @@ public:
 
   ~sqlite_backend();
 
+  bool init_failed() const;
+
   expected<void> put(const data& key, data value,
                      optional<timestamp> expiry) override;
 

--- a/include/broker/mixin/data_store_manager.hh
+++ b/include/broker/mixin/data_store_manager.hh
@@ -74,7 +74,8 @@ public:
       return ec::master_exists;
     }
     auto ptr = detail::make_backend(backend_type, std::move(opts));
-    BROKER_ASSERT(ptr != nullptr);
+    if (!ptr)
+      return ec::backend_failure;
     BROKER_INFO("spawning new master:" << name);
     auto self = super::self();
     auto ms = self->template spawn<spawn_flags>(detail::master_actor, self,

--- a/src/detail/make_backend.cc
+++ b/src/detail/make_backend.cc
@@ -13,8 +13,12 @@ std::unique_ptr<detail::abstract_backend> make_backend(backend type,
   switch (type) {
     case backend::memory:
       return std::make_unique<memory_backend>(std::move(opts));
-    case backend::sqlite:
-      return std::make_unique<sqlite_backend>(std::move(opts));
+    case backend::sqlite: {
+      auto rval = std::make_unique<sqlite_backend>(std::move(opts));
+      if (rval->init_failed())
+        return nullptr;
+      return rval;
+    }
   }
 
   die("invalid backend type");


### PR DESCRIPTION
* Change broker::filesystem::detail functions that rely on
  std::filesystem to use non-throwing calls

* Add error messages to come broker::filesystem::detail functions:
  mkdirs(), remove(), and remove_all()

* Use sqlite3_errmsg() to emit reason for sqlite3_open() failures

* Change sqlite backend initialization failures to be non-fatal

Related to https://github.com/zeek/zeek/issues/1426