### PR TITLE
Fix error handling with OpenSSL calls

### DIFF
--- a/src/internal/connector.cc
+++ b/src/internal/connector.cc
@@ -207,6 +207,7 @@ ssl_context_from_cfg(const openssl_options_ptr& cfg) {
   BROKER_DEBUG(BROKER_ARG2("authentication", cfg->authentication_enabled()));
   if (cfg->authentication_enabled()) {
     // Require valid certificates on both sides.
+    ERR_clear_error();
     if (!cfg->certificate.empty()
         && SSL_CTX_use_certificate_chain_file(ctx.get(),
                                               cfg->certificate.c_str())
@@ -237,6 +238,7 @@ ssl_context_from_cfg(const openssl_options_ptr& cfg) {
     if (SSL_CTX_set_cipher_list(ctx.get(), "HIGH:!aNULL:!MD5") != 1)
       throw ssl_error("failed to set cipher list");
   } else { // No authentication.
+    ERR_clear_error();
     SSL_CTX_set_verify(ctx.get(), SSL_VERIFY_NONE, nullptr);
 #if defined(SSL_CTX_set_ecdh_auto) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
     SSL_CTX_set_ecdh_auto(ctx.get(), 1);


### PR DESCRIPTION
While testing Broker locally, I would sometimes run into very weird reconnect-loops in a cluster setup when restarting one of the nodes.

After much trial and error, I figured out that it only happened when using OpenSSL transport and that there actually isn't any error causing the disconnect. Just OpenSSL not clearing error states and thus Broker believing that an error happened when in reality it's just reading an error that happened at some point in the past... Solution is to call `ERR_clear_error` before pretty much any OpenSSL function, because the error queue is (for whatever reason) managed separately and reading an error from OpenSSL (what we do if something goes wrong) does not clear the error (what we expected).