### PR TITLE
Update bundled CAF to 0.18.2

### DIFF
--- a/tests/cpp/integration.cc
+++ b/tests/cpp/integration.cc
@@ -61,6 +61,7 @@ configuration make_config() {
                            caf::test::engine::argv()))
     CAF_FAIL("parsing the config failed: " << to_string(err));
   cfg.set("caf.middleman.network-backend", "testing");
+  cfg.set("caf.middleman.heartbeat-interval", caf::timespan{0});
   cfg.set("caf.scheduler.policy", "testing");
   cfg.set("caf.logger.inline-output", true);
   return cfg;


### PR DESCRIPTION
I found the `cpp/integration.cc` failing/hanging on update to CAF 0.18.2 and bisected to https://github.com/actor-framework/actor-framework/commit/dca955edf70e41ccda389d4c3825b725ae7d5842.  I didn't dig deeply after, but think I see how the non-zero heartbeat, if it tries to schedule/send recurring message right away, could cause the test to initiate a blocking `peer()` too early:

https://github.com/zeek/broker/blob/e156897b57f4be5c29f7f94aa56bcd45d8815003/tests/cpp/integration.cc#L287-L297

and so just adapted the test to explicitly set a zero heartbeat-interval.