### PR TITLE
Revert accidental change to CMake file from #255

### DIFF
--- a/src/BrokerConfig.cmake.in
+++ b/src/BrokerConfig.cmake.in
@@ -1,23 +1,22 @@
-@PACKAGE_INIT @
+@PACKAGE_INIT@
 
-  include(CMakeFindDependencyMacro)
+include(CMakeFindDependencyMacro)
 
-    set(CMAKE_THREAD_PREFER_PTHREAD ON) set(THREADS_PREFER_PTHREAD_FLAG ON)
-      find_dependency(Threads REQUIRED)
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_dependency(Threads REQUIRED)
 
-        find_dependency(OpenSSL REQUIRED)
+find_dependency(OpenSSL REQUIRED)
 
-          find_dependency(CAF @CAF_VERSION @REQUIRED COMPONENTS core io)
+find_dependency(CAF @CAF_VERSION@ REQUIRED COMPONENTS core io)
 
-            include("${CMAKE_CURRENT_LIST_DIR}/BrokerTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/BrokerTargets.cmake")
 
-              set(BROKER_LIBRARY "@BROKER_LIBRARY@" CACHE INTERNAL
-                                 "name of the Broker library target")
+set(BROKER_LIBRARY "@BROKER_LIBRARY@" CACHE INTERNAL "name of the Broker library target")
 
-                function(set_include_dir) get_target_property(dirs ${
-                  BROKER_LIBRARY} INTERFACE_INCLUDE_DIRECTORIES)
-                  set(BROKER_INCLUDE_DIR "${dirs}" CACHE INTERNAL
-                                         "extra include directories")
-                    endfunction()
+function(set_include_dir)
+  get_target_property(dirs ${BROKER_LIBRARY} INTERFACE_INCLUDE_DIRECTORIES)
+  set(BROKER_INCLUDE_DIR "${dirs}" CACHE INTERNAL "extra include directories")
+endfunction()
 
-                      set_include_dir()
+set_include_dir()


### PR DESCRIPTION
For #255, we ran `clang-format` over the code base. By accident, we've also formatted `BrokerConfig.cmake.in` and broke CMake packaging in the process by changing `@PACKAGE_INIT@` to `@PACKAGE_INIT @`.