### PR TITLE
Remove global topic variables

### DIFF
--- a/include/broker/mixin/data_store_manager.hh
+++ b/include/broker/mixin/data_store_manager.hh
@@ -48,7 +48,7 @@ public:
   bool has_remote_master(const std::string& name) {
     // If we don't have a master recorded locally, we could still have a
     // propagated filter to a remote core hosting a master.
-    return dref().has_remote_subscriber(name / topics::master_suffix);
+    return dref().has_remote_subscriber(name / topic::master_suffix());
   }
 
   const auto& masters() const noexcept {
@@ -80,7 +80,7 @@ public:
     auto self = super::self();
     auto ms = self->template spawn<spawn_flags>(detail::master_actor, self,
                                                 name, std::move(ptr), clock_);
-    filter_type filter{name / topics::master_suffix};
+    filter_type filter{name / topic::master_suffix()};
     if (auto err = dref().add_store(ms, filter))
       return err;
     masters_.emplace(name, ms);
@@ -106,7 +106,7 @@ public:
                                                 resync_interval, stale_interval,
                                                 mutation_buffer_interval,
                                                 clock_);
-    filter_type filter{name / topics::clone_suffix};
+    filter_type filter{name / topic::clone_suffix()};
     if (auto err = dref().add_store(cl, filter))
       return err;
     clones_.emplace(name, cl);
@@ -125,7 +125,7 @@ public:
   void snapshot(const std::string& name, caf::actor& clone) {
     auto msg = make_internal_command<snapshot_command>(super::self(),
                                                        std::move(clone));
-    dref().publish(make_command_message(name / topics::master_suffix, msg));
+    dref().publish(make_command_message(name / topic::master_suffix(), msg));
   }
 
   /// Detaches all masters and clones by sending exit messages to the

--- a/include/broker/mixin/notifier.hh
+++ b/include/broker/mixin/notifier.hh
@@ -120,12 +120,12 @@ private:
   }
 
   void emit(const status& stat) {
-    auto dmsg = make_data_message(topics::statuses, get_as<data>(stat));
+    auto dmsg = make_data_message(topic::statuses(), get_as<data>(stat));
     dref().ship_locally(std::move(dmsg));
   }
 
   void emit(const error& err) {
-    auto dmsg = make_data_message(topics::errors, get_as<data>(err));
+    auto dmsg = make_data_message(topic::errors(), get_as<data>(err));
     dref().ship_locally(std::move(dmsg));
   }
 

--- a/include/broker/topic.hh
+++ b/include/broker/topic.hh
@@ -18,7 +18,28 @@ public:
   static constexpr char sep = '/';
 
   /// A reserved string which must not appear in a user topic.
-  static constexpr char reserved[] = "<$>";
+  static constexpr std::string_view reserved = "<$>";
+
+  static constexpr std::string_view master_suffix_str = "<$>/data/master";
+
+  static constexpr std::string_view clone_suffix_str = "<$>/data/clone";
+
+  static constexpr std::string_view errors_str = "<$>/local/data/errors";
+
+  static constexpr std::string_view statuses_str = "<$>/local/data/statuses";
+
+  static constexpr std::string_view store_events_str
+    = "<$>/local/data/store-events";
+
+  static topic master_suffix();
+
+  static topic clone_suffix();
+
+  static topic errors();
+
+  static topic statuses();
+
+  static topic store_events();
 
   /// Splits a topic into a vector of its components.
   /// @param t The topic to split.
@@ -73,9 +94,24 @@ public:
     return f.apply(x.str_);
   }
 
+  friend bool operator==(const topic& lhs, std::string_view rhs) {
+    return lhs.str_ == rhs;
+  }
+
+  friend bool operator==(std::string_view lhs, const topic& rhs) {
+    return lhs == rhs.str_;
+  }
+
 private:
+  static topic from(std::string_view str) {
+    return topic{std::string{str}};
+  }
+
   std::string str_;
 };
+
+/// Returns whether `prefix` is a prefix match for `t`.
+bool is_prefix(const topic& t, std::string_view prefix) noexcept;
 
 /// @relates topic
 bool operator==(const topic& lhs, const topic& rhs);
