### PR TITLE
Enable performance-* checks and fix findings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
   Checks: -*,
           bugprone-*,
           clang-analyzer-*,
+          performance-*,
           -bugprone-easily-swappable-parameters,
           -clang-analyzer-security.insecureAPI.rand,
           -clang-analyzer-webkit*,

--- a/include/broker/alm/routing_table.hh
+++ b/include/broker/alm/routing_table.hh
@@ -144,7 +144,7 @@ void erase(routing_table& tbl, const endpoint_id& whom,
   impl(whom);
   while (!unreachable_peers.empty()) {
     // Our lambda modifies unreachable_peers, so we can't use iterators here.
-    endpoint_id peer = std::move(unreachable_peers.back());
+    endpoint_id peer = unreachable_peers.back();
     unreachable_peers.pop_back();
     impl(peer);
     on_remove(peer);

--- a/include/broker/configuration.hh
+++ b/include/broker/configuration.hh
@@ -111,7 +111,7 @@ public:
 
   configuration();
 
-  configuration(configuration&&);
+  configuration(configuration&&) noexcept;
 
   /// Constructs a configuration with non-default Broker options.
   explicit configuration(broker_options opts);
@@ -177,20 +177,20 @@ public:
                   std::string_view description);
 
   template <class T>
-  std::enable_if_t<std::is_integral_v<T>> set(std::string key, T val) {
+  std::enable_if_t<std::is_integral_v<T>> set(std::string_view key, T val) {
     if constexpr (std::is_same_v<T, bool>)
-      set_bool(std::move(key), val);
+      set_bool(key, val);
     else if constexpr (std::is_signed_v<T>)
-      set_i64(std::move(key), val);
+      set_i64(key, val);
     else
-      set_u64(std::move(key), val);
+      set_u64(key, val);
   }
 
-  void set(std::string key, timespan val);
+  void set(std::string_view key, timespan val);
 
-  void set(std::string key, std::string val);
+  void set(std::string_view key, std::string val);
 
-  void set(std::string key, std::vector<std::string> val);
+  void set(std::string_view key, std::vector<std::string> val);
 
   std::optional<int64_t> read_i64(std::string_view key, int64_t min_val,
                                   int64_t max_val) const;
@@ -223,11 +223,11 @@ public:
   void init(int argc, char** argv);
 
 private:
-  void set_i64(std::string key, int64_t val);
+  void set_i64(std::string_view key, int64_t val);
 
-  void set_u64(std::string key, uint64_t val);
+  void set_u64(std::string_view key, uint64_t val);
 
-  void set_bool(std::string key, bool val);
+  void set_bool(std::string_view key, bool val);
 
   std::unique_ptr<impl> impl_;
 };

--- a/include/broker/endpoint.hh
+++ b/include/broker/endpoint.hh
@@ -452,7 +452,7 @@ public:
   ///                this function may block.
   /// @returns `true` if `what` was added before the timeout, `false` otherwise.
   [[nodiscard]] bool
-  await_filter_entry(topic what,
+  await_filter_entry(const topic& what,
                      timespan timeout = defaults::await_peer_timeout);
 
   // -- worker management ------------------------------------------------------
@@ -514,9 +514,10 @@ protected:
   worker subscriber_;
 
 private:
-  worker do_subscribe(filter_type&& topics, detail::sink_driver_ptr driver);
+  worker do_subscribe(filter_type&& topics,
+                      const detail::sink_driver_ptr& driver);
 
-  worker do_publish_all(detail::source_driver_ptr driver);
+  worker do_publish_all(const detail::source_driver_ptr& driver);
 
   template <class F>
   worker make_worker(F fn);

--- a/include/broker/error.hh
+++ b/include/broker/error.hh
@@ -334,8 +334,7 @@ public:
 
   template <ec Code>
   static error make(ec_constant<Code>, endpoint_id node, std::string msg) {
-    return make_impl(Code, endpoint_info{std::move(node), std::nullopt},
-                     std::move(msg));
+    return make_impl(Code, endpoint_info{node, std::nullopt}, std::move(msg));
   }
 
 private:

--- a/include/broker/internal/clone_actor.hh
+++ b/include/broker/internal/clone_actor.hh
@@ -71,7 +71,7 @@ public:
 
   error consume_nil(consumer_type* src);
 
-  void close(consumer_type* src, error);
+  void close(consumer_type* src, const error&);
 
   void send(consumer_type*, channel_type::cumulative_ack);
 

--- a/include/broker/internal/core_actor.hh
+++ b/include/broker/internal/core_actor.hh
@@ -190,7 +190,7 @@ public:
   /// `init_new_peer` with the buffers that connect to the worker.
   caf::error init_new_peer(endpoint_id peer, const network_info& addr,
                            const filter_type& filter,
-                           pending_connection_ptr conn);
+                           const pending_connection_ptr& conn);
 
   /// Connects the input and output buffers for a new client to our central
   /// merge point.

--- a/include/broker/internal/json_client.hh
+++ b/include/broker/internal/json_client.hh
@@ -60,7 +60,7 @@ public:
 
   static std::string_view default_serialization_failed_error();
 
-  void init(filter_type filter, out_t out,
+  void init(const filter_type& filter, const out_t& out,
             caf::async::consumer_resource<data_message> core_pull);
 };
 

--- a/include/broker/internal/master_actor.hh
+++ b/include/broker/internal/master_actor.hh
@@ -85,7 +85,7 @@ public:
 
   error consume_nil(consumer_type* src);
 
-  void close(consumer_type* src, error);
+  void close(consumer_type* src, const error&);
 
   void send(consumer_type*, channel_type::cumulative_ack);
 

--- a/include/broker/internal/store_actor.hh
+++ b/include/broker/internal/store_actor.hh
@@ -103,7 +103,7 @@ public:
       [this](atom::increment, detail::shared_store_state_ptr ptr) {
         attached_states.emplace(std::move(ptr), size_t{0}).first->second += 1;
       },
-      [this](atom::decrement, detail::shared_store_state_ptr ptr) {
+      [this](atom::decrement, const detail::shared_store_state_ptr& ptr) {
         auto& xs = attached_states;
         if (auto i = xs.find(ptr); i != xs.end())
           if (--(i->second) == 0)
@@ -169,7 +169,7 @@ public:
   // -- convenience functions --------------------------------------------------
 
   /// Sends a delayed message by using the endpoint's clock.
-  void send_later(caf::actor hdl, timespan delay, caf::message msg);
+  void send_later(const caf::actor& hdl, timespan delay, caf::message msg);
 
   // -- member variables -------------------------------------------------------
 

--- a/include/broker/internal/web_socket.hh
+++ b/include/broker/internal/web_socket.hh
@@ -18,8 +18,9 @@ using connect_event_t = std::pair<pull_t, push_t>;
 using on_connect_t =
   std::function<void(const caf::settings&, connect_event_t&)>;
 
-expected<uint16_t> launch(caf::actor_system& sys, openssl_options_ptr ssl_cfg,
-                          std::string addr, uint16_t port, bool reuse_addr,
+expected<uint16_t> launch(caf::actor_system& sys,
+                          const openssl_options_ptr& ssl_cfg, std::string addr,
+                          uint16_t port, bool reuse_addr,
                           const std::string& allowed_path,
                           on_connect_t on_connect);
 

--- a/include/broker/message.hh
+++ b/include/broker/message.hh
@@ -77,7 +77,7 @@ using packed_message =
 inline packed_message make_packed_message(packed_message_type type,
                                           uint16_t ttl, topic dst,
                                           std::vector<std::byte> bytes) {
-  return packed_message{type, ttl, dst, std::move(bytes)};
+  return packed_message{type, ttl, std::move(dst), std::move(bytes)};
 }
 
 /// @relates packed_message

--- a/include/broker/status.hh
+++ b/include/broker/status.hh
@@ -116,13 +116,13 @@ public:
   template <sc S>
   static status make(endpoint_id node, std::string msg) {
     static_assert(sc_has_endpoint_info_v<S>);
-    return {S, endpoint_info{std::move(node), std::nullopt}, std::move(msg)};
+    return {S, endpoint_info{node, std::nullopt}, std::move(msg)};
   }
 
   template <sc S>
   static status make(sc_constant<S>, endpoint_id node, std::string msg) {
     static_assert(sc_has_endpoint_info_v<S>);
-    return {S, endpoint_info{std::move(node), std::nullopt}, std::move(msg)};
+    return {S, endpoint_info{node, std::nullopt}, std::move(msg)};
   }
 
   /// Default-constructs an unspecified status.

--- a/include/broker/store.hh
+++ b/include/broker/store.hh
@@ -103,11 +103,11 @@ public:
 
   store() = default;
 
-  store(store&&) = default;
+  store(store&&) noexcept = default;
 
   store(const store&);
 
-  store& operator=(store&&);
+  store& operator=(store&&) noexcept;
 
   store& operator=(const store&);
 
@@ -204,7 +204,7 @@ public:
         break;
     }
 
-    add(std::move(key), std::move(amount), init_type, std::move(expiry));
+    add(std::move(key), std::move(amount), init_type, expiry);
   }
 
   /// Decrements a value by a given amount. This is supported for all
@@ -213,7 +213,7 @@ public:
   /// @param value The amount to decrement the value.
   /// @param expiry An optional new expiration time for *key*.
   void decrement(data key, data amount, std::optional<timespan> expiry = {}) {
-    subtract(std::move(key), std::move(amount), std::move(expiry));
+    subtract(std::move(key), std::move(amount), expiry);
   }
 
   /// Appends a string to another one.
@@ -221,7 +221,7 @@ public:
   /// @param str The string to append.
   /// @param expiry An optional new expiration time for *key*.
   void append(data key, data str, std::optional<timespan> expiry = {}) {
-    add(std::move(key), std::move(str), data::type::string, std::move(expiry));
+    add(std::move(key), std::move(str), data::type::string, expiry);
   }
 
   /// Inserts an index into a set.
@@ -229,7 +229,7 @@ public:
   /// @param index The index to insert.
   /// @param expiry An optional new expiration time for *key*.
   void insert_into(data key, data index, std::optional<timespan> expiry = {}) {
-    add(std::move(key), std::move(index), data::type::set, std::move(expiry));
+    add(std::move(key), std::move(index), data::type::set, expiry);
   }
 
   /// Inserts an index into a table.
@@ -241,7 +241,7 @@ public:
   void insert_into(data key, data index, data value,
                    std::optional<timespan> expiry = {}) {
     add(std::move(key), vector({std::move(index), std::move(value)}),
-        data::type::table, std::move(expiry));
+        data::type::table, expiry);
   }
 
   /// Removes am index from a set or table.
@@ -249,7 +249,7 @@ public:
   /// @param index The index to remove.
   /// @param expiry An optional new expiration time for *key*.
   void remove_from(data key, data index, std::optional<timespan> expiry = {}) {
-    subtract(std::move(key), std::move(index), std::move(expiry));
+    subtract(std::move(key), std::move(index), expiry);
   }
 
   /// Appends a value to a vector.
@@ -257,15 +257,14 @@ public:
   /// @param value The value to append.
   /// @param expiry An optional new expiration time for *key*.
   void push(data key, data value, std::optional<timespan> expiry = {}) {
-    add(std::move(key), std::move(value), data::type::vector,
-        std::move(expiry));
+    add(std::move(key), std::move(value), data::type::vector, expiry);
   }
 
   /// Removes the last value of a vector.
   /// @param key The key of the vector from which to remove the last value.
   /// @param expiry An optional new expiration time for *key*.
-  void pop(data key, std::optional<timespan> expiry = {}) {
-    subtract(key, key, std::move(expiry));
+  void pop(const data& key, std::optional<timespan> expiry = {}) {
+    subtract(key, key, expiry);
   }
 
   // --await-idle-start

--- a/include/broker/store_event.hh
+++ b/include/broker/store_event.hh
@@ -75,7 +75,7 @@ public:
 
     entity_id publisher() const {
       if (auto value = to<endpoint_id>((*xs_)[5])) {
-        return {std::move(*value), get<uint64_t>((*xs_)[6])};
+        return {*value, get<uint64_t>((*xs_)[6])};
       }
       return {};
     }

--- a/include/broker/subnet.hh
+++ b/include/broker/subnet.hh
@@ -19,7 +19,7 @@ public:
   subnet();
 
   /// Construct subnet from an address and length.
-  subnet(address addr, uint8_t length);
+  subnet(const address& addr, uint8_t length);
 
   /// @return whether an address is contained within this subnet.
   bool contains(const address& addr) const;

--- a/src/broker-node.cc
+++ b/src/broker-node.cc
@@ -295,7 +295,7 @@ void relay_mode(broker::endpoint& ep, topic_list topics) {
     }
     return true;
   };
-  auto in = ep.make_subscriber(topics);
+  auto in = ep.make_subscriber(std::move(topics));
   auto& cfg = broker::internal::endpoint_access{&ep}.cfg();
   if (get_or(cfg, "verbose", false) && get_or(cfg, "rate", false)) {
     auto timeout = std::chrono::system_clock::now();
@@ -368,7 +368,7 @@ void ping_mode(broker::endpoint& ep, topic_list topics) {
 void pong_mode(broker::endpoint& ep, topic_list topics) {
   assert(topics.size() > 0);
   verbose::println("receive pings from topics ", topics);
-  auto in = ep.make_subscriber(topics);
+  auto in = ep.make_subscriber(std::move(topics));
   for (;;) {
     auto x = in.get();
     auto& val = get_data(x);

--- a/src/broker-pipe.cc
+++ b/src/broker-pipe.cc
@@ -185,7 +185,7 @@ void subscribe_mode_stream(broker::endpoint& ep, const std::string& topic_str,
     // Init.
     [](size_t& msgs) { msgs = 0; },
     // OnNext.
-    [cap](size_t& msgs, data_message x) {
+    [cap](size_t& msgs, const data_message& x) {
       ++msg_count;
       if (!rate)
         print_line(std::cout, to_string(x));

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -206,7 +206,7 @@ configuration::configuration() : configuration(skip_init) {
   init(0, nullptr);
 }
 
-configuration::configuration(configuration&& other)
+configuration::configuration(configuration&& other) noexcept
   : impl_(std::move(other.impl_)) {
   // cannot '= default' this because impl is incomplete in the header.
 }
@@ -443,28 +443,28 @@ void configuration::add_option(std::vector<std::string>* dst,
                                                           description);
 }
 
-void configuration::set(std::string key, timespan val) {
-  impl_->set(std::move(key), val);
+void configuration::set(std::string_view key, timespan val) {
+  impl_->set(key, val);
 }
 
-void configuration::set(std::string key, std::string val) {
-  impl_->set(std::move(key), std::move(val));
+void configuration::set(std::string_view key, std::string val) {
+  impl_->set(key, std::move(val));
 }
 
-void configuration::set(std::string key, std::vector<std::string> val) {
-  impl_->set(std::move(key), std::move(val));
+void configuration::set(std::string_view key, std::vector<std::string> val) {
+  impl_->set(key, std::move(val));
 }
 
-void configuration::set_i64(std::string key, int64_t val) {
-  impl_->set(std::move(key), val);
+void configuration::set_i64(std::string_view key, int64_t val) {
+  impl_->set(key, val);
 }
 
-void configuration::set_u64(std::string key, uint64_t val) {
-  impl_->set(std::move(key), val);
+void configuration::set_u64(std::string_view key, uint64_t val) {
+  impl_->set(key, val);
 }
 
-void configuration::set_bool(std::string key, bool val) {
-  impl_->set(std::move(key), val);
+void configuration::set_bool(std::string_view key, bool val) {
+  impl_->set(key, val);
 }
 
 std::optional<int64_t> configuration::read_i64(std::string_view key,

--- a/src/detail/memory_backend.cc
+++ b/src/detail/memory_backend.cc
@@ -15,7 +15,7 @@ memory_backend::memory_backend(backend_options opts)
 
 expected<void> memory_backend::put(const data& key, data value,
                                    std::optional<timestamp> expiry) {
-  store_[key] = {std::move(value), std::move(expiry)};
+  store_[key] = {std::move(value), expiry};
   return {};
 }
 
@@ -26,12 +26,12 @@ expected<void> memory_backend::add(const data& key, const data& value,
   if (i == store_.end()) {
     if (init_type == data::type::none)
       return ec::type_clash;
-    auto newv = std::make_pair(data::from_type(init_type), expiry);
-    i = store_.emplace(std::move(key), std::move(newv)).first;
+    auto new_val = std::make_pair(data::from_type(init_type), expiry);
+    i = store_.emplace(key, std::move(new_val)).first;
   }
   auto result = visit(adder{value}, i->second.first);
   if (result)
-    i->second.second = std::move(expiry);
+    i->second.second = expiry;
   return result;
 }
 
@@ -42,7 +42,7 @@ expected<void> memory_backend::subtract(const data& key, const data& value,
     return ec::no_such_key;
   auto result = visit(remover{value}, i->second.first);
   if (result)
-    i->second.second = std::move(expiry);
+    i->second.second = expiry;
   return result;
 }
 

--- a/src/detail/sqlite_backend.cc
+++ b/src/detail/sqlite_backend.cc
@@ -464,7 +464,7 @@ expected<expirables> sqlite_backend::expiries() const {
       auto expiry_count = sqlite3_column_int64(impl_->expiries, 1);
       auto duration = timespan(expiry_count);
       auto expiry = timestamp(duration);
-      auto e = expirable(std::move(*key), std::move(expiry));
+      auto e = expirable(std::move(*key), expiry);
       rval.emplace_back(std::move(e));
     } else {
       return {key.error()};

--- a/src/internal/core_actor.cc
+++ b/src/internal/core_actor.cc
@@ -56,8 +56,8 @@ core_actor_state::core_actor_state(caf::event_based_actor* self,
   if (conn) {
     auto on_peering = [this](endpoint_id remote_id, const network_info& addr,
                              const filter_type& filter,
-                             pending_connection_ptr conn) {
-      std::ignore = init_new_peer(remote_id, addr, filter, std::move(conn));
+                             const pending_connection_ptr& conn) {
+      std::ignore = init_new_peer(remote_id, addr, filter, conn);
     };
     auto on_peer_unavailable = [this](const network_info& addr) {
       peer_unavailable(addr);
@@ -184,7 +184,8 @@ caf::behavior core_actor_state::make_behavior() {
     [this](atom::peer, endpoint_id peer, const network_info& addr,
            const filter_type& filter, node_consumer_res in_res,
            node_producer_res out_res) -> caf::result<void> {
-      if (auto err = init_new_peer(peer, addr, filter, in_res, out_res))
+      if (auto err = init_new_peer(peer, addr, filter, std::move(in_res),
+                                   std::move(out_res)))
         return err;
       else
         return caf::unit;
@@ -242,7 +243,7 @@ caf::behavior core_actor_state::make_behavior() {
       dispatch(dst, pack(msg));
     },
     // -- interface for subscribers --------------------------------------------
-    [this](atom::subscribe, filter_type filter) {
+    [this](atom::subscribe, const filter_type& filter) {
       // Subscribe to topics without actually caring about the events. This
       // makes sure that this node receives events on the topics, which in means
       // we can forward them.
@@ -289,7 +290,8 @@ caf::behavior core_actor_state::make_behavior() {
     },
     // -- interface for publishers ---------------------------------------------
     [this](data_consumer_res src) {
-      auto sub = data_inputs->add(self->make_observable().from_resource(src));
+      auto sub =
+        data_inputs->add(self->make_observable().from_resource(std::move(src)));
       subscriptions.emplace_back(std::move(sub));
     },
     // -- data store management ------------------------------------------------
@@ -302,7 +304,7 @@ caf::behavior core_actor_state::make_behavior() {
     [this](atom::data_store, atom::master, atom::attach,
            const std::string& name, backend backend_type,
            backend_options opts) {
-      return attach_master(name, backend_type, opts);
+      return attach_master(name, backend_type, std::move(opts));
     },
     [this](atom::data_store, atom::master, atom::get,
            const std::string& name) -> caf::result<caf::actor> {
@@ -585,8 +587,8 @@ void core_actor_state::client_added(endpoint_id client_id,
   emit(endpoint_info{client_id, std::nullopt, type},
        sc_constant<sc::endpoint_discovered>(),
        "found a new client in the network");
-  emit(endpoint_info{client_id, addr, std::move(type)},
-       sc_constant<sc::peer_added>(), "handshake successful");
+  emit(endpoint_info{client_id, addr, type}, sc_constant<sc::peer_added>(),
+       "handshake successful");
 }
 
 void core_actor_state::client_removed(endpoint_id client_id,
@@ -595,7 +597,7 @@ void core_actor_state::client_removed(endpoint_id client_id,
   BROKER_TRACE(BROKER_ARG(client_id) << BROKER_ARG(addr) << BROKER_ARG(type));
   emit(endpoint_info{client_id, addr, type}, sc_constant<sc::peer_lost>(),
        "lost connection to client");
-  emit(endpoint_info{client_id, std::nullopt, std::move(type)},
+  emit(endpoint_info{client_id, std::nullopt, type},
        sc_constant<sc::endpoint_unreachable>(), "lost the last path");
 }
 
@@ -611,9 +613,10 @@ void core_actor_state::try_connect(const network_info& addr,
   adapter->async_connect(
     addr,
     [this, rp](endpoint_id peer, const network_info& addr,
-               const filter_type& filter, pending_connection_ptr conn) mutable {
+               const filter_type& filter,
+               const pending_connection_ptr& conn) mutable {
       BROKER_TRACE(BROKER_ARG(peer) << BROKER_ARG(addr) << BROKER_ARG(filter));
-      if (auto err = init_new_peer(peer, addr, filter, std::move(conn));
+      if (auto err = init_new_peer(peer, addr, filter, conn);
           err && err != ec::repeated_peering_handshake_request)
         rp.deliver(std::move(err));
       else
@@ -649,7 +652,7 @@ void core_actor_state::try_connect(const network_info& addr,
     },
     [this, rp, addr](const caf::error& what) mutable {
       BROKER_TRACE(BROKER_ARG(what));
-      rp.deliver(std::move(what));
+      rp.deliver(what);
       peer_unavailable(addr);
     });
 }
@@ -807,7 +810,7 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer_id,
                  BROKER_DEBUG("close output flow to" << peer_id); //
                })
                // Emit values to the producer resource.
-               .subscribe(out_res);
+               .subscribe(std::move(out_res));
   // Increase the logical time for this connection. This timestamp is crucial
   // for our do_finally handler, because this handler must do nothing if we have
   // already removed the connection manually, e.g., as a result of unpeering.
@@ -815,7 +818,7 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer_id,
   auto ts = (i == peers.end()) ? lamport_timestamp{} : ++i->second.ts;
   // Read messages from the peer.
   auto in = self->make_observable()
-              .from_resource(in_res)
+              .from_resource(std::move(in_res))
               // If the peer closes this buffer, we assume a disconnect.
               .do_finally([this, peer_id, ts] { //
                 BROKER_DEBUG("close input flow from" << peer_id);
@@ -852,7 +855,7 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer_id,
 caf::error core_actor_state::init_new_peer(endpoint_id peer,
                                            const network_info& addr,
                                            const filter_type& filter,
-                                           pending_connection_ptr ptr) {
+                                           const pending_connection_ptr& ptr) {
   // Spin up a background worker that takes care of socket I/O. We communicate
   // to this worker via producer/consumer buffer resources. The [rd_1, wr_1]
   // pair is the direction core actor -> network. The other pair is for the
@@ -902,11 +905,12 @@ caf::error core_actor_state::init_new_client(const network_info& addr,
     auto sub = central_merge
                  ->as_observable()
                  // Select by subscription.
-                 .filter([this, filter, client_id](const node_message& msg) {
+                 .filter([this, filt = std::move(filter),
+                          client_id](const node_message& msg) {
                    if (get_sender(msg) == client_id)
                      return false;
                    detail::prefix_matcher f;
-                   return f(filter, get_topic(msg));
+                   return f(filt, get_topic(msg));
                  })
                  // Deserialize payload and wrap it into an data message.
                  .flat_map_optional([this](const node_message& msg) {
@@ -915,12 +919,12 @@ caf::error core_actor_state::init_new_client(const network_info& addr,
                    return unpack<data_message>(get_packed_message(msg));
                  })
                  // Emit values to the producer resource.
-                 .subscribe(out_res);
+                 .subscribe(std::move(out_res));
     subscriptions.emplace_back(sub);
   }
   // Push messages received from the client into the central merge point.
   auto in = self->make_observable()
-              .from_resource(in_res)
+              .from_resource(std::move(in_res))
               // If the client closes this buffer, we assume a disconnect.
               .do_finally([this, client_id, addr, type] {
                 BROKER_DEBUG("client" << addr << "disconnected");
@@ -1066,7 +1070,7 @@ void core_actor_state::shutdown_stores() {
 // -- dispatching of messages to peers regardless of subscriptions ------------
 
 void core_actor_state::dispatch(endpoint_id receiver, packed_message msg) {
-  central_merge->append_to_buf(make_node_message(id, receiver, msg));
+  central_merge->append_to_buf(make_node_message(id, receiver, std::move(msg)));
   central_merge->try_push();
 }
 

--- a/src/internal/prometheus.cc
+++ b/src/internal/prometheus.cc
@@ -135,7 +135,7 @@ caf::behavior prometheus_actor::make_behavior() {
       if (num_connections() + num_doormen() == 0)
         quit();
     },
-    [this](data_message msg) {
+    [this](const data_message& msg) {
       BROKER_TRACE(BROKER_ARG(msg));
       collector_.insert_or_update(get_data(msg));
     },

--- a/src/internal/store_actor.cc
+++ b/src/internal/store_actor.cc
@@ -80,12 +80,12 @@ void store_actor_state::init(caf::event_based_actor* selfptr,
                               defaults::store::tick_interval);
   self //
     ->make_observable()
-    .from_resource(in_res)
+    .from_resource(std::move(in_res))
     .for_each([this](const command_message& msg) { dispatch(msg); },
               [this](const caf::error& what) { self->quit(what); },
               [this] { self->quit(); });
   out.emplace(self);
-  out->as_observable().subscribe(out_res);
+  out->as_observable().subscribe(std::move(out_res));
 }
 
 // -- event signaling ----------------------------------------------------------
@@ -147,7 +147,7 @@ void store_actor_state::on_down_msg(const caf::actor_addr& source,
 
 // -- convenience functions ----------------------------------------------------
 
-void store_actor_state::send_later(caf::actor hdl, timespan delay,
+void store_actor_state::send_later(const caf::actor& hdl, timespan delay,
                                    caf::message msg) {
   clock->send_later(facade(hdl), tick_interval, &msg);
 }

--- a/src/internal/web_socket.cc
+++ b/src/internal/web_socket.cc
@@ -109,8 +109,9 @@ void ssl_accept(caf::net::multiplexer& mpx, Socket fd,
   mpx.init(ptr);
 }
 
-expected<uint16_t> launch(caf::actor_system& sys, openssl_options_ptr ssl_cfg,
-                          std::string addr, uint16_t port, bool reuse_addr,
+expected<uint16_t> launch(caf::actor_system& sys,
+                          const openssl_options_ptr& ssl_cfg, std::string addr,
+                          uint16_t port, bool reuse_addr,
                           const std::string& allowed_path,
                           on_connect_t on_connect) {
   using namespace std::literals;

--- a/src/store.cc
+++ b/src/store.cc
@@ -194,7 +194,7 @@ store::store(endpoint_id this_peer, worker frontend, std::string name) {
   caf::anon_send(hdl, atom::increment_v, std::move(ptr));
 }
 
-store& store::operator=(store&& other) {
+store& store::operator=(store&& other) noexcept {
   with_state_ptr([this](detail::shared_store_state_ptr& st) {
     auto frontend = dref(st).frontend;
     caf::anon_send(frontend, atom::decrement_v, std::move(st));
@@ -463,7 +463,7 @@ void store::await_idle(std::function<void(bool)> callback, timespan timeout) {
   with_state_or(
     [&](state_impl& st) {
       auto await_actor = [cb{std::move(callback)}](caf::event_based_actor* self,
-                                                   caf::actor frontend,
+                                                   const caf::actor& frontend,
                                                    timespan t) {
         self->request(frontend, t, atom::await_v, atom::idle_v)
           .then([cb](atom::ok) { cb(true); },

--- a/src/subnet.cc
+++ b/src/subnet.cc
@@ -13,8 +13,7 @@ namespace broker {
 
 subnet::subnet() : len_(0) {}
 
-subnet::subnet(address addr, uint8_t length)
-  : net_(std::move(addr)), len_(length) {
+subnet::subnet(const address& addr, uint8_t length) : net_(addr), len_(length) {
   if (init())
     return;
   net_ = {};

--- a/src/telemetry/metric_registry.cc
+++ b/src/telemetry/metric_registry.cc
@@ -260,7 +260,7 @@ public:
   using super = impl_base;
 
   post_init_impl(internal::endpoint_context_ptr ctx)
-    : super(std::addressof(ctx->sys.metrics())), ctx_(ctx) {
+    : super(std::addressof(ctx->sys.metrics())), ctx_(std::move(ctx)) {
     // nop
   }
 


### PR DESCRIPTION
Followup to #274, relates #249.

The performance findings of `clang-tidy` where mostly about (mis-) using `move` on primitive types, omitting `noexcept` in trivial constructors and making unnecessary copies where a const-reference (or view type such as `std::string_view`) would do.