### PR TITLE
Fix minor Coverity findings

### DIFF
--- a/include/broker/configuration.hh
+++ b/include/broker/configuration.hh
@@ -44,7 +44,7 @@ struct broker_options {
   bool ignore_broker_conf = false;
 
   /// How many hops we forward at the most before dropping a message.
-  uint16_t ttl = 16;
+  uint16_t ttl = defaults::ttl;
 
   broker_options() = default;
 
@@ -181,7 +181,7 @@ public:
   std::enable_if_t<std::is_integral_v<T>> set(std::string key, T val) {
     if constexpr (std::is_same_v<T, bool>)
       set_bool(std::move(key), val);
-    if constexpr (std::is_signed_v<T>)
+    else if constexpr (std::is_signed_v<T>)
       set_i64(std::move(key), val);
     else
       set_u64(std::move(key), val);

--- a/include/broker/defaults.hh
+++ b/include/broker/defaults.hh
@@ -10,6 +10,8 @@
 
 namespace broker::defaults {
 
+constexpr uint16_t ttl = 16;
+
 constexpr std::string_view recording_directory = "";
 
 constexpr size_t output_generator_file_cap = std::numeric_limits<size_t>::max();

--- a/include/broker/internal/metric_exporter.hh
+++ b/include/broker/internal/metric_exporter.hh
@@ -25,7 +25,7 @@ namespace broker::internal {
 /// before actually spawning an exporter.
 struct metric_exporter_params {
   std::vector<std::string> selected_prefixes;
-  caf::timespan interval;
+  caf::timespan interval = caf::timespan{0};
   topic target;
   std::string id;
   static metric_exporter_params from(const caf::actor_system_config& cfg);

--- a/include/broker/store_event.hh
+++ b/include/broker/store_event.hh
@@ -54,7 +54,7 @@ public:
       return xs_ != nullptr;
     }
 
-    const std::string& store_id() const noexcept {
+    const std::string& store_id() const {
       return get<std::string>((*xs_)[1]);
     }
 

--- a/src/error.cc
+++ b/src/error.cc
@@ -278,15 +278,22 @@ bool convert(const data& src, error& dst) {
 }
 
 ec error_view::code() const noexcept {
-  return get_as<ec>((*xs_)[1]);
+  auto result = ec::unspecified;
+  std::ignore = convert((*xs_)[1], result);
+  return result;
 }
 
 const std::string* error_view::message() const noexcept {
   if (is<none>((*xs_)[2]))
     return nullptr;
-  auto& ctx = get<vector>((*xs_)[2]);
-  return ctx.size() == 1 ? &get<std::string>(ctx[0])
-                         : &get<std::string>(ctx[1]);
+  auto try_get_str = [](const vector& vec, size_t index) {
+    return vec.size() > index ? get_if<std::string>(vec[index]) : nullptr;
+  };
+  if (auto ctx = get_if<vector>((*xs_)[2]); !ctx) {
+    return nullptr;
+  } else {
+    return try_get_str(*ctx, ctx->size() == 1 ? 0 : 1);
+  }
 }
 
 std::optional<endpoint_info> error_view::context() const {

--- a/src/internal/core_actor.cc
+++ b/src/internal/core_actor.cc
@@ -66,6 +66,7 @@ core_actor_state::core_actor_state(caf::event_based_actor* self,
                                         on_peer_unavailable, filter,
                                         peer_statuses));
   }
+  ttl = caf::get_or(self->config(),"broker.ttl", defaults::ttl);
 }
 
 core_actor_state::~core_actor_state() {

--- a/src/internal/metric_view.cc
+++ b/src/internal/metric_view.cc
@@ -65,23 +65,25 @@ bool metric_view::get_type(const vector& row,
     return true;
   };
   static constexpr bool bad = false;
-  const auto& t = broker::get<std::string>(row[index(field::type)]);
+  const auto* t = broker::get_if<std::string>(row[index(field::type)]);
   const auto& v = row[index(field::value)];
-  if (t == "counter") {
+  if (!t) {
+    return bad;
+  } else if (*t == "counter") {
     if (is<integer>(v))
       return good(metric_type::int_counter);
     else if (is<real>(v))
       return good(metric_type::dbl_counter);
     else
       return bad;
-  } else if (t == "gauge") {
+  } else if (*t == "gauge") {
     if (is<integer>(v))
       return good(metric_type::int_gauge);
     else if (is<real>(v))
       return good(metric_type::dbl_gauge);
     else
       return bad;
-  } else if (t == "histogram") {
+  } else if (*t == "histogram") {
     if (auto vals = get_if<vector>(v); vals && vals->size() >= 2) {
       if (std::all_of(vals->begin(), vals->end() - 1, pair_predicate<integer>{})
           && is<integer>(vals->back()))

--- a/src/status.cc
+++ b/src/status.cc
@@ -127,9 +127,9 @@ std::string to_string(status_view x) {
 }
 
 bool convertible_to_status(const vector& xs) noexcept {
-  if (xs.size() != 4 || !is<std::string>(xs[0]))
+  if (xs.size() != 4)
     return false;
-  if (get<std::string>(xs[0]) != "status")
+  if (auto str = get_if<std::string>(xs[0]); !str || *str != "status")
     return false;
   if (auto code = to<sc>(xs[1]))
     return *code != sc::unspecified
@@ -186,7 +186,8 @@ const std::string* status_view::message() const noexcept {
   BROKER_ASSERT(xs_ != nullptr);
   if (is<none>((*xs_)[3]))
     return nullptr;
-  return &get<std::string>((*xs_)[3]);
+  else
+    return get_if<std::string>((*xs_)[3]);
 }
 
 std::optional<endpoint_info> status_view::context() const {

--- a/src/store.cc
+++ b/src/store.cc
@@ -52,7 +52,7 @@ public:
       name(std::move(name)),
       frontend(std::move(frontend_hdl)),
       self(frontend->home_system()) {
-    BROKER_DEBUG("created state for store" << name);
+    BROKER_DEBUG("created state for store" << this->name);
   }
 
   ~state_impl() {


### PR DESCRIPTION
Not initializing the `ttl` member was the most critical issue coming out of Coverity. Also cleaning up some findings about using throwing functions on `std::variant` in `noexcept` functions.

It seems like Coverity generally fails to recognize initialization via placement new, so there are lots of findings in the CAF wrapper types. Ideally, we'd avoid the placement new stuff entirely but requires some CAF changes (at least for the `error` wrapper). I'll look into that later since these findings seemed more urgent.