### PR TITLE
Dockerfile updates for consistency with recent Zeek changes

### DIFF
--- a/ci/centos-7/Dockerfile
+++ b/ci/centos-7/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:7
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 # Disabled lookup of fastest mirror since the list seems to be outdated and no valid mirror can be detected.
 RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
 
@@ -23,15 +27,15 @@ RUN yum -y install \
     devtoolset-8 \
   && yum clean all && rm -rf /var/cache/yum
 
-RUN yum install -y \
+RUN yum -y install \
     cmake3 \
     diffutils \
     make \
+    openssl \
     openssl-devel \
     python3 \
     python3-devel \
-    && yum clean all \
-    && rm -rf /var/cache/yum
+  && yum clean all && rm -rf /var/cache/yum
 
 RUN echo 'unset BASH_ENV PROMPT_COMMAND ENV' > /usr/bin/zeek-ci-env && \
     echo 'source /opt/rh/devtoolset-8/enable' >> /usr/bin/zeek-ci-env && \

--- a/ci/centos-stream-8/Dockerfile
+++ b/ci/centos-stream-8/Dockerfile
@@ -1,14 +1,18 @@
 FROM quay.io/centos/centos:stream8
 
-RUN dnf install -y \
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN dnf -y install \
     cmake \
     diffutils \
     gcc \
     gcc-c++ \
     git \
     make \
+    openssl \
     openssl-devel \
     python3 \
     python3-devel \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -1,14 +1,18 @@
 FROM quay.io/centos/centos:stream9
 
-RUN dnf install -y \
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN dnf -y install \
     cmake \
     diffutils \
     gcc \
     gcc-c++ \
     git \
     make \
+    openssl \
     openssl-devel \
     python3 \
     python3-devel \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/debian-10/Dockerfile
+++ b/ci/debian-10/Dockerfile
@@ -1,21 +1,27 @@
 FROM debian:10
 
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"
 ENV PATH "${CMAKE_DIR}/bin:${PATH}"
 
