### PR TITLE
Add interface include dirs to broker lib targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,10 @@ if (ENABLE_SHARED)
   install(TARGETS broker
           EXPORT BrokerTargets
           DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  target_include_directories(broker INTERFACE
+                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+                             $<INSTALL_INTERFACE:include>)
 endif ()
 
 if (ENABLE_STATIC)
@@ -399,6 +403,10 @@ if (ENABLE_STATIC)
   install(TARGETS broker_static
           EXPORT BrokerTargets
           DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  target_include_directories(broker_static INTERFACE
+                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+                             $<INSTALL_INTERFACE:include>)
 endif ()
 
 if (ENABLE_SHARED)


### PR DESCRIPTION
This fixes a bug in our CMake package for Broker. I've encountered this when trying to use the CMake package for Broker: compiling against Broker will fail, because we don't tell downstream projects where to find the headers. So this patch simply adds interface include paths that we then [pick up in our BrokerConfig.cmake](https://github.com/zeek/broker/blob/3b1029dbab5439197ad35a0b0ec4aa5074bacda7/src/BrokerConfig.cmake.in#L21).