### PR TITLE
Fix output of build-type CFLAGS during configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,7 +442,9 @@ endif ()
 
 # -- Build Summary ------------------------------------------------------------
 
-string(TOUPPER CMAKE_BUILD_TYPE BuildType)
+if (CMAKE_BUILD_TYPE)
+    string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
+endif ()
 
 macro(display test desc summary)
   if ( ${test} )


### PR DESCRIPTION
This fixes a bug where the CFLAGS that are based on the build type weren't being displayed in the output during configure. The flags were getting set correctly in the build, but not in the output.

Fixes https://github.com/zeek/zeek/issues/1665