-RUN apt update -y \
-    && apt install -y \
-       curl \
-       g++ \
-       gcc \
-       git \
-       libssl-dev \
-       make \
-       python3 \
-       python3-dev \
-    && apt autoclean \
-    && rm -rf /var/lib/apt/lists/* \
-    # Install a recent CMake to build Spicy.
-    && mkdir -p "${CMAKE_DIR}" \
-    && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
+RUN apt-get update && apt-get -y install \
+    curl \
+    g++ \
+    gcc \
+    git \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install a recent CMake to build Spicy.
+RUN mkdir -p "${CMAKE_DIR}" \
+  && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -1,15 +1,20 @@
 FROM debian:11
 
-RUN apt update -y \
-    && apt install -y \
-       cmake \
-       g++ \
-       gcc \
-       git \
-       libssl-dev \
-       make \
-       python3 \
-       python3-dev \
-       python3-pip \
-    && apt autoclean \
-    && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN apt-get update && apt-get -y install \
+    cmake \
+    g++ \
+    gcc \
+    git \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+    python3-pip \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*

--- a/ci/debian-9-32bit/Dockerfile
+++ b/ci/debian-9-32bit/Dockerfile
@@ -1,25 +1,31 @@
 FROM i386/debian:9
 
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"
 ENV PATH "${CMAKE_DIR}/bin:${PATH}"
 
-RUN apt update -y \
-    && apt install -y \
-       curl \
-       clang-7 \
-       git \
-       libc++-7-dev \
-       libc++abi-7-dev \
-       libssl-dev \
-       make \
-       python3 \
-       python3-dev \
-    && apt autoclean \
-    && rm -rf /var/lib/apt/lists/* \
-    # Recent CMake.
-    && mkdir -p "${CMAKE_DIR}" \
-    && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
+RUN apt-get update && apt-get -y install \
+    clang-7 \
+    curl \
+    git \
+    libc++-7-dev \
+    libc++abi-7-dev \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Recent CMake.
+RUN mkdir -p "${CMAKE_DIR}" \
+  && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
 
 RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100

--- a/ci/debian-9/Dockerfile
+++ b/ci/debian-9/Dockerfile
@@ -1,26 +1,33 @@
 FROM debian:9
 
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"
 ENV PATH "${CMAKE_DIR}/bin:${PATH}"
 
-RUN apt update -y \
-    && apt install -y \
-       curl \
-       clang-7 \
-       git \
-       libc++-7-dev \
-       libc++abi-7-dev \
-       libssl-dev \
-       make \
-       python3 \
-       python3-dev \
-    && apt autoclean \
-    && rm -rf /var/lib/apt/lists/* \
-    # Recent CMake.
-    && mkdir -p "${CMAKE_DIR}" \
-    && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
+RUN apt-get update && apt-get -y install \
+    clang-7 \
+    curl \
+    git \
+    libc++-7-dev \
+    libc++abi-7-dev \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*
 
-ENV CC=/usr/bin/clang-7
-ENV CXX=/usr/bin/clang++-7
+# Recent CMake.
+RUN mkdir -p "${CMAKE_DIR}" \
+  && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
+
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100
+
 ENV CXXFLAGS=-stdlib=libc++

--- a/ci/fedora-34/Dockerfile
+++ b/ci/fedora-34/Dockerfile
@@ -1,6 +1,10 @@
 FROM fedora:34
 
-RUN dnf install -y \
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN dnf -y install \
     cmake \
     gcc \
     gcc-c++ \
@@ -10,5 +14,4 @@ RUN dnf install -y \
     openssl-devel \
     python3 \
     python3-devel \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/fedora-35/Dockerfile
+++ b/ci/fedora-35/Dockerfile
@@ -1,6 +1,10 @@
 FROM fedora:35
 
-RUN dnf install -y \
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN dnf -y install \
     cmake \
     diffutils \
     gcc \
@@ -11,5 +15,4 @@ RUN dnf install -y \
     openssl-devel \
     python3 \
     python3-devel \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/opensuse-leap-15.3/Dockerfile
+++ b/ci/opensuse-leap-15.3/Dockerfile
@@ -1,12 +1,16 @@
 FROM opensuse/leap:15.3
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN zypper in -y \
-  cmake \
-  gcc \
-  gcc-c++ \
-  git \
-  make \
-  python3 \
-  python3-devel \
-  libopenssl-devel \
+    cmake \
+    gcc \
+    gcc-c++ \
+    git \
+    libopenssl-devel \
+    make \
+    python3 \
+    python3-devel \
   && rm -rf /var/cache/zypp

--- a/ci/ubuntu-18.04/Dockerfile
+++ b/ci/ubuntu-18.04/Dockerfile
@@ -1,25 +1,31 @@
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"
 ENV PATH "${CMAKE_DIR}/bin:${PATH}"
 
-RUN apt update -y \
-    && apt install -y \
-       curl \
-       diffutils \
-       g++-8 \
-       gcc-8 \
-       git \
-       libssl-dev \
-       make \
-       python3 \
-       python3-dev \
-    && apt-get autoclean \
-    && rm -rf /var/lib/apt/lists/* \
-    # Recent CMake.
-    && mkdir -p "${CMAKE_DIR}" \
-    && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
+RUN apt-get update && apt-get -y install \
+    curl \
+    diffutils \
+    g++-8 \
+    gcc-8 \
+    git \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+  && apt-get autoclean \
+  && rm -rf /var/lib/apt/lists/*
 
-ENV CC=/usr/bin/gcc-8
-ENV CXX=/usr/bin/g++-8
+# Recent CMake.
+RUN mkdir -p "${CMAKE_DIR}" \
+  && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
+
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 100

--- a/ci/ubuntu-20.04/Dockerfile
+++ b/ci/ubuntu-20.04/Dockerfile
@@ -1,13 +1,18 @@
 FROM ubuntu:20.04
 
-RUN apt update -y \
-    && DEBIAN_FRONTEND="noninteractive" apt install -y \
-       cmake \
-       g++ \
-       git \
-       libssl-dev \
-       make \
-       python3 \
-       python3-dev \
-    && apt autoclean \
-    && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN apt-get update && apt-get -y install \
+    cmake \
+    g++ \
+    git \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*

--- a/ci/ubuntu-21.10/Dockerfile
+++ b/ci/ubuntu-21.10/Dockerfile
@@ -1,13 +1,18 @@
 FROM ubuntu:21.10
 
-RUN apt update -y \
-    && DEBIAN_FRONTEND="noninteractive" apt install -y \
-       cmake \
-       g++ \
-       git \
-       libssl-dev \
-       make \
-       python3 \
-       python3-dev \
-    && apt autoclean \
-    && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN apt-get update && apt-get -y install \
+    cmake \
+    g++ \
+    git \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This the broker counterpart to https://github.com/zeek/zeek/pull/2156. It makes a number of changes to the Dockerfiles to bring them more in line with how the Zeek ones are structured.