### PR TITLE
 Enable modernize-* checks and apply auto-fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,10 +2,15 @@
   Checks: -*,
           bugprone-*,
           clang-analyzer-*,
+          modernize-*,
           performance-*,
           -bugprone-easily-swappable-parameters,
           -clang-analyzer-security.insecureAPI.rand,
           -clang-analyzer-webkit*,
+          -modernize-avoid-c-arrays,
+          -modernize-use-equals-default,
+          -modernize-use-nodiscard,
+          -modernize-use-trailing-return-type,
   WarningsAsErrors: '*'
   HeaderFilterRegex: 'broker/.*.hh'
 ...

--- a/include/broker/alm/multipath.hh
+++ b/include/broker/alm/multipath.hh
@@ -304,7 +304,7 @@ public:
     }
   }
 
-  multipath(const tree_ptr&, multipath_node*);
+  multipath(tree_ptr, multipath_node*);
 
   explicit multipath(const tree_ptr& tptr) : multipath(tptr, tptr->root) {
     // nop

--- a/include/broker/detail/die.hh
+++ b/include/broker/detail/die.hh
@@ -2,8 +2,7 @@
 
 #include <iostream>
 
-namespace broker {
-namespace detail {
+namespace broker::detail {
 
 template <class T>
 void render(T&& x) {
@@ -26,5 +25,4 @@ template <class... Ts>
   std::abort();
 }
 
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/include/broker/detail/make_backend.hh
+++ b/include/broker/detail/make_backend.hh
@@ -7,11 +7,9 @@
 
 #include "broker/detail/abstract_backend.hh"
 
-namespace broker {
-namespace detail {
+namespace broker::detail {
 
 std::unique_ptr<abstract_backend> make_backend(backend type,
                                                backend_options opts);
 
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/include/broker/detail/memory_backend.hh
+++ b/include/broker/detail/memory_backend.hh
@@ -7,8 +7,7 @@
 
 #include "broker/detail/abstract_backend.hh"
 
-namespace broker {
-namespace detail {
+namespace broker::detail {
 
 /// An in-memory key-value storage backend.
 class memory_backend : public abstract_backend {
@@ -52,5 +51,4 @@ private:
   std::unordered_map<data, timestamp> expirations_;
 };
 
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/include/broker/detail/operators.hh
+++ b/include/broker/detail/operators.hh
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace broker {
-namespace detail {
+namespace broker::detail {
 
 template <class T, class U = T>
 struct equality_comparable {
@@ -29,5 +28,4 @@ template <class T, class U = T>
 struct totally_ordered : equality_comparable<T, U>,
                          less_than_comparable<T, U> {};
 
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/include/broker/detail/sink_driver.hh
+++ b/include/broker/detail/sink_driver.hh
@@ -106,7 +106,7 @@ public:
     new (&init_) Init(std::move(init_fn));
   }
 
-  ~sink_driver_impl() {
+  ~sink_driver_impl() override {
     if (!initialized_)
       after_init();
   }
@@ -161,7 +161,7 @@ public:
     new (&init_) Init(std::move(init_fn));
   }
 
-  ~sink_driver_impl() {
+  ~sink_driver_impl() override {
     if (!initialized_)
       after_init();
   }

--- a/include/broker/detail/source_driver.hh
+++ b/include/broker/detail/source_driver.hh
@@ -99,7 +99,7 @@ public:
     new (&init_) Init(std::move(init_fn));
   }
 
-  ~source_driver_impl() {
+  ~source_driver_impl() override {
     if (!initialized_)
       after_init();
   }
@@ -148,7 +148,7 @@ public:
     new (&init_) Init(std::move(init_fn));
   }
 
-  ~source_driver_impl() {
+  ~source_driver_impl() override {
     if (!initialized_)
       after_init();
   }

--- a/include/broker/detail/sqlite_backend.hh
+++ b/include/broker/detail/sqlite_backend.hh
@@ -16,7 +16,7 @@ public:
   ///             the filesystem.
   sqlite_backend(backend_options opts = backend_options{});
 
-  ~sqlite_backend();
+  ~sqlite_backend() override;
 
   bool init_failed() const;
 

--- a/include/broker/internal/flare_actor.hh
+++ b/include/broker/internal/flare_actor.hh
@@ -14,14 +14,12 @@ class flare_actor;
 
 } // namespace broker::internal
 
-namespace caf {
-namespace mixin {
+namespace caf::mixin {
 
 template <>
 struct is_blocking_requester<broker::internal::flare_actor> : std::true_type {};
 
-} // namespace mixin
-} // namespace caf
+} // namespace caf::mixin
 
 namespace broker::internal {
 
@@ -51,7 +49,7 @@ public:
 
 private:
   detail::flare flare_;
-  int flare_count_;
+  int flare_count_ = 0;
   std::mutex flare_mtx_;
 };
 

--- a/include/broker/status.hh
+++ b/include/broker/status.hh
@@ -126,7 +126,7 @@ public:
   }
 
   /// Default-constructs an unspecified status.
-  status() : code_(sc::unspecified) {
+  status() {
     // nop
   }
 
@@ -181,7 +181,7 @@ private:
     // nop
   }
 
-  sc code_;
+  sc code_ = sc::unspecified;
   endpoint_info context_;
   std::string message_;
 };

--- a/src/alm/multipath.cc
+++ b/src/alm/multipath.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "broker/alm/multipath.hh"
 
 #include "broker/alm/routing_table.hh"
@@ -139,8 +141,8 @@ multipath::multipath(const endpoint_id& id, bool is_receiver) : multipath(id) {
   head_->is_receiver_ = is_receiver;
 }
 
-multipath::multipath(const tree_ptr& t, multipath_node* h)
-  : tree_(t), head_(h) {
+multipath::multipath(tree_ptr t, multipath_node* h)
+  : tree_(std::move(t)), head_(h) {
   // nop
 }
 

--- a/src/broker-node.cc
+++ b/src/broker-node.cc
@@ -388,7 +388,7 @@ void pong_mode(broker::endpoint& ep, topic_list topics) {
 
 int main(int argc, char** argv) try {
   broker::endpoint::system_guard sys_guard; // Initialize global state.
-  setvbuf(stdout, NULL, _IOLBF, 0);         // Always line-buffer stdout.
+  setvbuf(stdout, nullptr, _IOLBF, 0);      // Always line-buffer stdout.
   // Parse CLI parameters using our config.
   broker::configuration cfg{broker::skip_init};
   extend_config(cfg);

--- a/src/broker-pipe.cc
+++ b/src/broker-pipe.cc
@@ -113,7 +113,7 @@ void publish_mode_select(broker::endpoint& ep, const std::string& topic_str,
   while (i < cap) {
     FD_ZERO(&readset);
     FD_SET(fd, &readset);
-    if (select(fd + 1, &readset, NULL, NULL, NULL) <= 0) {
+    if (select(fd + 1, &readset, nullptr, nullptr, nullptr) <= 0) {
       print_line(std::cerr, "select() failed, errno: " + std::to_string(errno));
       return;
     }
@@ -160,7 +160,7 @@ void subscribe_mode_select(broker::endpoint& ep, const std::string& topic_str,
   while (i < cap) {
     FD_ZERO(&readset);
     FD_SET(fd, &readset);
-    if (select(fd + 1, &readset, NULL, NULL, NULL) <= 0) {
+    if (select(fd + 1, &readset, nullptr, nullptr, nullptr) <= 0) {
       print_line(std::cerr, "select() failed, errno: " + std::to_string(errno));
       return;
     }

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -191,7 +192,7 @@ configuration::configuration(skip_init_t) {
   using std::string;
   using string_list = std::vector<string>;
   init_global_state();
-  impl_.reset(new impl);
+  impl_ = std::make_unique<impl>();
 }
 
 configuration::configuration(broker_options opts) : configuration(skip_init) {

--- a/src/detail/flare.cc
+++ b/src/detail/flare.cc
@@ -1,6 +1,6 @@
 #include "broker/detail/flare.hh"
 
-#include <errno.h>
+#include <cerrno>
 
 #include <algorithm>
 #include <exception>
@@ -38,7 +38,7 @@ bool try_again_later() {
 
 #else // BROKER_WINDOWS
 
-#  include <errno.h>
+#  include <cerrno>
 #  include <fcntl.h>
 #  include <poll.h>
 #  include <unistd.h>

--- a/src/detail/make_backend.cc
+++ b/src/detail/make_backend.cc
@@ -5,8 +5,7 @@
 #include "broker/detail/memory_backend.hh"
 #include "broker/detail/sqlite_backend.hh"
 
-namespace broker {
-namespace detail {
+namespace broker::detail {
 
 std::unique_ptr<detail::abstract_backend> make_backend(backend type,
                                                        backend_options opts) {
@@ -24,5 +23,4 @@ std::unique_ptr<detail::abstract_backend> make_backend(backend type,
   die("invalid backend type");
 }
 
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/src/detail/memory_backend.cc
+++ b/src/detail/memory_backend.cc
@@ -5,8 +5,7 @@
 #include "broker/detail/appliers.hh"
 #include "broker/detail/memory_backend.hh"
 
-namespace broker {
-namespace detail {
+namespace broker::detail {
 
 memory_backend::memory_backend(backend_options opts)
   : options_{std::move(opts)} {
@@ -75,9 +74,9 @@ expected<data> memory_backend::get(const data& key) const {
 
 expected<data> memory_backend::keys() const {
   set keys;
-  for (auto i = store_.begin(); i != store_.end(); i++)
-    keys.insert(i->first);
-  return expected<data>(std::move(keys));
+  for (const auto& i : store_)
+    keys.insert(i.first);
+  return {std::move(keys)};
 }
 
 expected<data> memory_backend::get(const data& key, const data& value) const {
@@ -116,5 +115,4 @@ expected<expirables> memory_backend::expiries() const {
   return {std::move(rval)};
 }
 
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/src/detail/prefix_matcher.cc
+++ b/src/detail/prefix_matcher.cc
@@ -1,7 +1,6 @@
 #include "broker/detail/prefix_matcher.hh"
 
-namespace broker {
-namespace detail {
+namespace broker::detail {
 
 bool prefix_matcher::operator()(const filter_type& filter,
                                 const topic& t) const noexcept {
@@ -11,5 +10,4 @@ bool prefix_matcher::operator()(const filter_type& filter,
   return false;
 }
 
-} // namespace detail
-} // namespace broker
+} // namespace broker::detail

--- a/src/internal/connector.cc
+++ b/src/internal/connector.cc
@@ -272,7 +272,7 @@ public:
     // nop
   }
 
-  ~plain_pending_connection() {
+  ~plain_pending_connection() override {
     caf::net::close(fd_);
   }
 
@@ -307,7 +307,7 @@ public:
     // nop
   }
 
-  ~encrypted_pending_connection() {
+  ~encrypted_pending_connection() override {
     caf::net::close(fd_);
   }
 
@@ -378,7 +378,7 @@ public:
     // nop
   }
 
-  const char* what() const noexcept {
+  const char* what() const noexcept override {
     if (flags_ & (POLLRDHUP | POLLHUP))
       return "POLLRDHUP: cannot read from closed pipe";
     else if (flags_ & POLLERR)

--- a/src/internal/core_actor.cc
+++ b/src/internal/core_actor.cc
@@ -22,6 +22,7 @@
 #include <caf/stream_slot.hpp>
 #include <caf/system_messages.hpp>
 #include <caf/unit.hpp>
+#include <memory>
 
 #include "broker/detail/assert.hh"
 #include "broker/detail/make_backend.hh"
@@ -80,9 +81,10 @@ core_actor_state::core_actor_state(caf::event_based_actor* self,
     auto on_peer_unavailable = [this](const network_info& addr) {
       peer_unavailable(addr);
     };
-    adapter.reset(new connector_adapter(self, std::move(conn), on_peering,
-                                        on_peer_unavailable, filter,
-                                        peer_statuses));
+    adapter = std::make_unique<connector_adapter>(self, std::move(conn),
+                                                  on_peering,
+                                                  on_peer_unavailable, filter,
+                                                  peer_statuses);
   }
 }
 

--- a/src/internal/flare_actor.cc
+++ b/src/internal/flare_actor.cc
@@ -10,8 +10,7 @@
 
 namespace broker::internal {
 
-flare_actor::flare_actor(caf::actor_config& sys)
-  : blocking_actor{sys}, flare_count_{0} {}
+flare_actor::flare_actor(caf::actor_config& sys) : blocking_actor{sys} {}
 
 void flare_actor::launch(caf::execution_unit*, bool, bool) {
   // Nothing todo here since we only extract messages via receive() calls.

--- a/src/internal/metric_collector.cc
+++ b/src/internal/metric_collector.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "broker/internal/metric_collector.hh"
 
 #include "broker/internal/logger.hh"
@@ -295,22 +297,28 @@ metric_collector::instance(const std::string& endpoint_name, metric_view mv) {
     instance_ptr new_instance;
     switch (mv.type()) {
       case metric_type::int_counter:
-        new_instance.reset(new remote_counter<integer>(owned(labels), fptr));
+        new_instance = std::make_unique<remote_counter<integer>>(owned(labels),
+                                                                 fptr);
         break;
       case metric_type::dbl_counter:
-        new_instance.reset(new remote_counter<real>(owned(labels), fptr));
+        new_instance = std::make_unique<remote_counter<real>>(owned(labels),
+                                                              fptr);
         break;
       case metric_type::int_gauge:
-        new_instance.reset(new remote_gauge<integer>(owned(labels), fptr));
+        new_instance = std::make_unique<remote_gauge<integer>>(owned(labels),
+                                                               fptr);
         break;
       case metric_type::dbl_gauge:
-        new_instance.reset(new remote_gauge<real>(owned(labels), fptr));
+        new_instance = std::make_unique<remote_gauge<real>>(owned(labels),
+                                                            fptr);
         break;
       case metric_type::int_histogram:
-        new_instance.reset(new remote_histogram<integer>(owned(labels), fptr));
+        new_instance =
+          std::make_unique<remote_histogram<integer>>(owned(labels), fptr);
         break;
       case metric_type::dbl_histogram:
-        new_instance.reset(new remote_histogram<real>(owned(labels), fptr));
+        new_instance = std::make_unique<remote_histogram<real>>(owned(labels),
+                                                                fptr);
         break;
       default:
         return nullptr;

--- a/src/internal/prometheus.cc
+++ b/src/internal/prometheus.cc
@@ -1,5 +1,6 @@
 #include "broker/internal/prometheus.hh"
 
+#include <memory>
 #include <string_view>
 
 #include <caf/actor_system_config.hpp>
@@ -146,7 +147,8 @@ caf::behavior prometheus_actor::make_behavior() {
     },
   };
   auto params = metric_exporter_params::from(config());
-  exporter_.reset(new exporter_state_type(this, core_, std::move(params)));
+  exporter_ = std::make_unique<exporter_state_type>(this, core_,
+                                                    std::move(params));
   return bhvr.or_else(exporter_->make_behavior());
 }
 

--- a/src/publisher.cc
+++ b/src/publisher.cc
@@ -39,7 +39,7 @@ public:
     // nop
   }
 
-  ~publisher_queue() {
+  ~publisher_queue() override {
     if (buf_)
       buf_->close();
   }

--- a/src/store.cc
+++ b/src/store.cc
@@ -55,7 +55,7 @@ public:
     BROKER_DEBUG("created state for store" << this->name);
   }
 
-  ~state_impl() {
+  ~state_impl() override {
     BROKER_DEBUG("destroyed state for store" << name);
   }
 

--- a/src/subscriber.cc
+++ b/src/subscriber.cc
@@ -39,7 +39,7 @@ public:
     // nop
   }
 
-  ~subscriber_queue() {
+  ~subscriber_queue() override {
     if (buf_)
       buf_->cancel();
   }

--- a/src/version.cc
+++ b/src/version.cc
@@ -1,7 +1,6 @@
 #include "broker/version.hh"
 
-namespace broker {
-namespace version {
+namespace broker::version {
 
 std::string string() {
   using std::to_string;
@@ -9,5 +8,4 @@ std::string string() {
          + to_string(version::patch) + version::suffix;
 }
 
-} // namespace version
-} // namespace broker
+} // namespace broker::version


### PR DESCRIPTION
 Note: changes have been automatically generated from `clang-tidy`.

Relates #249.