### PR TITLE
Add clang-tidy to CI with an initial set of checks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,6 +54,14 @@ unix_env: &UNIX_ENV
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
+clang_tidy_task:
+  container:
+    dockerfile: ci/fedora-36/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  sync_submodules_script: git submodule update --recursive --init
+  build_script: ./ci/analyze.sh
+  << : *UNIX_ENV
+
 fedora35_task:
   container:
     # Fedora 35 EOL: Around Dec 2022

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,10 @@
+---
+  Checks: -*,
+          bugprone-*,
+          clang-analyzer-*,
+          -bugprone-easily-swappable-parameters,
+          -clang-analyzer-security.insecureAPI.rand,
+          -clang-analyzer-webkit*,
+  WarningsAsErrors: '*'
+  HeaderFilterRegex: 'broker/.*.hh'
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,23 @@ else()
   set(BROKER_LIBRARY broker_static)
 endif()
 
+set(tidyCfgFile "${CMAKE_SOURCE_DIR}/.clang-tidy")
+if (BROKER_ENABLE_TIDY)
+  # Create a preprocessor definition that depends on .clang-tidy content so
+  # the compile command will change when .clang-tidy changes. This ensures
+  # that a subsequent build re-runs clang-tidy on all sources even if they
+  # do not otherwise need to be recompiled.
+  file(SHA1 ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy clang_tidy_sha1)
+  set(BROKER_CLANG_TIDY_DEF "CLANG_TIDY_SHA1=${clang_tidy_sha1}")
+  unset(clang_tidy_sha1)
+  add_custom_target(clang_tidy_dummy DEPENDS ${tidyCfgFile})
+  set_target_properties(${BROKER_LIBRARY} PROPERTIES
+                        CXX_CLANG_TIDY "clang-tidy;--config-file=${tidyCfgFile}")
+  target_compile_definitions(${BROKER_LIBRARY} PRIVATE ${BROKER_CLANG_TIDY_DEF})
+  configure_file(.clang-tidy .clang-tidy COPYONLY)
+endif ()
+
+
 # -- Tools --------------------------------------------------------------------
 
 macro(add_tool name)
@@ -409,6 +426,11 @@ macro(add_tool name)
     target_link_libraries(${name} broker_static CAF::core CAF::io CAF::net)
     add_dependencies(${name} broker_static)
   endif()
+  if (BROKER_ENABLE_TIDY)
+    set_target_properties(${name} PROPERTIES
+                          CXX_CLANG_TIDY "clang-tidy;--config-file=${tidyCfgFile}")
+    target_compile_definitions(${name} PRIVATE ${BROKER_CLANG_TIDY_DEF})
+  endif ()
 endmacro()
 
 if (NOT BROKER_DISABLE_TOOLS)

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+set -e
+set -x
+
+CXX=clang++ ./configure --build-type=debug
+
+run-clang-tidy -p build -j ${BROKER_CI_CPUS} $PWD/src

--- a/ci/fedora-36/Dockerfile
+++ b/ci/fedora-36/Dockerfile
@@ -5,6 +5,8 @@ FROM fedora:36
 ENV DOCKERFILE_VERSION 20220615
 
 RUN dnf -y install \
+    clang \
+    clang-tools-extra \
     cmake \
     diffutils \
     gcc \

--- a/configure
+++ b/configure
@@ -24,6 +24,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --enable-static-only   only build static libraries, not shared
     --with-log-level=LVL   build embedded CAF with debugging output.  Levels:
                              ERROR, WARNING, INFO, DEBUG, TRACE
+    --with-clang-tidy      run with clang-tidy (requires CMake >= 3.7.2)
     --sanitizers=LIST      comma-separated list of sanitizer names to enable
     --disable-sanitizer-optimizations
                            build without any optimizations when using sanitizers
@@ -130,6 +131,9 @@ while [ $# -ne 0 ]; do
             ;;
         --enable-static)
             append_cache_entry ENABLE_STATIC        BOOL   true
+            ;;
+        --with-clang-tidy)
+            append_cache_entry BROKER_ENABLE_TIDY   BOOL   true
             ;;
         --sanitizers=*)
             append_cache_entry BROKER_SANITIZERS    STRING    $optarg

