### PR TITLE
Prevent use of LeakSanitizer on FreeBSD

### DIFF
--- a/src/config.hh.in
+++ b/src/config.hh.in
@@ -20,7 +20,8 @@
     #endif
 #endif
 
-#if defined(BROKER_ASAN)
+// FreeBSD doesn't support LeakSanitizer
+#if defined(BROKER_ASAN) && !defined(__FreeBSD__)
     #include <sanitizer/lsan_interface.h>
     #define BROKER_LSAN_CHECK(x) __lsan_do_leak_check(x)
     #define BROKER_LSAN_ENABLE() __lsan_enable()


### PR DESCRIPTION
Since it's not expressly supported AFAICT: https://clang.llvm.org/docs/LeakSanitizer.html
> LeakSanitizer is supported on x86_64 Linux and macOS.