### PR TITLE
Hex escape broker::to_string(data<string>) containing non-ascii chars

### DIFF
--- a/bindings/python/data.cpp
+++ b/bindings/python/data.cpp
@@ -236,7 +236,14 @@ void init_data(py::module& m) {
 	})
     .def("as_vector", [](const broker::data& d) { return broker::get<broker::vector>(d); })
     .def("get_type", &broker::data::get_type)
-    .def("__str__", [](const broker::data& d) { return broker::to_string(d); })
+    .def("__str__",
+         [](const broker::data& d) {
+           // Don't to_string a string to avoid hex escaping it.
+           if (broker::holds_alternative<std::string>(d))
+             return broker::get<std::string>(d);
+
+           return broker::to_string(d);
+         })
     .def(hash(py::self))
     .def(py::self < py::self)
     .def(py::self <= py::self)

--- a/tests/python/data.py
+++ b/tests/python/data.py
@@ -183,6 +183,7 @@ class TestDataConstruction(unittest.TestCase):
     def test_string(self):
         self.check_to_broker_and_back('', '', broker.Data.Type.String)
         self.check_to_broker_and_back('foo', 'foo', broker.Data.Type.String)
+        self.check_to_broker_and_back('foo\x00null', 'foo\x00null', broker.Data.Type.String)
         self.check_to_broker_and_back('\ttab', '\ttab', broker.Data.Type.String)
         self.check_to_broker_and_back('new\n', 'new\n', broker.Data.Type.String)
 


### PR DESCRIPTION
...trying something as a fix for zeek/zeek#2272 .

@Neverlord - not sure this is quite the right place and approach and you may outright reject - no hard feelings. This is similar to what @AmazingPP had done for RenderMessage(), but ensures that other `broker::to_string().c_str()` users wouldn't have `NUL` chars terminate output.

Not sure it's okay to just change the semantics here and if it's actually limited to broker::to_string. If broker::to_string() is mostly for debugging / informative messages only, it might be okay?