### PR TITLE
Drop [[nodiscard]] on convert functions

### DIFF
--- a/include/broker/address.hh
+++ b/include/broker/address.hh
@@ -87,7 +87,7 @@ private:
 // -- free functions -----------------------------------------------------------
 
 /// @relates address
-[[nodiscard]] inline bool convert(const std::string& str, address& a) {
+inline bool convert(const std::string& str, address& a) {
   return a.convert_from(str);
 }
 

--- a/include/broker/error.hh
+++ b/include/broker/error.hh
@@ -222,13 +222,13 @@ std::string to_string(ec code);
 std::string_view enum_str(ec code);
 
 /// @relates ec
-[[nodiscard]] bool convert(std::string_view str, ec& code) noexcept;
+bool convert(std::string_view str, ec& code) noexcept;
 
 /// @relates ec
-[[nodiscard]] bool convert(const data& str, ec& code) noexcept;
+bool convert(const data& str, ec& code) noexcept;
 
 /// @relates ec
-[[nodiscard]] inline bool convert(const std::string& str, ec& code) noexcept {
+inline bool convert(const std::string& str, ec& code) noexcept {
   // Disambiguation: std::string_view and broker::data are both valid
   // conversions for std::string.
   return convert(std::string_view{str}, code);
@@ -284,10 +284,10 @@ struct can_convert_predicate<error> {
 /// `src.category() == caf::atom("broker")`. The `context` field, depending on
 /// the error code, is either, `nil`,`[<string>]`, or
 /// `[<endpoint_info>, <string>]`.
-[[nodiscard]] bool convert(const error& src, data& dst);
+bool convert(const error& src, data& dst);
 
 /// Converts data in the format `["error", code, context]` back to an error.
-[[nodiscard]] bool convert(const data& src, error& dst);
+bool convert(const data& src, error& dst);
 
 /// Creates a view into a ::data object that is convertible to ::error.
 class error_view {


### PR DESCRIPTION
Fixes #257. While adding the attributes is generally best practice, leaving them out here isn't a big deal since the `convert` functions are not meant to be called directly and users should instead rely on the higher-level functions (such as `to<...>`).