### PR TITLE
Remove deprecated std::iterator usage

### DIFF
--- a/include/broker/detail/radix_tree.hh
+++ b/include/broker/detail/radix_tree.hh
@@ -75,10 +75,13 @@ public:
   using value_type = std::pair<const key_type, mapped_type>;
   using size_type = size_t;
 
-  class iterator : public std::iterator<std::forward_iterator_tag, value_type> {
+  class iterator {
     friend class radix_tree;
 
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = radix_tree<T, N>::value_type;
+    using difference_type = std::ptrdiff_t;
     using reference = value_type&;
     using pointer = value_type*;
 


### PR DESCRIPTION
I'm getting the following warnings when building the tests on macOS:

```
[427/449] Building CXX object tests/CMakeFiles/broker-test.dir/cpp/radix_tree.cc.o
In file included from /Users/tim/Desktop/projects/broker/tests/cpp/radix_tree.cc:3:
/Users/tim/Desktop/projects/broker/include/broker/detail/radix_tree.hh:78:32: warning: 'iterator<std::forward_iterator_tag, std::pair<const std::string, int>>' is deprecated [-Wdeprecated-declarations]
  class iterator : public std::iterator<std::forward_iterator_tag, value_type> {
                               ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/deque:283:34: note: in instantiation of member class 'broker::detail::radix_tree<int, 10>::iterator' requested here
  static const _DiffType value = sizeof(_ValueType) < 256 ? 4096 / sizeof(_ValueType) : 16;
                                 ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/deque:293:32: note: in instantiation of template class 'std::__deque_block_size<broker::detail::radix_tree<int, 10>::iterator, long>' requested here
                               __deque_block_size<_ValueType, _DiffType>::value
                               ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/deque:960:13: note: in instantiation of default argument for '__deque_iterator<broker::detail::radix_tree<int, 10>::iterator, broker::detail::radix_tree<int, 10>::iterator *, broker::detail::radix_tree<int, 10>::iterator &, broker::detail::radix_tree<int, 10>::iterator **, long>' required here
    typedef __deque_iterator<value_type, pointer, reference, __map_pointer,
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/deque:1273:15: note: in instantiation of template class 'std::__deque_base<broker::detail::radix_tree<int, 10>::iterator, std::allocator<broker::detail::radix_tree<int, 10>::iterator>>' requested here
    : private __deque_base<_Tp, _Allocator>
              ^
/Users/tim/Desktop/projects/broker/tests/cpp/radix_tree.cc:21:51: note: in instantiation of template class 'std::deque<broker::detail::radix_tree<int, 10>::iterator>' requested here
bool check_match(deque<test_radix_tree::iterator> matches,
                                                  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__iterator/iterator.h:27:29: note: 'iterator<std::forward_iterator_tag, std::pair<const std::string, int>>' has been explicitly marked deprecated here
struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 iterator
                            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__config:1066:39: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
#  define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__config:1043:48: note: expanded from macro '_LIBCPP_DEPRECATED'
#    define _LIBCPP_DEPRECATED __attribute__ ((deprecated))
                                               ^
In file included from /Users/tim/Desktop/projects/broker/tests/cpp/radix_tree.cc:3:
/Users/tim/Desktop/projects/broker/include/broker/detail/radix_tree.hh:78:32: warning: 'iterator<std::forward_iterator_tag, std::pair<const std::string, void *>>' is deprecated [-Wdeprecated-declarations]
  class iterator : public std::iterator<std::forward_iterator_tag, value_type> {
                               ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__utility/pair.h:50:9: note: in instantiation of member class 'broker::detail::radix_tree<void *, 10>::iterator' requested here
    _T1 first;
        ^
/Users/tim/Desktop/projects/broker/tests/cpp/radix_tree.cc:91:12: note: in instantiation of template class 'std::pair<broker::detail::radix_tree<void *, 10>::iterator, bool>' requested here
  CHECK(rt.insert({string(key1, key1 + 299), key1}).second);
           ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__iterator/iterator.h:27:29: note: 'iterator<std::forward_iterator_tag, std::pair<const std::string, void *>>' has been explicitly marked deprecated here
struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 iterator
                            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__config:1066:39: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
#  define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__config:1043:48: note: expanded from macro '_LIBCPP_DEPRECATED'
#    define _LIBCPP_DEPRECATED __attribute__ ((deprecated))
                                               ^
2 warnings generated.
```

`std::iterator` was deprecated in C++17 in favor of using type traits directly in the class. This PR replaces `std::iterator` with said traits.