### PR TITLE
Fix CMake package file when bundling CAF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ if (CAF_ROOT)
     find_package(CAF REQUIRED COMPONENTS openssl test io core)
   endif()
   list(APPEND LINK_LIBS CAF::core CAF::io)
+  set(BROKER_USE_EXTERNAL_CAF ON)
 else ()
   message(STATUS "Using bundled CAF")
   set(CAF_ENABLE_EXAMPLES OFF CACHE INTERNAL "")
@@ -219,11 +220,15 @@ else ()
   add_subdirectory(caf EXCLUDE_FROM_ALL)
   list(APPEND OPTIONAL_SRC $<TARGET_OBJECTS:libcaf_core_obj>)
   list(APPEND OPTIONAL_SRC $<TARGET_OBJECTS:libcaf_io_obj>)
+  set(BROKER_USE_EXTERNAL_CAF OFF)
 endif ()
 
 # NOTE: building and linking against a different version of the CAF incubator is
 #       also FOR DEVELOPMENT ONLY.
 if (CAFIncubator_ROOT)
+  if(NOT BROKER_USE_EXTERNAL_CAF)
+    message(FATAL_ERROR "Cannot use bundled CAF with an external incubator")
+  endif()
   if (CMAKE_VERSION VERSION_LESS 3.12)
     find_package(CAFIncubator REQUIRED COMPONENTS net PATHS "${CAF_ROOT}")
   else()
@@ -231,6 +236,9 @@ if (CAFIncubator_ROOT)
   endif()
   list(APPEND LINK_LIBS CAF::net)
 else()
+  if(BROKER_USE_EXTERNAL_CAF)
+    message(FATAL_ERROR "Cannot use an external CAF with the bundled incubator")
+  endif()
   message(STATUS "Using bundled CAF incubator")
   set(CAF_INC_ENABLE_TESTING OFF CACHE INTERNAL "")
   set(CAF_INC_ENABLE_BB_MODULE OFF CACHE INTERNAL "")
@@ -511,15 +519,15 @@ install(
   EXPORT BrokerTargets
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Broker")
 
-write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfigVersion.cmake"
-  VERSION ${BROKER_VERSION}
-  COMPATIBILITY ExactVersion)
-
 configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/src/BrokerConfig.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfig.cmake"
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Broker")
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfigVersion.cmake"
+  VERSION ${BROKER_VERSION}
+  COMPATIBILITY ExactVersion)
 
 install(
   FILES

--- a/src/BrokerConfig.cmake.in
+++ b/src/BrokerConfig.cmake.in
@@ -8,7 +8,10 @@ find_dependency(Threads REQUIRED)
 
 find_dependency(OpenSSL REQUIRED)
 
-find_dependency(CAF @CAF_VERSION@ REQUIRED COMPONENTS core io)
+set(BROKER_USE_EXTERNAL_CAF @BROKER_USE_EXTERNAL_CAF@)
+if(BROKER_USE_EXTERNAL_CAF)
+  find_dependency(CAF @CAF_VERSION@ REQUIRED COMPONENTS core io net)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/BrokerTargets.cmake")
 


### PR DESCRIPTION
I noticed the other day that the CMake packaging for `libbroker` is broken ever since we switched a setup that makes CAF opaque. It's still unconditionally asking to find a CAF package, even when using the bundled version (default). This means users have to install a matching CAF release even though nothing actually requires it anymore. This matters for Zeek only when trying to use an external Broker library (which isn't officially supported, but this is how I found out that Broker ships broken CMake packages during development).

The new version turns the `find_dependecy` line off for the (default) bundled build.

A default build, after installing to a `local` prefix:

```
$ fgrep -R CAF local/lib/cmake .
local/lib/cmake/Broker/BrokerConfig.cmake:set(BROKER_USE_EXTERNAL_CAF OFF)
local/lib/cmake/Broker/BrokerConfig.cmake:if(BROKER_USE_EXTERNAL_CAF)
local/lib/cmake/Broker/BrokerConfig.cmake:  find_dependency(CAF 0.18.5 REQUIRED COMPONENTS core io net)
```

A build configured to use an external CAF, after installing to a `local` prefix:

```
$ fgrep -R CAF local/lib/cmake .
local/lib/cmake//Broker/BrokerTargets.cmake:  INTERFACE_LINK_LIBRARIES "Threads::Threads;OpenSSL::SSL;OpenSSL::Crypto;CAF::core;CAF::io;CAF::net"
local/lib/cmake//Broker/BrokerConfig.cmake:set(BROKER_USE_EXTERNAL_CAF ON)
local/lib/cmake//Broker/BrokerConfig.cmake:if(BROKER_USE_EXTERNAL_CAF)
local/lib/cmake//Broker/BrokerConfig.cmake:  find_dependency(CAF 0.18.5 REQUIRED COMPONENTS core io net)
```

That first hit is:

```
set_target_properties(broker PROPERTIES
  INTERFACE_LINK_LIBRARIES "Threads::Threads;OpenSSL::SSL;OpenSSL::Crypto;CAF::core;CAF::io;CAF::net"
)
```

Note that there's no hit in the targets file in the default build (as there shouldn't be).