### PR TITLE
Rework CI scripts for Windows

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,6 +43,9 @@ unix_env: &UNIX_ENV
     BROKER_BENCHMARK_HOST: ENCRYPTED[91d00f9b8e7423899232f7fc66769d6fb95fdb381b0e1546d5922483b060c853394f4146533fa4946809e8b2b97fb6d6]
     BROKER_BENCHMARK_PORT: ENCRYPTED[a22877e5c27b0957d7c7e78e2b1e1ea73ac02544544f453aee5af3bed2e90437a5b85cd2893bf6a741dfe22976c7ebb6]
 
+    # Give verbose error output on a test failure.
+    CTEST_OUTPUT_ON_FAILURE: 1
+
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
@@ -228,6 +231,8 @@ memcheck_task:
     BROKER_CI_CPUS: *CPUS
     BROKER_CI_CONFIGURE_FLAGS: *MEMCHECK_CONFIG
     BROKER_CI_MEMCHECK: true
+    # Give verbose error output on a test failure.
+    CTEST_OUTPUT_ON_FAILURE: 1
 
 windows_task:
   # 2 hour timeout just for potential of building Docker image taking a while
@@ -246,3 +251,6 @@ windows_task:
   test_script: ci/windows/test.cmd
   env:
     BROKER_CI_CPUS: 8
+    # Give verbose error output on a test failure.
+    CTEST_OUTPUT_ON_FAILURE: 1
+

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -230,10 +230,6 @@ memcheck_task:
     BROKER_CI_MEMCHECK: true
 
 windows_task:
-  # The Windows task is currently disabled on Cirrus since it times out for
-  # unknown reason (seems to hang during downloading/running the Docker image),
-  # so Travis is used instead.
-  only_if: false
   # 2 hour timeout just for potential of building Docker image taking a while
   timeout_in: 120m
   windows_container:

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -31,7 +31,10 @@ target_include_directories(_broker PUBLIC
                            ${PYTHON_INCLUDE_DIRS})
 
 # Set libraries to link against.
-target_compile_options(_broker PRIVATE "-fvisibility=hidden")
+if (NOT WIN32)
+  target_compile_options(_broker PRIVATE "-fvisibility=hidden")
+endif ()
+
 if (ENABLE_SHARED)
   set(libbroker broker)
 else ()

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -67,16 +67,15 @@ if ( NOT PY_MOD_INSTALL_DIR )
   # Figure out Python module install directory.
   if (BROKER_PYTHON_PREFIX)
     set(pyver ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-    set(PY_MOD_INSTALL_DIR
-        ${BROKER_PYTHON_PREFIX}/lib/python${pyver}/site-packages)
+    file(TO_CMAKE_PATH "${BROKER_PYTHON_PREFIX}/lib/python${pyver}/site-packages" PY_MOD_INSTALL_DIR)
   elseif (BROKER_PYTHON_HOME)
-    set(PY_MOD_INSTALL_DIR ${BROKER_PYTHON_HOME}/lib/python)
+    file(TO_CMAKE_PATH "${BROKER_PYTHON_HOME}/lib/python" PY_MOD_INSTALL_DIR)
   else ()
     execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
       "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
       OUTPUT_VARIABLE python_site_packages
       OUTPUT_STRIP_TRAILING_WHITESPACE)
-    set(PY_MOD_INSTALL_DIR ${python_site_packages})
+    file(TO_CMAKE_PATH ${python_site_packages} PY_MOD_INSTALL_DIR)
   endif ()
 endif ()
 message(STATUS "Python bindings will be built and installed to:")

--- a/bindings/python/_broker.cpp
+++ b/bindings/python/_broker.cpp
@@ -5,13 +5,17 @@
 #include <utility>
 #include <vector>
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pybind11/functional.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 #include "broker/backend.hh"
 #include "broker/backend_options.hh"

--- a/bindings/python/data.cpp
+++ b/bindings/python/data.cpp
@@ -3,10 +3,14 @@
 #include <utility>
 #include <array>
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pybind11/pybind11.h>
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 #include "set_bind.h"
 

--- a/bindings/python/enums.cpp
+++ b/bindings/python/enums.cpp
@@ -1,10 +1,14 @@
 
 #include <utility>
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pybind11/pybind11.h>
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 #include "broker/api_flags.hh"
 #include "broker/backend.hh"

--- a/bindings/python/store.cpp
+++ b/bindings/python/store.cpp
@@ -2,10 +2,14 @@
 #include <utility>
 #include <string>
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pybind11/pybind11.h>
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 #include "broker/data.hh"
 #include "broker/store.hh"