--- a/include/broker/detail/prefix_matcher.hh
+++ b/include/broker/detail/prefix_matcher.hh
@@ -11,10 +11,10 @@ namespace broker::detail {
 struct prefix_matcher {
   using filter_type = std::vector<topic>;
 
-  bool operator()(const filter_type& filter, const topic& t) const;
+  bool operator()(const filter_type& filter, const topic& t) const noexcept;
 
   template <class T>
-  bool operator()(const filter_type& filter, const T& x) const {
+  bool operator()(const filter_type& filter, const T& x) const noexcept {
     return (*this)(filter, get_topic(x));
   }
 };

--- a/include/broker/error.hh
+++ b/include/broker/error.hh
@@ -183,7 +183,7 @@ public:
   }
 
 private:
-  std::byte obj_[sizeof(impl*)];
+  std::byte obj_[sizeof(void*)];
 };
 
 /// @relates error
@@ -350,7 +350,7 @@ inline error_view make_error_view(const data& src) {
 } // namespace broker
 
 #define BROKER_TRY_IMPL(statement)                                             \
-  if (auto err = statement)                                                    \
+  if (auto err = (statement))                                                  \
   return err
 
 #define BROKER_TRY_1(x1) BROKER_TRY_IMPL(x1)

--- a/include/broker/internal/type_id.hh
+++ b/include/broker/internal/type_id.hh
@@ -15,9 +15,11 @@
 
 // -- imported atoms -----------------------------------------------------------
 
+// NOLINTBEGIN
 #define BROKER_CAF_ATOM_ALIAS(name)                                            \
   using name = caf::name##_atom;                                               \
   constexpr auto name##_v = caf::name##_atom_v;
