### PR TITLE
Zeek 5.0.x compatibility

### DIFF
--- a/include/broker/time.hh
+++ b/include/broker/time.hh
@@ -42,7 +42,8 @@ void convert(timestamp t, std::string& str);
 void convert(timestamp i, double& secs);
 
 /// @relates timespan
-void convert(double secs, timespan& i);
+/// @note always returns `true` for compatibility with Zeek 5.0 releases.
+bool convert(double secs, timespan& i);
 
 /// @relates timespan
 void convert(double secs, timestamp& ts);

--- a/src/time.cc
+++ b/src/time.cc
@@ -27,8 +27,9 @@ void convert(timestamp t, double& secs) {
            .count();
 }
 
-void convert(double secs, timespan& s) {
+bool convert(double secs, timespan& s) {
   s = std::chrono::duration_cast<timespan>(fractional_seconds{secs});
+  return true;
 }
 
 void convert(double secs, timestamp& ts) {


### PR DESCRIPTION
Just a minor change that makes it easier to run current Broker versions with Zeek 5.0 releases.