--- a/bindings/python/zeek.cpp
+++ b/bindings/python/zeek.cpp
@@ -3,10 +3,14 @@
 #include <string>
 #include <stdexcept>
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pybind11/pybind11.h>
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 #include "broker/zeek.hh"
 #include "broker/data.hh"

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -30,24 +30,26 @@ RUN powershell -NoLogo -NoProfile -Command `
     Remove-Item C:\ProgramData\chocolatey\logs -Force -Recurse ; `
     Remove-Item C:\Users\ContainerAdministrator\AppData\Local\Temp -Force -Recurse
 
-RUN choco install -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' cmake openssl
+# OpenSSL has to be installed separately from the above here or
+# the call to install the MSVC bits fails for some reason. Python
+# is separate so we can specify a version.
+RUN choco install -y --no-progress openssl
+RUN choco install -y --no-progress --version=3.10.0 python
 
 # Download the Build Tools bootstrapper.
-ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+ADD https://aka.ms/vs/17/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 
 # Install Build Tools and additional workloads, excluding workloads and
 # components with known issues.  Based on example from:
 # https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2019
 RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
-    --installPath C:\BuildTools `
     --add Microsoft.VisualStudio.Workload.VCTools `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-    --add Microsoft.VisualStudio.Component.Windows10SDK.18362 `
+    --add Microsoft.VisualStudio.Component.VC.CMake.Project `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
+    --add Microsoft.VisualStudio.Component.TestTools.BuildTools `
     --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
     --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
     --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
     --remove Microsoft.VisualStudio.Component.Windows81SDK `
  || IF "%ERRORLEVEL%"=="3010" EXIT 0
