### PR TITLE
Fix heap-use-after-free during shutdown

### DIFF
--- a/src/endpoint.cc
+++ b/src/endpoint.cc
@@ -370,9 +370,8 @@ void endpoint::shutdown() {
     children_.clear();
   }
   BROKER_DEBUG("stop background tasks");
-  background_tasks_.clear();
-  anon_send_exit(telemetry_exporter_, caf::exit_reason::user_shutdown);
   telemetry_exporter_ = nullptr;
+  background_tasks_.clear();
   BROKER_DEBUG("send shutdown message to core actor");
   anon_send(core_, atom::shutdown_v);
   core_ = nullptr;


### PR DESCRIPTION
Fixes https://github.com/zeek/zeek/issues/1607.

@ckreibich with this patch, I can no longer reproduce a crash when hitting CTRL+C. Without the patch, ASAN reported a `heap-use-after-free`. Mind double-checking on your end for the merge?