### PR TITLE
Minimize messaging in sim_clock::advance_time

### DIFF
--- a/src/endpoint.cc
+++ b/src/endpoint.cc
@@ -207,22 +207,38 @@ public:
         --pending_count_;
       }
     }
-    // Wait for response messages.
+    // Send messages to all actors that we sync with.
     caf::scoped_actor self{ctx_->sys};
-    for (auto& who : sync_with_actors) {
+    for (auto& who : sync_with_actors)
       self->send(who, atom::sync_point_v, self);
-      self->delayed_send(self, timeout::frontend, atom::tick_v);
+    // Schedule a timeout (tick) message to abort syncing in case the actors
+    // take too long.
+    auto tout_mme = caf::make_mailbox_element(self->ctrl(),
+                                              caf::make_message_id(),
+                                              caf::no_stages, atom::tick_v);
+    auto& caf_clock = self->clock();
+    auto tout =
+      caf_clock.schedule_message(caf_clock.now() + timeout::frontend,
+                                 caf::actor_cast<caf::strong_actor_ptr>(self),
+                                 std::move(tout_mme));
+    // Wait for response messages.
+    bool abort_syncing = false;
+    for (size_t i = 0; !abort_syncing && i < sync_with_actors.size(); ++i)
       self->receive(
         [&](atom::sync_point) {
           // nop
         },
         [&](atom::tick) {
           BROKER_DEBUG("advance_time actor syncing timed out");
+          abort_syncing = true;
         },
         [&](caf::error& e) {
           BROKER_DEBUG("advance_time actor syncing failed");
+          abort_syncing = true;
         });
-    }
+    // Dispose the timeout if it's still pending to avoid unnecessary messaging.
+    if (!abort_syncing)
+      tout.dispose();
   }
 
   void send_later(worker dest, timespan after, void* vptr) override {


### PR DESCRIPTION
This applies the performance optimization that we've discussed in https://github.com/zeek/zeek/issues/2454.

The gist of it is the sim-clock now sends its `sync_point` messages to all stores at once and then collects all responses in a second loop, also using a single timeout message instead of having one per store.