-
-# This entry point starts the developer command prompt and launches PowerShell.
-ENTRYPOINT ["C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "-arch=amd64", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/ci/windows/build.cmd
+++ b/ci/windows/build.cmd
@@ -1,9 +1,14 @@
+:: Import the visual studio compiler environment into the one running in the
+:: cmd current shell. This path is hard coded to the one on the CI image, but
+:: can be adjusted if running builds locally. Unfortunately, the initial path
+:: isn't in the environment so we have to hardcode the whole path.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 
 mkdir build
 cd build
 
-:: All of the relevant binaries here are put in the path by the bat file above
+:: The configure script doesn't work for Windows but we can call cmake directly
+:: to do the same. Ninja is installed as part of the CI image.
 C:\WINDOWS\system32\cmd.exe /c %SYSTEMROOT%\System32\chcp.com 65001 >NUL && ^
 cmake.exe -G "Ninja" -DCMAKE_BUILD_TYPE:STRING="Debug" ^
 -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_MAKE_PROGRAM=ninja.exe ^

--- a/ci/windows/build.cmd
+++ b/ci/windows/build.cmd
@@ -1,6 +1,13 @@
-set PATH=%PATH%;C:\Program Files\CMake\bin
+call "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+
 mkdir build
 cd build
-cmake -A x64 -DOPENSSL_ROOT_DIR="C:\Program Files\OpenSSL-Win64" -DEXTRA_FLAGS=/MP%BROKER_CI_CPUS% .. || exit \b 1
-cmake --build . --target install --config release || exit \b 1
+
+:: All of the relevant binaries here are put in the path by the bat file above
+C:\WINDOWS\system32\cmd.exe /c %SYSTEMROOT%\System32\chcp.com 65001 >NUL && ^
+cmake.exe -G "Ninja" -DCMAKE_BUILD_TYPE:STRING="Debug" ^
+-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_MAKE_PROGRAM=ninja.exe ^
+-DOPENSSL_ROOT_DIR="C:\Program Files\OpenSSL-Win64" -DEXTRA_FLAGS=/MP%BROKER_CI_CPUS% ..
+
+cmake.exe --build . --target install --config release || exit \b 1
 cd ..

--- a/ci/windows/build.cmd
+++ b/ci/windows/build.cmd
@@ -7,7 +7,8 @@ cd build
 C:\WINDOWS\system32\cmd.exe /c %SYSTEMROOT%\System32\chcp.com 65001 >NUL && ^
 cmake.exe -G "Ninja" -DCMAKE_BUILD_TYPE:STRING="Debug" ^
 -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_MAKE_PROGRAM=ninja.exe ^
--DOPENSSL_ROOT_DIR="C:\Program Files\OpenSSL-Win64" -DEXTRA_FLAGS=/MP%BROKER_CI_CPUS% ..
+-DOPENSSL_ROOT_DIR="C:\Program Files\OpenSSL-Win64" -DEXTRA_FLAGS=/MP%BROKER_CI_CPUS% ^
+-DDISABLE_PYTHON_BINDINGS="true" ..
 
 cmake.exe --build . --target install --config release || exit \b 1
 cd ..

--- a/ci/windows/prepare.cmd
+++ b/ci/windows/prepare.cmd
@@ -5,5 +5,3 @@ wmic cpu get NumberOfCores, NumberOfLogicalProcessors/Format:List
 systeminfo
 dir C:
 choco list --localonly
-cmake --version
-cmake --help

--- a/ci/windows/test.cmd
+++ b/ci/windows/test.cmd
@@ -1,3 +1,4 @@
+:: See build.cmd for documentation on this call.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 
 cd build

--- a/ci/windows/test.cmd
+++ b/ci/windows/test.cmd
@@ -1,2 +1,4 @@
+call "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+
 cd build
 ctest -C release || exit \b 1

--- a/include/broker/address.hh
+++ b/include/broker/address.hh
@@ -14,7 +14,7 @@ class address : detail::comparable<address> {
 public:
   static constexpr size_t num_bytes = 16;
 
-  struct impl;
+  using array_type = std::array<uint8_t, num_bytes>;
 
   /// Distinguishes between address types.
   enum class family : uint8_t {
@@ -32,8 +32,6 @@ public:
 
   address(const address&) noexcept;
 
-  explicit address(const impl*) noexcept;
-
   /// Construct an address from raw bytes.
   /// @param bytes A pointer to the raw representation.  This must point
   /// to 4 bytes if *fam* is `family::ipv4` and 16 bytes for `family::ipv6`.
@@ -42,8 +40,6 @@ public:
   address(const uint32_t* bytes, family fam, byte_order order);
 
   address& operator=(const address&) noexcept;
-
-  ~address();
 
   /// Mask out lower bits of the address.
   /// @param top_bits_to_keep The number of bits to *not* mask out, counting
@@ -64,11 +60,15 @@ public:
 
   /// @returns the raw bytes of the address in network order. For IPv4
   /// addresses, this uses the IPv4-mapped IPv6 address representation.
-  std::array<uint8_t, 16>& bytes();
+  array_type& bytes() noexcept {
+    return bytes_;
+  }
 
   /// @returns the raw bytes of the address in network order. For IPv4
   /// addresses, this uses the IPv4-mapped IPv6 address representation.
-  const std::array<uint8_t, 16>& bytes() const;
+  const std::array<uint8_t, 16>& bytes() const noexcept {
+    return bytes_;
+  }
 
   [[nodiscard]] int compare(const address& other) const noexcept;
 
@@ -78,14 +78,8 @@ public:
 
   [[nodiscard]] bool convert_from(const std::string& str);
 
-  /// Returns a pointer to the native representation.
-  [[nodiscard]] impl* native_ptr() noexcept;
-
-  /// Returns a pointer to the native representation.
-  [[nodiscard]] const impl* native_ptr() const noexcept;
-
 private:
-  std::byte obj_[num_bytes];
+  array_type bytes_;
 };
 
 /// @relates address

--- a/include/broker/detail/pp.hh
+++ b/include/broker/detail/pp.hh
@@ -8,7 +8,7 @@
 
 #define BROKER_PP_PASTE(x, y) BROKER_PP_CAT(x, y)
 
-#ifdef _MSVC_VER
+#ifdef _MSC_VER
 
 #define BROKER_PP_SIZE(...)                                                    \
   BROKER_PP_PASTE(                                                             \
@@ -19,7 +19,7 @@
                      11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, ),                     \
     BROKER_PP_EMPTY())
 
-#else // _MSVC_VER
+#else // _MSC_VER
 
 #define BROKER_PP_SIZE(...)                                                    \
   BROKER_PP_SIZE_I(__VA_ARGS__, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54,    \

--- a/include/broker/internal/generator_file_reader.hh
+++ b/include/broker/internal/generator_file_reader.hh
@@ -23,10 +23,16 @@ public:
 
   using mapped_pointer = void*;
 
+#ifdef BROKER_WINDOWS
+  using file_handle_type = void*;
+#else
+  using file_handle_type = detail::native_socket;
+#endif
+
   using read_raw_callback
     = std::function<bool(value_type*, caf::span<const caf::byte>)>;
 
-  generator_file_reader(detail::native_socket fd, mapper_handle mapper,
+  generator_file_reader(file_handle_type fd, mapper_handle mapper,
                         mapped_pointer addr, size_t file_size);
 
   generator_file_reader(generator_file_reader&&) = delete;
@@ -71,7 +77,7 @@ public:
   }
 
 private:
-  detail::native_socket fd_;
+  file_handle_type fd_;
   mapper_handle mapper_;
   mapped_pointer addr_;
   size_t file_size_;

--- a/include/broker/internal/metric_exporter.hh
+++ b/include/broker/internal/metric_exporter.hh
@@ -60,7 +60,7 @@ public:
   }
 
   caf::behavior make_behavior() {
-    BROKER_ASSERT(core != nullptr);
+    BROKER_ASSERT(core);
     self->monitor(core);
     self->set_down_handler([this](const caf::down_msg& down) {
       if (down.source == core) {

--- a/include/broker/internal/native.hh
+++ b/include/broker/internal/native.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "broker/address.hh"
 #include "broker/endpoint_id.hh"
 #include "broker/error.hh"
 #include "broker/status.hh"
@@ -8,7 +7,6 @@
 
 #include <caf/actor.hpp>
 #include <caf/error.hpp>
-#include <caf/ip_address.hpp>
 #include <caf/node_id.hpp>
 
 // Generates the necessary boilerplate code for `native` to work.
@@ -30,7 +28,6 @@ template <class Facade>
 struct conversion_oracle;
 
 BROKER_MAP_CAF_TYPE(caf::error, error)
-BROKER_MAP_CAF_TYPE(caf::ip_address, address)
 BROKER_MAP_CAF_TYPE(caf::node_id, endpoint_id)
 BROKER_MAP_CAF_TYPE(caf::actor, worker)
 

--- a/include/broker/worker.hh
+++ b/include/broker/worker.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "broker/detail/comparable.hh"
+#include "broker/config.hh"
 
 #include <cstddef>
 #include <functional>
@@ -15,6 +16,16 @@ public:
   // -- member types -----------------------------------------------------------
 
   struct impl;
+
+  // -- constants --------------------------------------------------------------
+
+#ifdef BROKER_WINDOWS
+  static constexpr size_t obj_size = sizeof(impl*) * 2;
+#else
+  static constexpr size_t obj_size = sizeof(impl*);
+#endif
+
+  // --- construction and destruction ------------------------------------------
 
   worker() noexcept;
 
@@ -64,7 +75,7 @@ public:
   [[nodiscard]] const impl* native_ptr() const noexcept;
 
 private:
-  std::byte obj_[sizeof(impl*)];
+  std::byte obj_[obj_size];
 };
 
 inline bool operator==(const worker& hdl, std::nullptr_t) {

--- a/src/address.cc
+++ b/src/address.cc
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "broker/config.hh"
-#include "broker/internal/native.hh"
 
 #include <caf/detail/network_order.hpp>
 #include <caf/hash/fnv.hpp>
@@ -17,11 +16,8 @@
 
 namespace broker {
 
-static_assert(sizeof(caf::ip_address) == address::num_bytes);
-
 namespace {
 
-using internal::native;
 using native_t = caf::ip_address;
 
 static constexpr bool is_little_endian =
@@ -36,9 +32,9 @@ constexpr std::array<uint8_t, 12> v4_mapped_prefix
 
 auto to_array(const uint32_t* bytes, address::family fam,
               address::byte_order order) {
-  static constexpr size_t bytes_size = native_t::num_bytes / sizeof(uint32_t);
+  static constexpr size_t bytes_size = address::num_bytes / sizeof(uint32_t);
   using std::make_reverse_iterator;
-  native_t::array_type result;
+  address::array_type result;
   if (fam == address::family::ipv4) {
     auto dst = std::copy(v4_mapped_prefix.begin(), v4_mapped_prefix.end(),
                          result.begin());
@@ -66,7 +62,7 @@ auto to_array(const uint32_t* bytes, address::family fam,
       }
     }
     auto first = reinterpret_cast<const uint8_t*>(bytes);
-    auto last = first + native_t::num_bytes;
+    auto last = first + address::num_bytes;
     std::copy(first, last, result.begin());
   }
   return result;
@@ -75,27 +71,20 @@ auto to_array(const uint32_t* bytes, address::family fam,
 } // namespace
 
 address::address() noexcept {
-  new (obj_) native_t();
+  memset(bytes_.data(), 0, num_bytes);
 }
 
-address::address(const address& other) noexcept {
-  new (obj_) native_t(native(other));
-}
-address::address(const impl* other) noexcept {
-  new (obj_) native_t(native(other));
+address::address(const address& other) noexcept : bytes_(other.bytes_) {
+  // nop
 }
 
 address::address(const uint32_t* bytes, family fam, byte_order order) {
-  new (obj_) native_t(to_array(bytes, fam, order));
+  bytes_ = to_array(bytes, fam, order);
 }
 
 address& address::operator=(const address& other) noexcept {
-  native(*this) = native(other);
+  bytes_ = other.bytes_;
   return *this;
-}
-
-address::~address() {
-  native(*this).~native_t();
 }
 
 static uint32_t bit_mask32(int bottom_bits) {
@@ -121,43 +110,30 @@ bool address::mask(uint8_t top_bits_to_keep) {
 }
 
 bool address::is_v4() const noexcept {
-  return native(*this).embeds_v4();
-}
-
-std::array<uint8_t, 16>& address::bytes() {
-  return native(*this).bytes();
-}
-
-const std::array<uint8_t, 16>& address::bytes() const {
-  return native(*this).bytes();
+  return native_t{bytes_}.embeds_v4();
 }
 
 int address::compare(const address& other) const noexcept {
-  return native(*this).compare(native(other));
+  return memcmp(bytes_.data(), other.bytes_.data(), num_bytes);
 }
 
 size_t address::hash() const {
-  return caf::hash::fnv<size_t>::compute(native(*this));
+  return caf::hash::fnv<size_t>::compute(bytes_);
 }
 
 bool address::convert_to(std::string& str) const {
-  str = to_string(native(*this));
+  str = to_string(native_t{bytes_});
   return true;
 }
 
 bool address::convert_from(const std::string& str) {
-  if (auto err = caf::parse(str, native(*this)))
+  native_t tmp;
+  if (auto err = caf::parse(str, tmp)) {
+    bytes_ = tmp.bytes();
     return false;
-  else
+  } else {
     return true;
-}
-
-address::impl* address::native_ptr() noexcept {
-  return reinterpret_cast<impl*>(obj_);
-}
-
-const address::impl* address::native_ptr() const noexcept {
-  return reinterpret_cast<const impl*>(obj_);
+  }
 }
 
 } // namespace broker

--- a/src/address.cc
+++ b/src/address.cc
@@ -129,9 +129,9 @@ bool address::convert_to(std::string& str) const {
 bool address::convert_from(const std::string& str) {
   native_t tmp;
   if (auto err = caf::parse(str, tmp)) {
-    bytes_ = tmp.bytes();
     return false;
   } else {
+    bytes_ = tmp.bytes();
     return true;
   }
 }

--- a/src/config.hh.in
+++ b/src/config.hh.in
@@ -20,8 +20,8 @@
     #endif
 #endif
 
-// FreeBSD doesn't support LeakSanitizer
-#if defined(BROKER_ASAN) && !defined(__FreeBSD__)
+// FreeBSD and Windows don't support LeakSanitizer
+#if defined(BROKER_ASAN) && !defined(__FreeBSD__) && !defined(_WIN32)
     #include <sanitizer/lsan_interface.h>
     #define BROKER_LSAN_CHECK(x) __lsan_do_leak_check(x)
     #define BROKER_LSAN_ENABLE() __lsan_enable()

--- a/src/internal/generator_file_reader.cc
+++ b/src/internal/generator_file_reader.cc
@@ -107,7 +107,7 @@ void* make_file_view(void* addr, size_t) {
 
 namespace broker::internal {
 
-generator_file_reader::generator_file_reader(detail::native_socket fd,
+generator_file_reader::generator_file_reader(file_handle_type fd,
                                              mapper_handle mapper,
                                              mapped_pointer addr,
                                              size_t file_size)

--- a/src/internal/metric_view.cc
+++ b/src/internal/metric_view.cc
@@ -1,5 +1,7 @@
 #include "broker/internal/metric_view.hh"
 
+#include <algorithm>
+
 namespace broker::internal {
 
 metric_view::metric_view(const vector* row)

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -15,7 +15,7 @@ using native_t = caf::actor;
 
 } // namespace
 
-static_assert(sizeof(worker::impl*) == sizeof(caf::actor));
+static_assert(worker::obj_size >= sizeof(caf::actor));
 
 worker::worker() noexcept {
   new (obj_) native_t();


### PR DESCRIPTION
This PR reworks all of the CI scripts for Windows builds to properly produce a build. The biggest change is the switch using the versions of CMake and Ninja that can be installed via MSVC.

Note that the build currently fails, but that issue is being tracked via #213.