### PR TITLE
Additional tweaks to Broker's Python bindings for unhashable types

### DIFF
--- a/bindings/python/broker/__init__.py
+++ b/bindings/python/broker/__init__.py
@@ -608,13 +608,25 @@ class Data(_broker.Data):
 
 class ImmutableData(Data):
     """A Data specialization that uses immutable complex types for returned Python
-    objects. For sets, the return type is frozenset, for tables it's a
-    MappingProxyType of a dict with a straightforward hashing implementation,
-    and for vectors it's Python tuples."""
-
-    class HashableDict(dict):
+    objects. For sets, the return type is frozenset, for tables it's a hashable,
+    read-only derivative of dict, and for vectors it's Python tuples.
+    """
+    class HashableReadOnlyDict(dict):
         def __hash__(self):
             return hash(frozenset(self.items()))
+
+        def __readonly__(self, *args, **kwargs):
+            raise TypeError('cannot modify this dict')
+
+        # https://stackoverflow.com/a/31049908
+        __setitem__ = __readonly__
+        __delitem__ = __readonly__
+        pop = __readonly__
+        popitem = __readonly__
+        clear = __readonly__
+        update = __readonly__
+        setdefault = __readonly__
+        del __readonly__
 
     @staticmethod
     def to_py(d):
@@ -623,7 +635,10 @@ class ImmutableData(Data):
 
         def to_table(t):
             tmp = {ImmutableData.to_py(k): ImmutableData.to_py(v) for (k, v) in t.items()}
-            return types.MappingProxyType(ImmutableData.HashableDict(tmp.items()))
+            # It's tempting here to use types.MappingProxyType here, but it is
+            # not hashable, so doesn't solve our main problem, and cannot be
+            # derived from.
+            return ImmutableData.HashableReadOnlyDict(tmp.items())
 
         def to_vector(v):
             return tuple(ImmutableData.to_py(i) for i in v)

--- a/bindings/python/broker/zeek.py
+++ b/bindings/python/broker/zeek.py
@@ -17,3 +17,18 @@ class Event(_broker.zeek.Event):
 
     def args(self):
         return [broker.Data.to_py(a) for a in _broker.zeek.Event.args(self)]
+
+# Similar to the Subscriber vs SafeSubscriber specialization, this is an event
+# specialization that is robust to Python's limitations regarding hashable
+# types. If you are working with Zeek types that Python cannot naturally
+# repesent (for example, sets of tables, or sets of records with table fields),
+# then you want to use this instead of the above Event (and SafeSubscriber
+# instead of the regular Subscriber). If you do not, you might hit things like
+#
+#    File "...python/broker/__init__.py", line 549, in to_set
+#        return set([Data.to_py(i) for i in s])
+#    TypeError: unhashable type: 'dict'
+#
+class SafeEvent(Event):
+    def args(self):
+        return [broker.ImmutableData.to_py(a) for a in _broker.zeek.Event.args(self)]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ if (BROKER_PYTHON_BINDINGS)
 
   if (ZEEK_FOUND)
     make_python_test(zeek)
+    make_python_test(zeek-unsafe-types)
   endif ()
 
   make_python_test(communication)

--- a/tests/python/zeek-unsafe-types.py
+++ b/tests/python/zeek-unsafe-types.py
@@ -1,0 +1,90 @@
+from __future__ import print_function
+import unittest
+import multiprocessing
+
+import broker
+
+from zeek_common import run_zeek_path, run_zeek
+
+ZeekHello = """
+redef Broker::default_connect_retry=1secs;
+redef Broker::default_listen_retry=1secs;
+redef exit_only_after_terminate = T;
+
+type Container: record {
+    config: table[string] of string &default=table();
+};
+
+type Containers: record {
+    containers: set[Container] &default=set();
+};
+
+global hello: event(cs: Containers);
+
+event zeek_init()
+    {
+    Broker::subscribe("/test");
+    Broker::peer("127.0.0.1", __PORT__/tcp);
+    }
+
+event Broker::peer_added(endpoint: Broker::EndpointInfo, s: string)
+    {
+    local container = Container($config = table(["foo"] = "bar"));
+    local containers = Containers($containers=set(container));
+
+    Broker::publish("/test", hello, containers);
+    }
+
+event Broker::peer_lost(endpoint: Broker::EndpointInfo, msg: string)
+    {
+    terminate();
+    }
+"""
+
+class TestCommunication(unittest.TestCase):
+    def test_regular(self):
+        with broker.Endpoint() as ep, \
+             ep.make_subscriber("/test") as sub:
+
+            port = ep.listen("127.0.0.1", 0)
+
+            p = multiprocessing.Process(target=run_zeek, args=(ZeekHello, port))
+            p.daemon = True
+            p.start()
+
+            # With a regular subscriber, retrieving the hello event
+            # will lead to a TypeError since it contains a set of tables:
+            with self.assertRaises(TypeError) as ctx:
+                t, msg = sub.get()
+
+            self.assertEquals(str(ctx.exception), "unhashable type: 'dict'")
+
+    def test_safe(self):
+        with broker.Endpoint() as ep, \
+             ep.make_safe_subscriber("/test") as sub:
+
+            port = ep.listen("127.0.0.1", 0)
+
+            p = multiprocessing.Process(target=run_zeek, args=(ZeekHello, port))
+            p.daemon = True
+            p.start()
+
+            # With a SafeSubscriber, the retrieval works because we now use
+            # ImmutableData under the hood:
+            t, msg = sub.get()
+
+            # The broker.zeek.Event class has a similar problem, since it uses
+            # broker.Data to render Broker data:
+            with self.assertRaises(TypeError) as ctx:
+                ev = broker.zeek.Event(msg)
+                args = ev.args()
+
+            self.assertEquals(str(ctx.exception), "unhashable type: 'dict'")
+
+            # broker.zeek.SafeEvent uses broker.ImmutableData, so can access
+            # the arguments safely:
+            ev = broker.zeek.SafeEvent(msg)
+            args = ev.args()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=3)

--- a/tests/python/zeek_common.py
+++ b/tests/python/zeek_common.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import tempfile
+
+def run_zeek_path():
+    base = os.path.realpath(__file__)
+    for d in (os.path.join(os.path.dirname(base), "../../build"), os.getcwd()):
+        run_zeek_script = os.path.abspath(os.path.join(d, "tests/python/run-zeek"))
+        if os.path.exists(run_zeek_script):
+            return run_zeek_script
+
+    return "zeek" # Hope for the best ...
+
+def run_zeek(script, port):
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".zeek", delete=False) as tmp:
+            print(script.replace("__PORT__", str(port)), file=tmp)
+            tmp.close()
+            subprocess.check_call([run_zeek_path(), "-b", "-B", "broker", tmp.name])
+        return True
+    except subprocess.CalledProcessError:
+        return False


### PR DESCRIPTION
I realized that the previous expansion, adding `ImmutableData`, wasn't quite right. This switches `ImmutableData` away from using `types.MappingProxyType` for dicts since it too isn't hashable, and adds a `broker.zeek.SafeEvent` specialization for `broker.zeek.Event` that uses `ImmutableData`. This is a bit clunky since it leaves the decision as to which variants to use to the user, but it does work.

Includes a Zeek-using test that uses complex data structures on the Zeek side.