@@ -94,19 +130,6 @@ bool convert(const topic& t, std::string& str);
 /// @relates topic
 bool is_internal(const topic& x);
 
-/// Topics with a special meaning.
-namespace topics {
-
-const topic reserved = topic{topic::reserved};
-const topic master = topic{"data"} / "master";
-const topic clone = topic{"data"} / "clone";
-const topic master_suffix = reserved / master;
-const topic clone_suffix = reserved / clone;
-const topic errors = reserved / "local/data/errors";
-const topic statuses = reserved / "local/data/statuses";
-const topic store_events = reserved / "local/data/store-events";
-
-} // namespace topics
 } // namespace broker
 
 /// Converts a string to a topic.

--- a/src/core_actor.cc
+++ b/src/core_actor.cc
@@ -66,8 +66,8 @@ void core_state::subscribe(filter_type xs) {
   BROKER_TRACE(BROKER_ARG(xs));
   // Status and error topics are internal topics.
   auto internal_only = [](const topic& x) {
-    return x == topics::errors || x == topics::statuses
-           || topics::store_events.prefix_of(x);
+    return x == topic::errors_str || x == topic::statuses_str
+           || is_prefix(x, topic::store_events_str);
   };
   xs.erase(std::remove_if(xs.begin(), xs.end(), internal_only), xs.end());
   if (xs.empty())

--- a/src/detail/clone_actor.cc
+++ b/src/detail/clone_actor.cc
@@ -35,7 +35,7 @@ static double now(endpoint::clock* clock) {
 void clone_state::init(caf::event_based_actor* ptr, std::string&& nm,
                        caf::actor&& parent, endpoint::clock* ep_clock) {
   super::init(ptr, ep_clock, std::move(nm), std::move(parent));
-  master_topic = id / topics::master_suffix;
+  master_topic = id / topic::master_suffix();
 }
 
 void clone_state::forward(internal_command&& x) {

--- a/src/detail/master_actor.cc
+++ b/src/detail/master_actor.cc
@@ -34,7 +34,7 @@ void master_state::init(caf::event_based_actor* ptr, std::string&& nm,
                         backend_pointer&& bp, caf::actor&& parent,
                         endpoint::clock* ep_clock) {
   super::init(ptr, ep_clock, std::move(nm), std::move(parent));
-  clones_topic = id / topics::clone_suffix;
+  clones_topic = id / topic::clone_suffix();
   backend = std::move(bp);
   if (auto es = backend->expiries()) {
     for (auto& e : *es) {

--- a/src/detail/store_actor.cc
+++ b/src/detail/store_actor.cc
@@ -56,7 +56,7 @@ void store_actor_state::init(caf::event_based_actor* self,
   this->clock = clock;
   this->id = std::move(id);
   this->core = std::move(core);
-  this->dst = topics::store_events / this->id;
+  this->dst = topic::store_events() / this->id;
 }
 
 void store_actor_state::emit_insert_event(const data& key, const data& value,

--- a/src/detail/unipath_manager.cc
+++ b/src/detail/unipath_manager.cc
@@ -424,7 +424,7 @@ public:
         continue;
       }
       // Somewhat hacky, but don't forward data store clone messages.
-      auto ttl = ends_with(get_topic(x).string(), topics::clone_suffix.string())
+      auto ttl = ends_with(get_topic(x).string(), topic::clone_suffix_str)
                  ? uint16_t{0}
                  : std::min(ttl_, static_cast<uint16_t>(x.ttl - 1));
       x.ttl = ttl;

--- a/src/status_subscriber.cc
+++ b/src/status_subscriber.cc
@@ -10,7 +10,7 @@
 
 #define BROKER_RETURN_CONVERTED_MSG()                                          \
   auto& t = get_topic(msg);                                                    \
-  if (t == topics::errors) {                                                   \
+  if (t == topic::errors_str) {                                                \
     if (auto value = to<error>(get_data(msg)))                                 \
       return value_type{std::move(*value)};                                    \
     BROKER_WARNING("received malformed error");                                \
@@ -22,7 +22,7 @@
 
 #define BROKER_APPEND_CONVERTED_MSG()                                          \
   auto& t = get_topic(msg);                                                    \
-  if (t == topics::errors) {                                                   \
+  if (t == topic::errors_str) {                                                \
     if (auto value = to<error>(get_data(msg)))                                 \
       result.emplace_back(std::move(*value));                                  \
     else                                                                       \
@@ -43,9 +43,9 @@ namespace {
 std::vector<topic> make_status_topics(bool receive_statuses) {
   std::vector<topic> result;
   result.reserve(2);
-  result.emplace_back(topics::errors);
+  result.emplace_back(topic::errors());
   if (receive_statuses)
-    result.emplace_back(topics::statuses);
+    result.emplace_back(topic::statuses());
   return result;
 }
 

--- a/src/topic.cc
+++ b/src/topic.cc
@@ -62,7 +62,8 @@ std::string_view topic::suffix() const noexcept {
 
 bool is_prefix(const topic& t, std::string_view prefix) noexcept {
   const auto& str = t.string();
-  return str.size() <= prefix.size() && prefix.compare(0, str.size(), str) == 0;
+  return str.size() >= prefix.size()
+         && str.compare(0, prefix.size(), prefix) == 0;
 }
 
 bool operator==(const topic& lhs, const topic& rhs) {

--- a/src/topic.cc
+++ b/src/topic.cc
@@ -4,8 +4,6 @@
 
 namespace broker {
 
-constexpr char topic::reserved[];
-
 std::vector<std::string> topic::split(const topic& t) {
   std::vector<std::string> result;
   std::string::size_type i = 0;
@@ -50,8 +48,7 @@ std::string&& topic::move_string() && {
 }
 
 bool topic::prefix_of(const topic& t) const {
-  return str_.size() <= t.str_.size()
-         && t.str_.compare(0, str_.size(), str_) == 0;
+  return is_prefix(t, str_);
 }
 
 std::string_view topic::suffix() const noexcept {
@@ -61,6 +58,11 @@ std::string_view topic::suffix() const noexcept {
   } else {
     return {str_};
   }
+}
+
+bool is_prefix(const topic& t, std::string_view prefix) noexcept {
+  const auto& str = t.string();
+  return str.size() <= prefix.size() && prefix.compare(0, str.size(), str) == 0;
 }
 
 bool operator==(const topic& lhs, const topic& rhs) {
@@ -92,6 +94,26 @@ bool is_internal(const topic& x) {
   auto pre = internal_prefix;
   return str.size() >= pre.size()
          && caf::string_view{str.data(), pre.size()} == pre;
+}
+
+topic topic::master_suffix() {
+  return from(master_suffix_str);
+}
+
+topic topic::clone_suffix() {
+  return from(clone_suffix_str);
+}
+
+topic topic::errors() {
+  return from(errors_str);
+}
+
+topic topic::statuses() {
+  return from(statuses_str);
+}
+
+topic topic::store_events() {
+  return from(store_events_str);
 }
 
 } // namespace broker

--- a/tests/cpp/detail/telemetry/collector.cc
+++ b/tests/cpp/detail/telemetry/collector.cc
@@ -8,7 +8,7 @@
 
 using namespace broker;
 
-using namespace std::literals::chrono_literals;
+using namespace std::literals;
 
 namespace {
 
@@ -21,7 +21,7 @@ struct collector_ptr {
 caf::behavior dummy_core(collector_ptr ptr) {
   return {
     [collector{ptr.value}](atom::publish, data_message msg) {
-      CHECK_EQUAL(get_topic(msg), "/all/them/metrics");
+      CHECK_EQUAL(get_topic(msg), "/all/them/metrics"sv);
       CHECK_GREATER_EQUAL(collector->insert_or_update(get_data(msg)), 6u);
     },
   };

--- a/tests/cpp/detail/telemetry/exporter.cc
+++ b/tests/cpp/detail/telemetry/exporter.cc
@@ -8,7 +8,7 @@
 
 using namespace broker;
 
-using namespace std::literals::chrono_literals;
+using namespace std::literals;
 
 namespace {
 
@@ -184,12 +184,12 @@ TEST(the exporter allows changing the topic at runtime) {
   sched.advance_time(2s);
   expect((caf::tick_atom), to(aut));
   expect((atom::publish, data_message), from(aut).to(core));
-  CHECK_EQUAL(last_topic(), "all/them/metrics");
+  CHECK_EQUAL(last_topic(), "all/them/metrics"sv);
   inject((atom::put, topic), to(aut).with(atom::put_v, "foo/bar"_t));
   sched.advance_time(2s);
   expect((caf::tick_atom), to(aut));
   expect((atom::publish, data_message), from(aut).to(core));
-  CHECK_EQUAL(last_topic(), "foo/bar");
+  CHECK_EQUAL(last_topic(), "foo/bar"sv);
 }
 
 TEST(the exporter allows changing the ID at runtime) {

--- a/tests/cpp/master.cc
+++ b/tests/cpp/master.cc
@@ -93,7 +93,7 @@ struct fixture : base_fixture {
   fixture() {
     logger = ep.subscribe_nosync(
       // Topics.
-      {topics::store_events},
+      {topic::store_events()},
       // Init.
       [](caf::unit_t&) {},
       // Consume.
@@ -217,7 +217,7 @@ TEST(master_with_clone) {
   earth.sched.inline_next_enqueue(); // .get talks to the master
   CHECK_EQUAL(value_of(ds_earth.get("test")), data{123});
   // --- phase 5: peer from earth to mars --------------------------------------
-  auto foo_master = "foo" / topics::master_suffix;
+  auto foo_master = "foo" / topic::master_suffix();
 // Initiate handshake between core1 and core2.
   earth.self->send(core1, atom::peer_v, core2_proxy);
   run(tick_interval);

--- a/tests/cpp/status_subscriber.cc
+++ b/tests/cpp/status_subscriber.cc
@@ -40,7 +40,7 @@ struct fixture : base_fixture {
     if (!convert(x, xs))
       FAIL("unable to convert error to data");
     caf::anon_send(ep.core(), atom::publish_v, atom::local_v,
-                   make_data_message(topics::errors, std::move(xs)));
+                   make_data_message(topic::errors(), std::move(xs)));
   }
 
   void push(status x) {
@@ -48,7 +48,7 @@ struct fixture : base_fixture {
     if (!convert(x, xs))
       FAIL("unable to convert status to data");
     caf::anon_send(ep.core(), atom::publish_v, atom::local_v,
-                   make_data_message(topics::statuses, std::move(xs)));
+                   make_data_message(topic::statuses(), std::move(xs)));
   }
 
   caf::node_id node;

--- a/tests/cpp/topic.cc
+++ b/tests/cpp/topic.cc
@@ -15,11 +15,11 @@ auto sep = std::string{topic::sep};
 TEST(concatenation) {
   topic t;
   t /= "foo";
-  CHECK_EQUAL(t, "foo");
+  CHECK_EQUAL(t.string(), "foo");
   t /= "bar";
-  CHECK_EQUAL(t, "foo" + sep + "bar");
+  CHECK_EQUAL(t.string(), "foo" + sep + "bar");
   t /= "/baz";
-  CHECK_EQUAL(t, "foo" + sep + "bar" + sep + "baz");
+  CHECK_EQUAL(t.string(), "foo" + sep + "bar" + sep + "baz");
 }
 
 TEST(split) {
@@ -35,7 +35,7 @@ TEST(split) {
 TEST(join) {
   std::vector<std::string> xs{"/foo", "bar/", "/baz"};
   auto t = topic::join(xs);
-  CHECK_EQUAL(t, sep + "foo" + sep + "bar" + sep + "baz");
+  CHECK_EQUAL(t.string(), sep + "foo" + sep + "bar" + sep + "baz");
 }
 
 TEST(prefix) {


### PR DESCRIPTION
Fix a potential memory corruption during static initialization by avoiding global variables with non-trivial constructors.

Closes #187.