### PR TITLE
CI support refresh to bring in line with Zeek

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,6 +46,14 @@ unix_env: &UNIX_ENV
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
+fedora34_task:
+  container:
+    # Fedora 34 EOL: Around May 2022
+    dockerfile: ci/fedora-34/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *UNIX_ENV
+
 fedora33_task:
   container:
     # Fedora 33 EOL: Around November 2022
@@ -54,10 +62,10 @@ fedora33_task:
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
-fedora32_task:
+centosstream8_task:
   container:
-    # Fedora 32 EOL: Around May 2021
-    dockerfile: ci/fedora-32/Dockerfile
+    # Stream 8 support should be 5 years, so until 2024. but I cannot find a concrete timeline --cpk
+    dockerfile: ci/centos-stream-8/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *UNIX_ENV
@@ -107,6 +115,22 @@ debian9_32bit_task:
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
+opensuse_leap_15_2_task:
+  container:
+    # Opensuse Leap 15.2 EOL: Dec 2021
+    dockerfile: ci/opensuse-leap-15.2/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *UNIX_ENV
+
+opensuse_leap_15_3_task:
+  container:
+    # Opensuse Leap 15.3 EOL: TBD
+    dockerfile: ci/opensuse-leap-15.3/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *UNIX_ENV
+
 ubuntu20_task:
   container:
     # Ubuntu 20.04 EOL: April 2025
@@ -148,6 +172,17 @@ macos_catalina_task:
   << : *MACOS_RESOURCES_TEMPLATE
 
 # FreeBSD EOL timelines: https://www.freebsd.org/security/security.html#sup
+freebsd13_task:
+  freebsd_instance:
+    # FreeBSD 13 EOL: January 31, 2026
+    image_family: freebsd-13-0
+    cpu: 8
+    # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
+    memory: 8GB
+  prepare_script: ./ci/freebsd/prepare.sh
+  << : *CI_TEMPLATE
+  << : *UNIX_ENV
+
 freebsd12_task:
   freebsd_instance:
     # FreeBSD 12 EOL: June 30, 2024

--- a/ci/centos-stream-8/Dockerfile
+++ b/ci/centos-stream-8/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf install -y \
+    cmake \
+    gcc \
+    gcc-c++ \
+    git \
+    make \
+    openssl-devel \
+    python3 \
+    python3-devel \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf

--- a/ci/fedora-34/Dockerfile
+++ b/ci/fedora-34/Dockerfile
@@ -1,6 +1,6 @@
-FROM fedora:32
+FROM fedora:34
 
-RUN yum install -y \
+RUN dnf install -y \
     cmake \
     gcc \
     gcc-c++ \
@@ -10,5 +10,5 @@ RUN yum install -y \
     openssl-devel \
     python3 \
     python3-devel \
-    && yum clean all \
-    && rm -rf /var/cache/yum
+    && dnf clean all \
+    && rm -rf /var/cache/dnf

--- a/ci/opensuse-leap-15.2/Dockerfile
+++ b/ci/opensuse-leap-15.2/Dockerfile
@@ -1,0 +1,12 @@
+FROM opensuse/leap:15.2
+
+RUN zypper in -y \
+  cmake \
+  gcc \
+  gcc-c++ \
+  git \
+  make \
+  python3 \
+  python3-devel \
+  libopenssl-devel \
+  && rm -rf /var/cache/zypp

--- a/ci/opensuse-leap-15.3/Dockerfile
+++ b/ci/opensuse-leap-15.3/Dockerfile
@@ -1,0 +1,12 @@
+FROM opensuse/leap:15.3
+
+RUN zypper in -y \
+  cmake \
+  gcc \
+  gcc-c++ \
+  git \
+  make \
+  python3 \
+  python3-devel \
+  libopenssl-devel \
+  && rm -rf /var/cache/zypp


### PR DESCRIPTION
Drop Fedora 32, add Fedora 34, add Centos Stream, add OpenSUSE Leaps, add FreeBSD 13