### PR TITLE
Drop broken FreeBSD 11 build from pipeline

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -208,17 +208,6 @@ freebsd12_task:
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
-freebsd11_task:
-  freebsd_instance:
-    # FreeBSD 11 EOL: September 30, 2021
-    image_family: freebsd-11-4
-    cpu: 8
-    # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
-    memory: 8GB
-  prepare_script: ./ci/freebsd/prepare.sh
-  << : *CI_TEMPLATE
-  << : *UNIX_ENV
-
 memcheck_task:
   container:
     # Just uses a recent/common distro to run memory error/leak checks.


### PR DESCRIPTION
FreeBSD 11 is EOL and we've dropped it from the Zeek CI already.