### PR TITLE
Add the branch whitelist to the Windows/Clang-Tidy Cirrus tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -61,6 +61,7 @@ clang_tidy_task:
   sync_submodules_script: git submodule update --recursive --init
   build_script: ./ci/analyze.sh
   << : *UNIX_ENV
+  << : *BRANCH_WHITELIST
 
 fedora35_task:
   container:
@@ -266,4 +267,4 @@ windows_task:
     BROKER_CI_CPUS: 8
     # Give verbose error output on a test failure.
     CTEST_OUTPUT_ON_FAILURE: 1
-
+  <<: *BRANCH_WHITELIST


### PR DESCRIPTION
Without these changes, Cirrus spins up a build for Windows and clang-tidy with every change to the repo. I noticed it when making tags for the latest releases, since it started those two tasks in a separate build from the release branches. This forces those tasks to follow the same branch rules as all of the other tasks.