### PR TITLE
Fix recently introduced warnings on GCC

### DIFF
--- a/tests/btest/CMakeLists.txt
+++ b/tests/btest/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(btest-put-unique store/put-unique.cpp)
+add_executable(btest-put-unique store/put-unique.cc)
 
 target_link_libraries(btest-put-unique PRIVATE ${BROKER_LIBRARY} CAF::core CAF::net)

--- a/tests/btest/btest.cfg
+++ b/tests/btest/btest.cfg
@@ -3,7 +3,7 @@ TestDirs    = web-socket handshake store
 TmpDir      = %(testbase)s/.tmp
 BaselineDir = %(testbase)s/Baseline
 MinVersion  = 0.63
-IgnoreFiles = *.swp *.cpp
+IgnoreFiles = *.swp *.cc
 
 [environment]
 SCRIPTS    = %(testbase)s/scripts

--- a/tests/cpp/system/peering.cc
+++ b/tests/cpp/system/peering.cc
@@ -442,13 +442,13 @@ TEST(only one put_unique may pass) {
           std::vector<store::proxy>proxies;
           for (int i = 0; i < 3; ++i) {
             proxies.emplace_back(services);
-            for (int req_id = 1; req_id < 4; ++req_id) {
+            for (size_t req_id = 1; req_id < 4; ++req_id) {
               auto actual_id = proxies.back().put_unique("foo", "bar");
               SYNC_CHECK_EQUAL(req_id, actual_id);
             }
           }
           for (auto& px : proxies) {
-            for (int req_id = 1; req_id < 4; ++req_id) {
+            for (size_t req_id = 1; req_id < 4; ++req_id) {
               auto resp = px.receive();
               if (SYNC_CHECK(resp.id == req_id)) {
                 if (SYNC_CHECK(resp.answer)) {
@@ -493,7 +493,7 @@ TEST(only one put_unique may pass) {
   CHECK_EQ(results.size(), (num_endpoints - 1) * 3 * 3);
   CHECK_EQ(std::count(results.begin(), results.end(), data{true}), 1);
   CHECK_EQ(std::count(results.begin(), results.end(), data{false}),
-           results.size() - 1);
+           static_cast<int>(results.size() - 1));
 }
 
 SCENARIO("handshake fails if only one side enables encryption") {


### PR DESCRIPTION
Closes #243.

Btw, that CAF submodule update is solely picking up this one commit to fix a deprecation warning with `std::iterator`: https://github.com/actor-framework/actor-framework/commit/19a141fc148c63edfb5fbcd18dad7a9b64411e04.