### PR TITLE
Restore CPU/memory metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ if (NOT OPENSSL_LIBRARIES)
 endif()
 set(LINK_LIBS ${LINK_LIBS} ${OPENSSL_LIBRARIES})
 
-set(CAF_VERSION_MIN_REQUIRED 0.18.3)
+set(CAF_VERSION_MIN_REQUIRED 0.18.4)
 
 if ( TARGET CAF::core )
   message(STATUS "CAF version ${CAF_VERSION} passed in by parent project")

--- a/src/detail/telemetry/prometheus.cc
+++ b/src/detail/telemetry/prometheus.cc
@@ -103,8 +103,10 @@ caf::behavior prometheus_actor::make_behavior() {
       // default CAF Prometheus export.
       auto hdr = caf::as_bytes(caf::make_span(request_ok));
       BROKER_ASSERT(exporter_ != nullptr);
-      if (!exporter_->running())
+      if (!exporter_->running()) {
+        exporter_->proc_importer.update();
         exporter_->impl.scrape(system().metrics());
+      }
       collector_.insert_or_update(exporter_->impl.rows());
       auto text = collector_.prometheus_text();
       auto payload = caf::as_bytes(caf::make_span(text));


### PR DESCRIPTION
This also updates CAF to 0.18.4 as required by the metrics change.

Fixes #189 