### PR TITLE
Configure script: drop --with-caf, add -D option

### DIFF
--- a/configure
+++ b/configure
@@ -22,7 +22,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --enable-debug         compile in debugging mode (like --build-type=Debug)
     --enable-static        build static libraries (in addition to shared)
     --enable-static-only   only build static libraries, not shared
-    --with-log-level=LVL   enble debugging output.
+    --with-log-level=LVL   enable debugging output via the CAF logger.
                            Levels: ERROR, WARNING, INFO, DEBUG, TRACE
     --with-clang-tidy      run with clang-tidy (requires CMake >= 3.7.2)
     --sanitizers=LIST      comma-separated list of sanitizer names to enable

--- a/configure
+++ b/configure
@@ -22,8 +22,8 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --enable-debug         compile in debugging mode (like --build-type=Debug)
     --enable-static        build static libraries (in addition to shared)
     --enable-static-only   only build static libraries, not shared
-    --with-log-level=LVL   build embedded CAF with debugging output.  Levels:
-                             ERROR, WARNING, INFO, DEBUG, TRACE
+    --with-log-level=LVL   enble debugging output.
+                           Levels: ERROR, WARNING, INFO, DEBUG, TRACE
     --with-clang-tidy      run with clang-tidy (requires CMake >= 3.7.2)
     --sanitizers=LIST      comma-separated list of sanitizer names to enable
     --disable-sanitizer-optimizations
@@ -53,8 +53,10 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
                            build micro benchmarks (requires Google Benchmark)
 
   Required Packages in Non-Standard Locations:
-    --with-caf=PATH        path to CAF installation (use only for development!)
     --with-openssl=PATH    path to OpenSSL install root
+
+  Advanced Options (for developers):
+    -D PARAM               passes a parameter directly to CMake
 
   Influential Environment Variables (only on first invocation
   per build directory):
@@ -93,6 +95,14 @@ while [ $# -ne 0 ]; do
         --help|-h)
             echo "${usage}" 1>&2
             exit 1
+            ;;
+        -D)
+            shift
+            if [ $# -eq 0 ]; then
+                echo "Error: -D requires an argument."
+                exit 1
+            fi
+            CMakeCacheEntries="$CMakeCacheEntries -D $1"
             ;;
         --cmake=*)
             CMakeCommand=$optarg
@@ -155,9 +165,6 @@ while [ $# -ne 0 ]; do
             ;;
         --disable-tests)
             append_cache_entry BROKER_DISABLE_TESTS BOOL    true
-            ;;
-        --with-caf=*)
-            append_cache_entry CAF_ROOT             PATH    $optarg
             ;;
         --with-openssl=*)
             append_cache_entry OPENSSL_ROOT_DIR     PATH    $optarg


### PR DESCRIPTION
As discussed in https://github.com/zeek/broker/pull/285 (also see https://github.com/zeek/zeek/issues/2524): `--with-caf` is currently broken and we don't want users to build and link against an external CAF. To keep this option available for developers, we instead add a new, generic way to add flags directly to CMake via `-D <cmake-param>`. That isn't limited to CAF, so it simply offers a generic way to pass CMake arguments through the `configure` script directly to `CMake`.