+// NOLINTEND
 
 namespace broker::internal::atom {
 
@@ -50,11 +52,12 @@ static_assert(caf::has_type_id_v<broker::timespan>,
 static_assert(caf::has_type_id_v<broker::timestamp>,
               "broker::timestamp != caf::timestamp");
 
-#define BROKER_ADD_ATOM(name) CAF_ADD_ATOM(broker, broker::internal::atom, name)
+#define BROKER_ADD_ATOM(name)                                                  \
+  CAF_ADD_ATOM(broker_internal, broker::internal::atom, name)
 
-#define BROKER_ADD_TYPE_ID(type) CAF_ADD_TYPE_ID(broker, type)
+#define BROKER_ADD_TYPE_ID(type) CAF_ADD_TYPE_ID(broker_internal, type)
 
-CAF_BEGIN_TYPE_ID_BLOCK(broker, caf::first_custom_type_id)
+CAF_BEGIN_TYPE_ID_BLOCK(broker_internal, caf::first_custom_type_id)
 
   // -- atoms for generic communication ----------------------------------------
 
@@ -86,6 +89,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(broker, caf::first_custom_type_id)
   BROKER_ADD_ATOM(await)
   BROKER_ADD_ATOM(clear)
   BROKER_ADD_ATOM(clone)
+  BROKER_ADD_ATOM(data_store)
   BROKER_ADD_ATOM(decrement)
   BROKER_ADD_ATOM(erase)
   BROKER_ADD_ATOM(exists)
@@ -99,7 +103,6 @@ CAF_BEGIN_TYPE_ID_BLOCK(broker, caf::first_custom_type_id)
   BROKER_ADD_ATOM(resolve)
   BROKER_ADD_ATOM(restart)
   BROKER_ADD_ATOM(stale_check)
-  BROKER_ADD_ATOM(store)
   BROKER_ADD_ATOM(subtract)
   BROKER_ADD_ATOM(sync_point)
 
@@ -173,7 +176,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(broker, caf::first_custom_type_id)
   BROKER_ADD_TYPE_ID((std::shared_ptr<std::promise<void>>) )
   BROKER_ADD_TYPE_ID((std::vector<broker::peer_info>) )
 
-CAF_END_TYPE_ID_BLOCK(broker)
+CAF_END_TYPE_ID_BLOCK(broker_internal)
 
 // -- enable opt-in features for Broker types ----------------------------------
 

--- a/include/broker/status.hh
+++ b/include/broker/status.hh
@@ -39,7 +39,7 @@ template <sc S>
 using sc_constant = std::integral_constant<sc, S>;
 
 /// @relates sc
-std::string to_string(sc code) noexcept;
+std::string to_string(sc code);
 
 /// @relates sc
 bool convert(std::string_view str, sc& code) noexcept;
@@ -229,10 +229,10 @@ public:
 
   /// @copydoc status::code
   /// @pre `valid()`
-  sc code() const noexcept;
+  sc code() const;
 
   /// @copydoc status::code
-  const std::string* message() const noexcept;
+  const std::string* message() const;
 
   /// Retrieves additional contextual information, if available.
   std::optional<endpoint_info> context() const;

--- a/include/broker/store_event.hh
+++ b/include/broker/store_event.hh
@@ -73,7 +73,7 @@ public:
         return {};
     }
 
-    entity_id publisher() const noexcept {
+    entity_id publisher() const {
       if (auto value = to<endpoint_id>((*xs_)[5])) {
         return {std::move(*value), get<uint64_t>((*xs_)[6])};
       }
@@ -119,7 +119,7 @@ public:
       return xs_ != nullptr;
     }
 
-    const std::string& store_id() const noexcept {
+    const std::string& store_id() const {
       return get<std::string>((*xs_)[1]);
     }
 
@@ -142,7 +142,7 @@ public:
         return {};
     }
 
-    entity_id publisher() const noexcept {
+    entity_id publisher() const {
       if (auto value = to<endpoint_id>((*xs_)[6]))
         return {*value, get<uint64_t>((*xs_)[7])};
       else
@@ -186,7 +186,7 @@ public:
       return xs_ != nullptr;
     }
 
-    const std::string& store_id() const noexcept {
+    const std::string& store_id() const {
       return get<std::string>((*xs_)[1]);
     }
 
@@ -194,7 +194,7 @@ public:
       return (*xs_)[2];
     }
 
-    entity_id publisher() const noexcept {
+    entity_id publisher() const {
       if (auto value = to<endpoint_id>((*xs_)[3])) {
         return {*value, get<uint64_t>((*xs_)[4])};
       }
@@ -238,7 +238,7 @@ public:
       return xs_ != nullptr;
     }
 
-    const std::string& store_id() const noexcept {
+    const std::string& store_id() const {
       return get<std::string>((*xs_)[1]);
     }
 
@@ -246,7 +246,7 @@ public:
       return (*xs_)[2];
     }
 
-    entity_id publisher() const noexcept {
+    entity_id publisher() const {
       if (auto value = to<endpoint_id>((*xs_)[3]))
         return {*value, get<uint64_t>((*xs_)[4])};
       else

--- a/include/broker/worker.hh
+++ b/include/broker/worker.hh
@@ -4,6 +4,7 @@
 #include "broker/detail/comparable.hh"
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <utility>
@@ -20,9 +21,9 @@ public:
   // -- constants --------------------------------------------------------------
 
 #ifdef BROKER_WINDOWS
-  static constexpr size_t obj_size = sizeof(impl*) * 2;
+  static constexpr size_t obj_size = sizeof(void*) * 2;
 #else
-  static constexpr size_t obj_size = sizeof(impl*);
+  static constexpr size_t obj_size = sizeof(void*);
 #endif
 
   // --- construction and destruction ------------------------------------------
@@ -63,7 +64,7 @@ public:
 
   /// Compares this instance to `other`.
   /// @returns -1 if `*this < other`, 0 if `*this == other`, and 1 otherwise.
-  int compare(const worker& other) const noexcept;
+  intptr_t compare(const worker& other) const noexcept;
 
   /// Returns a has value for the ID.
   size_t hash() const noexcept;

--- a/src/address.cc
+++ b/src/address.cc
@@ -97,7 +97,7 @@ bool address::mask(uint8_t top_bits_to_keep) {
   if (top_bits_to_keep > 128)
     return false;
   uint32_t mask[4] = {0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
-  auto res = std::ldiv(top_bits_to_keep, 32);
+  auto res = std::div(top_bits_to_keep, 32);
   if (res.quot < 4)
     mask[res.quot] =
       caf::detail::to_network_order(mask[res.quot] & ~bit_mask32(32 - res.rem));

--- a/src/broker-pipe.cc
+++ b/src/broker-pipe.cc
@@ -123,7 +123,7 @@ void publish_mode_select(broker::endpoint& ep, const std::string& topic_str,
       if (!std::getline(std::cin, line))
         return; // Reached end of STDIO.
       else
-        out.publish(std::move(line));
+        out.publish(line);
     i += num;
     msg_count += num;
   }
@@ -215,7 +215,7 @@ void split(std::vector<std::string>& result, std::string_view str,
 
 } // namespace
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv) try {
   broker::endpoint::system_guard sys_guard;
   // Parse CLI parameters using our config.
   parameters params;
@@ -301,4 +301,7 @@ int main(int argc, char** argv) {
   auto i = std::find(b, std::end(as), std::make_pair(params.mode, params.impl));
   auto f = fs[std::distance(b, i)];
   f(ep, params.topic, params.message_cap);
+} catch (std::exception& ex) {
+  std::cerr << "*** exception: " << ex.what() << "\n";
+  return EXIT_FAILURE;
 }

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -515,7 +515,7 @@ std::once_flag init_global_state_flag;
 
 void configuration::init_global_state() {
   std::call_once(init_global_state_flag, [] {
-    caf::init_global_meta_objects<caf::id_block::broker>();
+    caf::init_global_meta_objects<caf::id_block::broker_internal>();
     caf::io::middleman::init_global_meta_objects();
     caf::core::init_global_meta_objects();
   });

--- a/src/data.cc
+++ b/src/data.cc
@@ -94,8 +94,8 @@ const char* data::get_type_name() const {
 namespace {
 
 template <class Container>
-void container_convert(Container& c, std::string& str, const char* left,
-                       const char* right, const char* delim = ", ") {
+void container_convert(Container& c, std::string& str, char left, char right) {
+  constexpr auto* delim = ", ";
   auto first = begin(c);
   auto last = end(c);
   str += left;
@@ -141,15 +141,15 @@ void convert(const table::value_type& x, std::string& str) {
 }
 
 void convert(const vector& x, std::string& str) {
-  container_convert(x, str, "(", ")");
+  container_convert(x, str, '(', ')');
 }
 
 void convert(const set& x, std::string& str) {
-  container_convert(x, str, "{", "}");
+  container_convert(x, str, '{', '}');
 }
 
 void convert(const table& x, std::string& str) {
-  container_convert(x, str, "{", "}");
+  container_convert(x, str, '{', '}');
 }
 
 void convert(const data& x, std::string& str) {

--- a/src/detail/peer_status_map.cc
+++ b/src/detail/peer_status_map.cc
@@ -30,7 +30,8 @@ bool peer_status_map::update(endpoint_id peer, peer_status& expected,
   if (closed_) {
     expected = peer_status::unknown;
     return false;
-  } else if (auto i = peers_.find(peer); i != peers_.end()) {
+  }
+  if (auto i = peers_.find(peer); i != peers_.end()) {
     if (i->second == expected) {
       i->second = desired;
       return true;
@@ -38,10 +39,9 @@ bool peer_status_map::update(endpoint_id peer, peer_status& expected,
       expected = i->second;
       return false;
     }
-  } else {
-    expected = peer_status::unknown;
-    return false;
   }
+  expected = peer_status::unknown;
+  return false;
 }
 
 bool peer_status_map::remove(endpoint_id peer, peer_status& expected) {
@@ -49,7 +49,8 @@ bool peer_status_map::remove(endpoint_id peer, peer_status& expected) {
   if (closed_) {
     expected = peer_status::unknown;
     return false;
-  } else if (auto i = peers_.find(peer); i != peers_.end()) {
+  }
+  if (auto i = peers_.find(peer); i != peers_.end()) {
     if (i->second == expected) {
       peers_.erase(i);
       return true;
@@ -57,10 +58,9 @@ bool peer_status_map::remove(endpoint_id peer, peer_status& expected) {
       expected = i->second;
       return false;
     }
-  } else {
-    expected = peer_status::unknown;
-    return false;
   }
+  expected = peer_status::unknown;
+  return false;
 }
 
 void peer_status_map::remove(endpoint_id peer) {

--- a/src/detail/prefix_matcher.cc
+++ b/src/detail/prefix_matcher.cc
@@ -4,7 +4,7 @@ namespace broker {
 namespace detail {
 
 bool prefix_matcher::operator()(const filter_type& filter,
-                                const topic& t) const {
+                                const topic& t) const noexcept {
   for (auto& prefix : filter)
     if (prefix.prefix_of(t))
       return true;

--- a/src/error.cc
+++ b/src/error.cc
@@ -105,7 +105,8 @@ error::error(error&& other) noexcept {
 }
 
 error& error::operator=(const error& other) {
-  native(*this) = native(other);
+  if (this != &other)
+    native(*this) = native(other);
   return *this;
 }
 
@@ -306,12 +307,13 @@ const std::string* error_view::message() const noexcept {
 }
 
 std::optional<endpoint_info> error_view::context() const {
-  if (is<none>((*xs_)[2]))
+  if (is<none>((*xs_)[2])) {
     return std::nullopt;
-  else if (auto& ctx = get<vector>((*xs_)[2]); ctx.size() == 2)
+  }
+  if (auto& ctx = get<vector>((*xs_)[2]); ctx.size() == 2) {
     return get_as<endpoint_info>(ctx[0]);
-  else
-    return std::nullopt;
+  }
+  return std::nullopt;
 }
 
 error_view error_view::make(const data& src) {

--- a/src/internal/connector.cc
+++ b/src/internal/connector.cc
@@ -843,7 +843,6 @@ public:
             return read_result::stop;
           payload_size = 0;
           read_pos = 0;
-          read_size = 4;
           return reached_fin_state() ? read_result::stop : read_result::again;
         } else {
           return read_result::again;
@@ -1012,7 +1011,7 @@ struct connect_manager {
                    << (event == read_mask ? "reading" : "writing")
                    << BROKER_ARG2("fd", i->first));
       if (auto fds_ptr = find_pollfd(i->first)) {
-        fds_ptr->events |= event;
+        fds_ptr->events = static_cast<short>(fds_ptr->events | event);
       } else {
         pending_fdset.emplace_back(pollfd{i->first, event, 0});
       }
@@ -1753,7 +1752,8 @@ connector::connector(endpoint_id this_peer, broker_options broker_cfg,
               static_cast<int>(max_ssl_passphrase_size));
       ::abort();
     }
-    strcpy(ssl_passphrase_buf, ssl_cfg_->passphrase.c_str());
+    strncpy(ssl_passphrase_buf, ssl_cfg_->passphrase.c_str(),
+            max_ssl_passphrase_size);
   }
 }
 

--- a/src/internal/core_actor.cc
+++ b/src/internal/core_actor.cc
@@ -293,17 +293,18 @@ caf::behavior core_actor_state::make_behavior() {
       subscriptions.emplace_back(std::move(sub));
     },
     // -- data store management ------------------------------------------------
-    [this](atom::store, atom::clone, atom::attach, const std::string& name,
+    [this](atom::data_store, atom::clone, atom::attach, const std::string& name,
            double resync_interval, double stale_interval,
            double mutation_buffer_interval) {
       return attach_clone(name, resync_interval, stale_interval,
                           mutation_buffer_interval);
     },
-    [this](atom::store, atom::master, atom::attach, const std::string& name,
-           backend backend_type, backend_options opts) {
+    [this](atom::data_store, atom::master, atom::attach,
+           const std::string& name, backend backend_type,
+           backend_options opts) {
       return attach_master(name, backend_type, opts);
     },
-    [this](atom::store, atom::master, atom::get,
+    [this](atom::data_store, atom::master, atom::get,
            const std::string& name) -> caf::result<caf::actor> {
       auto i = masters.find(name);
       if (i != masters.end())
@@ -311,7 +312,7 @@ caf::behavior core_actor_state::make_behavior() {
       else
         return caf::make_error(ec::no_such_master);
     },
-    [this](atom::shutdown, atom::store) { //
+    [this](atom::shutdown, atom::data_store) { //
       shutdown_stores();
     },
     // -- interface for legacy subscribers -------------------------------------
@@ -860,8 +861,11 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer,
   // message size. So on the wire, every byte block that our trait produces gets
   // prefixed with 32 bit with the size.
   namespace cn = caf::net;
-  auto [rd_1, wr_1] = caf::async::make_spsc_buffer_resource<node_message>();
-  auto [rd_2, wr_2] = caf::async::make_spsc_buffer_resource<node_message>();
+  // Note: structured bindings with values confuses clang-tidy's leak checker.
+  auto resources1 = caf::async::make_spsc_buffer_resource<node_message>();
+  auto& [rd_1, wr_1] = resources1;
+  auto resources2 = caf::async::make_spsc_buffer_resource<node_message>();
+  auto& [rd_2, wr_2] = resources2;
   if (auto err = ptr->run(self->system(), std::move(rd_1), std::move(wr_2))) {
     BROKER_DEBUG("failed to run pending connection:" << err);
     return err;
@@ -981,8 +985,11 @@ caf::result<caf::actor> core_actor_state::attach_master(const std::string& name,
     return caf::make_error(ec::backend_failure);
   BROKER_INFO("spawning new master:" << name);
   using caf::async::make_spsc_buffer_resource;
-  auto [con1, prod1] = make_spsc_buffer_resource<command_message>();
-  auto [con2, prod2] = make_spsc_buffer_resource<command_message>();
+  // Note: structured bindings with values confuses clang-tidy's leak checker.
+  auto resources1 = make_spsc_buffer_resource<command_message>();
+  auto& [con1, prod1] = resources1;
+  auto resources2 = make_spsc_buffer_resource<command_message>();
+  auto& [con2, prod2] = resources2;
   // Spin up the master and connect it to our flows.
   auto hdl = self->system().spawn<master_actor_type>(id, name, std::move(ptr),
                                                      caf::actor{self}, clock,
@@ -1023,8 +1030,11 @@ core_actor_state::attach_clone(const std::string& name, double resync_interval,
   // TODO: make configurable.
   auto tout = duration_cast<timespan>(fractional_seconds{10});
   using caf::async::make_spsc_buffer_resource;
-  auto [con1, prod1] = make_spsc_buffer_resource<command_message>();
-  auto [con2, prod2] = make_spsc_buffer_resource<command_message>();
+  // Note: structured bindings with values confuses clang-tidy's leak checker.
+  auto resources1 = make_spsc_buffer_resource<command_message>();
+  auto [con1, prod1] = resources1;
+  auto resources2 = make_spsc_buffer_resource<command_message>();
+  auto [con2, prod2] = resources2;
   auto hdl = self->system().spawn<clone_actor_type>(
     id, name, tout, caf::actor{self}, clock, std::move(con1), std::move(prod2));
   filter_type filter{name / topic::clone_suffix()};

--- a/src/internal/core_actor.cc
+++ b/src/internal/core_actor.cc
@@ -1032,9 +1032,9 @@ core_actor_state::attach_clone(const std::string& name, double resync_interval,
   using caf::async::make_spsc_buffer_resource;
   // Note: structured bindings with values confuses clang-tidy's leak checker.
   auto resources1 = make_spsc_buffer_resource<command_message>();
-  auto [con1, prod1] = resources1;
+  auto& [con1, prod1] = resources1;
   auto resources2 = make_spsc_buffer_resource<command_message>();
-  auto [con2, prod2] = resources2;
+  auto& [con2, prod2] = resources2;
   auto hdl = self->system().spawn<clone_actor_type>(
     id, name, tout, caf::actor{self}, clock, std::move(con1), std::move(prod2));
   filter_type filter{name / topic::clone_suffix()};

--- a/src/internal/json_client.cc
+++ b/src/internal/json_client.cc
@@ -108,7 +108,9 @@ json_client_state::json_client_state(caf::event_based_actor* selfptr,
   ctrl_msgs.emplace(self);
   // Connects us to the core.
   using caf::async::make_spsc_buffer_resource;
-  auto [core_pull, core_push] = make_spsc_buffer_resource<data_message>();
+  // Note: structured bindings with values confuses clang-tidy's leak checker.
+  auto resources = make_spsc_buffer_resource<data_message>();
+  auto& [core_pull, core_push] = resources;
   // Read from the WebSocket, push to core (core_push).
   self //
     ->make_observable()
@@ -209,7 +211,9 @@ void json_client_state::init(
   using caf::async::make_spsc_buffer_resource;
   // Pull data from the core and forward as JSON.
   if (!filter.empty()) {
-    auto [core_pull2, core_push2] = make_spsc_buffer_resource<data_message>();
+    // Note: structured bindings with values confuses clang-tidy's leak checker.
+    auto resources = make_spsc_buffer_resource<data_message>();
+    auto& [core_pull2, core_push2] = resources;
     auto core_json = //
       self->make_observable()
         .from_resource(core_pull2)

--- a/src/internal/master_resolver.cc
+++ b/src/internal/master_resolver.cc
@@ -29,7 +29,7 @@ caf::behavior master_resolver(master_resolver_actor* self) {
         caf::actor& who_asked) {
       BROKER_DEBUG("resolver starts looking for:" << name);
       for (auto& peer : peers)
-        self->send(peer, atom::store_v, atom::master_v, atom::get_v, name);
+        self->send(peer, atom::data_store_v, atom::master_v, atom::get_v, name);
 
       self->state.remaining_responses = peers.size();
       self->state.who_asked = std::move(who_asked);

--- a/src/internal/metric_view.cc
+++ b/src/internal/metric_view.cc
@@ -67,40 +67,35 @@ bool metric_view::get_type(const vector& row,
   };
   static constexpr bool bad = false;
   const auto* t = broker::get_if<std::string>(row[index(field::type)]);
-  const auto& v = row[index(field::value)];
-  if (!t) {
+  if (t == nullptr) {
     return bad;
-  } else if (*t == "counter") {
-    if (is<integer>(v))
+  }
+  const auto& v = row[index(field::value)];
+  if (*t == "counter") {
+    if (is<integer>(v)) {
       return good(metric_type::int_counter);
-    else if (is<real>(v))
+    } else if (is<real>(v)) {
       return good(metric_type::dbl_counter);
-    else
-      return bad;
+    }
   } else if (*t == "gauge") {
-    if (is<integer>(v))
+    if (is<integer>(v)) {
       return good(metric_type::int_gauge);
-    else if (is<real>(v))
+    } else if (is<real>(v)) {
       return good(metric_type::dbl_gauge);
-    else
-      return bad;
+    }
   } else if (*t == "histogram") {
     if (auto vals = get_if<vector>(v); vals && vals->size() >= 2) {
       if (std::all_of(vals->begin(), vals->end() - 1, pair_predicate<integer>{})
-          && is<integer>(vals->back()))
+          && is<integer>(vals->back())) {
         return good(metric_type::int_histogram);
-      else if (std::all_of(vals->begin(), vals->end() - 1,
-                           pair_predicate<real, integer>{})
-               && is<real>(vals->back()))
+      } else if (std::all_of(vals->begin(), vals->end() - 1,
+                             pair_predicate<real, integer>{})
+                 && is<real>(vals->back())) {
         return good(metric_type::dbl_histogram);
-      else
-        return bad;
-    } else {
-      return bad;
+      }
     }
-  } else {
-    return bad;
   }
+  return bad;
 }
 
 } // namespace broker::internal

--- a/src/internal/prometheus.cc
+++ b/src/internal/prometheus.cc
@@ -17,7 +17,7 @@ namespace {
 using std::string_view;
 
 // Cap incoming HTTP requests.
-constexpr size_t max_request_size = 512 * 1024;
+constexpr size_t max_request_size = 512ul * 1024ul;
 
 constexpr string_view valid_request_start = "GET /metrics HTTP/1.";
 

--- a/src/status.cc
+++ b/src/status.cc
@@ -24,7 +24,7 @@ std::string_view sc_strings[] = {
 
 } // namespace
 
-std::string to_string(sc code) noexcept {
+std::string to_string(sc code) {
   auto index = static_cast<uint8_t>(code);
   BROKER_ASSERT(index < std::size(sc_strings));
   return std::string{sc_strings[index]};
@@ -167,12 +167,12 @@ bool convert(const status& src, data& dst) {
   return true;
 }
 
-sc status_view::code() const noexcept {
+sc status_view::code() const {
   BROKER_ASSERT(xs_ != nullptr);
   return get_as<sc>((*xs_)[1]);
 }
 
-const std::string* status_view::message() const noexcept {
+const std::string* status_view::message() const {
   BROKER_ASSERT(xs_ != nullptr);
   if (is<none>((*xs_)[3]))
     return nullptr;

--- a/src/status_subscriber.cc
+++ b/src/status_subscriber.cc
@@ -64,9 +64,8 @@ status_subscriber status_subscriber::make(endpoint& ep, bool receive_statuses,
 }
 
 value_type status_subscriber::get(caf::timestamp timeout) {
-  auto maybe_msg = impl_.get(timeout);
-  if (maybe_msg) {
-    auto& msg = *maybe_msg;
+  if (auto maybe_msg = impl_.get(timeout)) {
+    auto msg = std::move(*maybe_msg);
     BROKER_RETURN_CONVERTED_MSG()
   }
   return nil;

--- a/src/store.cc
+++ b/src/store.cc
@@ -204,6 +204,8 @@ store& store::operator=(store&& other) {
 }
 
 store& store::operator=(const store& other) {
+  if (this == &other)
+    return *this;
   with_state_ptr([this](detail::shared_store_state_ptr& st) {
     auto frontend = dref(st).frontend;
     caf::anon_send(frontend, atom::decrement_v, std::move(st));

--- a/src/subnet.cc
+++ b/src/subnet.cc
@@ -67,23 +67,22 @@ void convert(const subnet& sn, std::string& str) {
 
 bool convert(const std::string& str, subnet& sn) {
   address addr;
-  if (auto separator_pos = str.find('/'); separator_pos == std::string::npos) {
+  auto separator_pos = str.find('/');
+  if (separator_pos == std::string::npos) {
     return false;
-  } else if (!convert(str.substr(0, separator_pos), addr)) {
-    return false;
-  } else {
+  }
+  if (convert(str.substr(0, separator_pos), addr)) {
     try {
       auto len = std::stoi(str.substr(separator_pos + 1));
-      if (len < 0 || len > 255) {
-        return false;
-      } else {
+      if (len >= 0 && len <= 255) {
         sn = subnet{addr, static_cast<uint8_t>(len)};
         return true;
       }
     } catch (std::exception&) {
-      return false;
+      // nop
     }
   }
+  return false;
 }
 
 } // namespace broker

--- a/src/telemetry/histogram.cc
+++ b/src/telemetry/histogram.cc
@@ -90,7 +90,7 @@ size_t num_buckets(const dbl_histogram_hdl* hdl) noexcept {
 double count_at(const dbl_histogram_hdl* hdl, size_t index) noexcept {
   auto xs = deref(hdl).buckets();
   BROKER_ASSERT(index < xs.size());
-  return xs[index].count.value();
+  return static_cast<double>(xs[index].count.value());
 }
 
 double upper_bound_at(const dbl_histogram_hdl* hdl, size_t index) noexcept {

--- a/src/telemetry/metric_registry.cc
+++ b/src/telemetry/metric_registry.cc
@@ -279,7 +279,10 @@ metric_registry metric_registry::pre_init_instance() {
 
 metric_registry metric_registry::merge(metric_registry what,
                                        broker::endpoint& where) {
-  return what.impl_->merge(where) ? from(where) : what;
+  if (what.impl_->merge(where)) {
+    return from(where);
+  }
+  return what;
 }
 
 metric_registry metric_registry::from(broker::endpoint& where) {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -43,7 +43,8 @@ worker& worker::operator=(worker&& other) noexcept {
 }
 
 worker& worker::operator=(const worker& other) noexcept {
-  native(*this) = native(other);
+  if (this != &other)
+    native(*this) = native(other);
   return *this;
 }
 
@@ -64,7 +65,7 @@ void worker::swap(worker& other) noexcept {
   native(*this).swap(native(other));
 }
 
-int worker::compare(const worker& other) const noexcept {
+intptr_t worker::compare(const worker& other) const noexcept {
   return native(*this).compare(native(other));
 }
 

--- a/tests/benchmark/broker-cluster-benchmark.cc
+++ b/tests/benchmark/broker-cluster-benchmark.cc
@@ -518,7 +518,7 @@ caf::behavior consumer(caf::stateful_actor<consumer_state>* self,
   self->state.this_node = this_node;
   self->state.observer = observer;
   self->send(self * core, atom::join_v, topics(*this_node));
-  self->send(self * core, atom::join_v, atom::store_v, topics(*this_node));
+  self->send(self * core, atom::join_v, atom::data_store_v, topics(*this_node));
   if (!verbose::enabled())
     return {
       [=](caf::stream<broker::data_message> in) {

--- a/tests/cpp/test.hh
+++ b/tests/cpp/test.hh
@@ -65,7 +65,7 @@ struct consumer_msg {
 
 // -- ID block for all message types in test suites ----------------------------
 
-CAF_BEGIN_TYPE_ID_BLOCK(broker_test, caf::id_block::broker::end)
+CAF_BEGIN_TYPE_ID_BLOCK(broker_test, caf::id_block::broker_internal::end)
 
   CAF_ADD_TYPE_ID(broker_test, (consumer_msg))
   CAF_ADD_TYPE_ID(broker_test, (producer_msg))

--- a/tests/micro-benchmark/include/main.hh
+++ b/tests/micro-benchmark/include/main.hh
@@ -31,7 +31,7 @@ using uuid_node_message = caf::cow_tuple<node_message_content, uuid_multipath>;
 
 #define MICRO_BENCH_ADD_TYPE(type) CAF_ADD_TYPE_ID(micro_benchmarks, type)
 
-CAF_BEGIN_TYPE_ID_BLOCK(micro_benchmarks, caf::id_block::broker::end)
+CAF_BEGIN_TYPE_ID_BLOCK(micro_benchmarks, caf::id_block::broker_internal::end)
 
   MICRO_BENCH_ADD_TYPE((caf::stream<legacy_node_message>) )
   MICRO_BENCH_ADD_TYPE((legacy_node_message))


### PR DESCRIPTION
This PR adds `clang-tidy` to our CI pipeline with `bugprone-*` and `clang-analyzer-*` checks (plus fixes for the findings) as initial set of checks. To make the PRs easier to review, I leave it at those first two categories and enable more checks in future PRs (already working on enabling `performance-*` checks).

I've also added a CMake option (with `configure` switch) to have `clang-tidy` run during development (slows down the build quite a bit).