### PR TITLE
Fix double-close on pipe handles

### DIFF
--- a/src/internal/connector.cc
+++ b/src/internal/connector.cc
@@ -983,17 +983,6 @@ struct connect_manager {
 
   connect_manager& operator=(const connect_manager&) = delete;
 
-  ~connect_manager() {
-    for (auto& entry : fdset) {
-      BROKER_DEBUG("close socket" << entry.fd);
-      caf::net::close(caf::net::socket{entry.fd});
-    }
-    for (auto& entry : pending_fdset) {
-      BROKER_DEBUG("close socket" << entry.fd);
-      caf::net::close(caf::net::socket{entry.fd});
-    }
-  }
-
   /// Returns the relative timeout for the next retry in milliseconds or -1.
   int next_timeout_ms() {
     if (retry_schedule.empty())


### PR DESCRIPTION
I have tracked down some infrequent unit tests on Fedora (see https://github.com/zeek/broker/issues/246) to double-close on the pipe handles in the `connector`.

The `connector` closes its pipe handles last, but the `connect_manager` closes them beforehand by blindly closing all sockets in its pollset. The error happens only in our multi-threaded tests:

- Thread A closes the pipe handle X (`~connect_manager`)
- Thread B accepts a new connection and the OS chooses X since it's just been released
- Thread A runs `~connector`, which closes X *again*
- Thread B gets an EBADFD seemingly out of nowhere and rightfully complains

I think the connector manager should not close any sockets at all, since these sockets are owned by other components that take ownership.

With this patch, I could run the `system.peering` suite on Fedora several hundred times without error during testing. Before the patch, it would break every couple dozen runs on average. Also, this has nothing to with Fedora and is simply a race on the Kernel's socket table. Just happened to occur most frequently in our Fedora build.