### PR TITLE
Remove redundant code

### DIFF
--- a/tests/cpp/integration.cc
+++ b/tests/cpp/integration.cc
@@ -53,20 +53,6 @@ using caf::io::connection_handle;
 
 namespace {
 
-configuration make_config() {
-  broker_options options;
-  options.disable_ssl = true;
-  configuration cfg(options);
-  if (auto err = cfg.parse(caf::test::engine::argc(),
-                           caf::test::engine::argv()))
-    CAF_FAIL("parsing the config failed: " << to_string(err));
-  cfg.set("caf.middleman.network-backend", "testing");
-  cfg.set("caf.middleman.heartbeat-interval", caf::timespan{0});
-  cfg.set("caf.scheduler.policy", "testing");
-  cfg.set("caf.logger.inline-output", true);
-  return cfg;
-}
-
 struct peer_fixture;
 
 // Holds state shared by all peers. There exists exactly one global fixture.
@@ -131,7 +117,7 @@ struct peer_fixture {
   peer_fixture(global_fixture* parent_ptr, std::string peer_name)
     : parent(parent_ptr),
       name(std::move(peer_name)),
-      ep(make_config()),
+      ep(base_fixture::make_config()),
       sys(ep.system()),
       sched(dynamic_cast<caf::scheduler::test_coordinator&>(sys.scheduler())),
       mm(sys.middleman()),

--- a/tests/cpp/test.hh
+++ b/tests/cpp/test.hh
@@ -128,7 +128,6 @@ public:
     return dynamic_cast<T&>(*ptr);
   }
 
-private:
   static broker::configuration make_config();
 };
 


### PR DESCRIPTION
The integration test suite broke recently with the latest CAF update. This has been fixed via e156897b57f4be5c29f7f94aa56bcd45d8815003. However, the integration unit test suite is bound to fail again if CAF introduces new configuration options that need tuning in test environments. CAF already ships base types for custom fixtures for this reason that are maintained upstream. The other Broker unit tests did not fail with the recent update, because the base fixture in Broker uses the designated scaffolding.

With this PR, we simply drop the custom configuration setup in the integration test suite and re-use the safe base fixture setup.