### PR TITLE
Implement graceful disconnect handshake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,7 @@ set(BROKER_SRC
   src/internal/metric_factory.cc
   src/internal/metric_scraper.cc
   src/internal/metric_view.cc
+  src/internal/peering.cc
   src/internal/pending_connection.cc
   src/internal/prometheus.cc
   src/internal/store_actor.cc

--- a/include/broker/defaults.hh
+++ b/include/broker/defaults.hh
@@ -19,6 +19,9 @@ constexpr size_t output_generator_file_cap = std::numeric_limits<size_t>::max();
 /// Configures the default timeout of @ref endpoint::await_peer.
 constexpr timespan await_peer_timeout = std::chrono::seconds{10};
 
+/// Configures the default timeout for unpeering from another node.
+constexpr timespan unpeer_timeout = std::chrono::seconds{3};
+
 } // namespace broker::defaults
 
 namespace broker::defaults::subscriber {

--- a/include/broker/internal/core_actor.hh
+++ b/include/broker/internal/core_actor.hh
@@ -4,6 +4,7 @@
 #include "broker/internal/connector.hh"
 #include "broker/internal/connector_adapter.hh"
 #include "broker/internal/fwd.hh"
+#include "broker/internal/peering.hh"
 #include "broker/lamport_timestamp.hh"
 
 #include <caf/disposable.hpp>
@@ -24,38 +25,8 @@ class core_actor_state {
 public:
   // -- member types -----------------------------------------------------------
 
-  /// Bundles state for a single connected peer.
-  struct peer_state {
-    /// Handle for aborting inputs from this peer.
-    caf::disposable in;
-
-    /// Handle for aborting outputs to this peer.
-    caf::disposable out;
-
-    /// Network address as reported from the transport (usually TCP).
-    network_info addr;
-
-    /// Stores whether the connection to this peer has been closed. We set this
-    /// flag instead of removing the peer entirely for implementing reconnects.
-    bool invalidated = false;
-
-    /// A logical timestamp for avoiding race conditions on this state.
-    lamport_timestamp ts;
-
-    peer_state() = delete;
-
-    peer_state(caf::disposable in, caf::disposable out, network_info addr)
-      : in(std::move(in)), out(std::move(out)), addr(std::move(addr)) {
-      // nop
-    }
-
-    peer_state(peer_state&&) = default;
-
-    peer_state& operator=(peer_state&&) = default;
-  };
-
   /// Convenience alias for a map of @ref peer_state objects.
-  using peer_state_map = std::unordered_map<endpoint_id, peer_state>;
+  using peer_state_map = std::unordered_map<endpoint_id, peering_ptr>;
 
   /// Bundles message-related metrics that have a label dimension for the type.
   struct message_metrics_t {
@@ -108,8 +79,11 @@ public:
   /// Creates the initial set of message handlers for `self`.
   caf::behavior make_behavior();
 
-  /// Cleans up all state for an orderly shutdown.
+  /// Initiates an orderly shutdown.
   void shutdown(shutdown_options options);
+
+  /// Cleans up all state.
+  void finalize_shutdown();
 
   // -- convenience functions --------------------------------------------------
 
@@ -143,33 +117,6 @@ public:
 
   // -- callbacks --------------------------------------------------------------
 
-  /// Called whenever this peer discovers a new peer in the network.
-  /// @param peer_id ID of the new peer.
-  /// @note The new peer gets stored in the routing table *before* calling this
-  ///       member function.
-  void peer_discovered(endpoint_id peer_id);
-
-  /// Called whenever this peer established a new connection.
-  /// @param peer_id ID of the newly connected peer.
-  /// @param addr Network address for the peer.
-  /// @note The new peer gets stored in the routing table *before* calling this
-  ///       member function.
-  void peer_connected(endpoint_id peer_id, const network_info& net);
-
-  /// Called whenever this peer lost a connection to a remote peer.
-  /// @param peer_id ID of the disconnected peer.
-  /// @param addr Network address for the peer.
-  void peer_disconnected(endpoint_id peer_id, const network_info& addr);
-
-  /// Called whenever this peer removed a direct connection to a remote peer.
-  /// @param peer_id ID of the removed peer.
-  /// @param addr Network address for the peer.
-  void peer_removed(endpoint_id peer_id, const network_info& addr);
-
-  /// Called after removing the last path to `peer_id` from the routing table.
-  /// @param peer_id ID of the (now unreachable) peer.
-  void peer_unreachable(endpoint_id peer_id);
-
   /// Called whenever the user tried to unpeer from an unknown peer.
   /// @param xs Either a peer ID, an actor handle or a network info.
   void cannot_remove_peer(endpoint_id x);
@@ -194,16 +141,6 @@ public:
 
   /// Tries to asynchronously connect to addr via the connector.
   void try_connect(const network_info& addr, caf::response_promise rp);
-
-  /// Cleans up state when a peer is shutting down the connection.
-  /// @param peer_id ID of the affected peer.
-  /// @param ts Timestamp of the connection. This function does nothing if the
-  ///           connection has been re-established in the meantime.
-  /// @param reason Error code describing why the peer is shutting the
-  ///               connection or a default-constructed error on regular
-  ///               shutdown.
-  void handle_peer_close_event(endpoint_id peer_id, lamport_timestamp ts,
-                               caf::error& reason);
 
   // -- flow management --------------------------------------------------------
 
@@ -268,9 +205,6 @@ public:
 
   /// Disconnects a peer by demand of the user.
   void unpeer(const network_info& peer_addr);
-
-  /// Disconnects a peer by demand of the user.
-  void unpeer(peer_state_map::iterator i);
 
   // -- properties -------------------------------------------------------------
 
@@ -357,6 +291,10 @@ public:
 
   /// Time-to-live when sending messages.
   uint16_t ttl;
+
+  /// When shutting down, this scheduled action forces disconnects on all peers
+  /// after the timeout.
+  caf::disposable shutting_down_timeout;
 
   /// Returns whether `shutdown` was called.
   bool shutting_down();

--- a/include/broker/internal/core_actor.hh
+++ b/include/broker/internal/core_actor.hh
@@ -218,9 +218,6 @@ public:
   /// with the connector, which needs access to the filter during handshake.
   shared_filter_ptr filter;
 
-  /// Stores known filters from other peers.
-  std::unordered_map<endpoint_id, filter_type> peer_filters;
-
   /// Stores whether this peer disabled forwarding, i.e., only appears as leaf
   /// node to other peers.
   bool disable_forwarding = false;

--- a/include/broker/internal/peering.hh
+++ b/include/broker/internal/peering.hh
@@ -19,10 +19,9 @@ namespace broker::internal {
 
 class peering : public std::enable_shared_from_this<peering> {
 public:
-  peering(const network_info& peer_addr,
-          std::shared_ptr<filter_type> peer_filter, endpoint_id id,
-          endpoint_id peer_id)
-    : addr_(peer_addr),
+  peering(network_info peer_addr, std::shared_ptr<filter_type> peer_filter,
+          endpoint_id id, endpoint_id peer_id)
+    : addr_(std::move(peer_addr)),
       filter_(std::move(peer_filter)),
       id_(id),
       peer_id_(peer_id) {

--- a/include/broker/internal/peering.hh
+++ b/include/broker/internal/peering.hh
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "broker/endpoint.hh"
+#include "broker/internal/connector.hh"
+#include "broker/internal/connector_adapter.hh"
+#include "broker/internal/fwd.hh"
+
+#include <caf/disposable.hpp>
+#include <caf/flow/item_publisher.hpp>
+#include <caf/flow/observable.hpp>
+#include <caf/make_counted.hpp>
+#include <caf/telemetry/counter.hpp>
+#include <caf/telemetry/gauge.hpp>
+
+#include <memory>
+
+namespace broker::internal {
+
+class peering : public std::enable_shared_from_this<peering> {
+public:
+  peering(endpoint_id id, endpoint_id peer_id) : id_(id), peer_id_(peer_id) {
+    // nop
+  }
+
+
+  /// Called when the ACK message for out BYE.
+  void on_bye_ack();
+
+  /// Forces the peering to shut down its connection without performing the BYE
+  /// handshake.
+  void force_disconnect();
+
+  void schedule_bye_timeout(caf::scheduled_actor* self);
+
+  std::vector<std::byte> make_bye_token();
+
+  node_message make_bye_message();
+
+  /// Returns the status message after losing the connection. If the
+  /// connection was closed by calling `remove`, this function returns a
+  /// `peer_removed` message. Otherwise, `peer_disconnected`.
+  node_message status_msg();
+
+  /// Sets up the pipeline for this peer.
+  caf::flow::observable<node_message>
+  setup(caf::scheduled_actor* self, node_consumer_res in_res,
+        node_producer_res out_res, caf::flow::observable<node_message> src);
+
+  /// Queries whether `remove` was called.
+  bool removed() const noexcept {
+    return removed_;
+  }
+
+  /// Tag this peering as removed and send a BYE message on the `snk` for a
+  /// graceful shutdown.
+  void remove(caf::scheduled_actor* self,
+              caf::flow::item_publisher<node_message>& snk,
+              bool with_timeout = true);
+
+  /// Returns the ID of this node.
+  endpoint_id id() const {
+    return id_;
+  }
+
+  /// Returns the ID of the peered node.
+  endpoint_id peer_id() const {
+    return peer_id_;
+  }
+
+  /// Returns the network address of the peered node.
+  const network_info& addr() const {
+    return addr_;
+  }
+
+  /// Sets a new value for the network address.
+  void addr(const network_info& new_value) {
+    addr_ = new_value;
+  }
+
+private:
+  /// Indicates whether we have explicitly removed this connection by sending a
+  /// BYE message to the peer.
+  bool removed_ = false;
+
+  /// Network address as reported from the transport (usually TCP).
+  network_info addr_;
+
+  /// Handle for aborting inputs.
+  caf::disposable in_;
+
+  /// Handle for aborting outputs.
+  caf::disposable out_;
+
+  /// Set in core_actor_state::unpeer.
+  caf::disposable bye_timeout_;
+
+  /// A 64-bit token that we use as ping payload when unpeering. The ping is
+  /// the last message we send. When receiving a pong message with that token,
+  /// we know all messages arrived and can shut down the connection.
+  uint64_t bye_id_ = 0;
+
+  /// The ID of this node.
+  endpoint_id id_;
+
+  /// The ID of our peer.
+  endpoint_id peer_id_;
+};
+
+using peering_ptr = std::shared_ptr<peering>;
+
+} // namespace broker::internal

--- a/include/broker/internal/peering.hh
+++ b/include/broker/internal/peering.hh
@@ -19,8 +19,13 @@ namespace broker::internal {
 
 class peering : public std::enable_shared_from_this<peering> {
 public:
-  peering(filter_type peer_filter, endpoint_id id, endpoint_id peer_id)
-    : filter_(std::move(peer_filter)), id_(id), peer_id_(peer_id) {
+  peering(const network_info& peer_addr,
+          std::shared_ptr<filter_type> peer_filter, endpoint_id id,
+          endpoint_id peer_id)
+    : addr_(peer_addr),
+      filter_(std::move(peer_filter)),
+      id_(id),
+      peer_id_(peer_id) {
     // nop
   }
 
@@ -83,12 +88,12 @@ public:
 
   /// Returns the filter of the peer.
   const filter_type& filter() const noexcept {
-    return filter_;
+    return *filter_;
   }
 
   /// Set a new filter for the peer.
   void filter(filter_type new_filter) {
-    filter_ = std::move(new_filter);
+    *filter_ = std::move(new_filter);
   }
 
 private:
@@ -100,7 +105,7 @@ private:
   network_info addr_;
 
   /// Stores the subscriptions of the remote peer.
-  filter_type filter_;
+  std::shared_ptr<filter_type> filter_;
 
   /// Handle for aborting inputs.
   caf::disposable in_;

--- a/src/internal/core_actor.cc
+++ b/src/internal/core_actor.cc
@@ -773,6 +773,11 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer_id,
         if (!ptr->removed() && !ptr->addr().address.empty()
             && ptr->addr().has_retry_time())
           try_connect(ptr->addr(), caf::response_promise{});
+        // Shutting down? Finalize shutdown after removing the last peer.
+        if (shutting_down() && peers.empty()) {
+          shutting_down_timeout.dispose();
+          finalize_shutdown();
+        }
       })
       .as_observable());
   peers.emplace(peer_id, ptr);

--- a/src/internal/core_actor.cc
+++ b/src/internal/core_actor.cc
@@ -32,19 +32,6 @@
 
 namespace broker::internal {
 
-namespace {
-
-constexpr size_t bye_token_size = 11;
-
-void set_bye_token(caf::byte* token, uint64_t bye_id) {
-  const auto* prefix = "BYE";
-  const auto* suffix = &bye_id;
-  memcpy(token, prefix, 3);
-  memcpy(token + 3, suffix, 8);
-}
-
-} // namespace
-
 // --- constructors and destructors --------------------------------------------
 
 core_actor_state::metrics_t::metrics_t(caf::actor_system& sys) {

--- a/src/internal/core_actor.cc
+++ b/src/internal/core_actor.cc
@@ -32,6 +32,19 @@
 
 namespace broker::internal {
 
+namespace {
+
+constexpr size_t bye_token_size = 11;
+
+void set_bye_token(caf::byte* token, uint64_t bye_id) {
+  const auto* prefix = "BYE";
+  const auto* suffix = &bye_id;
+  memcpy(token, prefix, 3);
+  memcpy(token + 3, suffix, 8);
+}
+
+} // namespace
+
 // --- constructors and destructors --------------------------------------------
 
 core_actor_state::metrics_t::metrics_t(caf::actor_system& sys) {
@@ -97,7 +110,7 @@ core_actor_state::~core_actor_state() {
 caf::behavior core_actor_state::make_behavior() {
   // Create the central "bus" where everything flows through.
   central_merge = flow_inputs.as_observable().merge().share();
-  // Process filter updates from our peers and add instrumentation for metrics.
+  // Process control messages and add instrumentation for metrics.
   central_merge //
     .for_each([this](const node_message& msg) {
       auto sender = get_sender(msg);
@@ -105,33 +118,38 @@ caf::behavior core_actor_state::make_behavior() {
       auto& metrics = metrics_for(get_type(msg));
       metrics.processed->inc();
       metrics.buffered->dec();
-      // We only care about incoming filter updates messages here.
-      if (sender == id || get_type(msg) != packed_message_type::routing_update)
+      // Ignore our own outputs.
+      if (sender == id)
         return;
-      // Deserialize payload and update peer filter.
-      if (auto i = peer_filters.find(sender); i != peer_filters.end()) {
-        filter_type new_filter;
-        caf::binary_deserializer src{nullptr, get_payload(msg)};
-        if (src.apply(new_filter)) {
-          i->second.swap(new_filter);
-        } else {
-          BROKER_ERROR("received malformed routing update from" << sender);
+      // Dispatch on the type of the message.
+      switch (get_type(msg)) {
+        default:
+          break;
+        case packed_message_type::routing_update: {
+          // Deserialize payload and update peer filter.
+          if (auto i = peer_filters.find(sender); i != peer_filters.end()) {
+            filter_type new_filter;
+            caf::binary_deserializer src{nullptr, get_payload(msg)};
+            if (src.apply(new_filter)) {
+              i->second.swap(new_filter);
+            } else {
+              BROKER_ERROR("received malformed routing update from" << sender);
+            }
+          } else {
+            // Ignore. Probably a stale message after unpeering.
+          }
+          break;
         }
-      } else {
-        // Ignore. Probably a stale message after unpeering.
+        case packed_message_type::ping: {
+          // Respond to PING messages with a PONG that has the same payload.
+          auto& payload = get_payload(msg);
+          BROKER_DEBUG("received a PING message with a payload of"
+                       << payload.size() << "bytes");
+          dispatch(sender, make_packed_message(packed_message_type::pong, ttl,
+                                               get_topic(msg), payload));
+          break;
+        }
       }
-    });
-  // Respond to PING messages.
-  central_merge //
-    .for_each([this](const node_message& msg) {
-      auto sender = get_sender(msg);
-      if (sender == id || get_type(msg) != packed_message_type::ping)
-        return;
-      auto& payload = get_payload(msg);
-      BROKER_DEBUG("received a PING message with a payload of" << payload.size()
-                                                               << "bytes");
-      dispatch(sender, make_packed_message(packed_message_type::pong, 1,
-                                           get_topic(msg), payload));
     });
   // Initialize data_outputs and command_outputs.
   data_outputs =
@@ -239,7 +257,7 @@ caf::behavior core_actor_state::make_behavior() {
     [this](atom::get, atom::peer) {
       std::vector<peer_info> result;
       for (const auto& [peer_id, state] : peers) {
-        endpoint_info info{peer_id, state.addr};
+        endpoint_info info{peer_id, state->addr()};
         result.emplace_back(peer_info{std::move(info), peer_flags::remote,
                                       peer_status::connected});
       }
@@ -399,8 +417,7 @@ caf::behavior core_actor_state::make_behavior() {
     },
     [this](atom::await, endpoint_id peer_id) {
       auto rp = self->make_response_promise();
-      if (auto i = peers.find(peer_id);
-          i != peers.end() && !i->second.invalidated)
+      if (auto i = peers.find(peer_id); i != peers.end())
         rp.deliver(peer_id);
       else
         awaited_peers.emplace(peer_id, rp);
@@ -416,27 +433,14 @@ caf::behavior core_actor_state::make_behavior() {
 
 void core_actor_state::shutdown(shutdown_options options) {
   BROKER_TRACE(BROKER_ARG(options));
+  if (shutting_down())
+    return;
   // Tell the connector to shut down. No new connection allowed.
   if (adapter)
     adapter->async_shutdown();
-  // Close the shared state for the peers.
-  peer_statuses->close();
   // Shut down data stores.
   shutdown_stores();
-  // Drop all peers. Don't cancel their flows, though. Incoming flows were
-  // cancelled already and output flows get closed automatically once the
-  // mergers shut down.
-  for (auto& kvp : peers) {
-    auto& [peer_id, st] = kvp;
-    if (!st.invalidated) {
-      BROKER_DEBUG("drop state for" << peer_id);
-      peer_removed(peer_id, st.addr);
-      peer_unreachable(peer_id);
-    }
-  }
-  peers.clear();
-  // Close all inputs.
-  unsafe_inputs.close();
+  // We no longer add new input flows.
   flow_inputs.close();
   // Cancel all subscriptions to local publishers.
   for (auto& sub : subscriptions)
@@ -450,8 +454,7 @@ void core_actor_state::shutdown(shutdown_options options) {
   awaited_peers.clear();
   // Ignore future messages. Calling unbecome() removes our 'behavior' (set of
   // message handlers). An actor without behavior runs as long as still has
-  // active flows. Once the flows processed currently pending data the actor
-  // goes down.
+  // active flows. Once the last flow terminates, the actor goes down.
   self->unbecome();
   self->set_default_handler(
     [](caf::scheduled_actor* sptr, caf::message&) -> caf::skippable_result {
@@ -465,6 +468,29 @@ void core_actor_state::shutdown(shutdown_options options) {
       else
         return caf::make_message();
     });
+  // Close all peers gracefully. By disposing their outputs, we send the BYE
+  // message and wait for the "ack" (via one last pong message).
+  if (peers.empty()) {
+    // Nothing to wait for, do the final steps right away.
+    finalize_shutdown();
+    return;
+  }
+  for (auto& kvp : peers)
+    kvp.second->remove(self, unsafe_inputs, false);
+  shutting_down_timeout = self->run_delayed(defaults::unpeer_timeout,
+                                            [this] { finalize_shutdown(); });
+}
+
+void core_actor_state::finalize_shutdown() {
+  // Drop any remaining state of peers.
+  for (auto& kvp : peers)
+    kvp.second->force_disconnect();
+  peers.clear();
+  // Close the shared state for all peers.
+  peer_statuses->close();
+  // Close all inputs.
+  unsafe_inputs.close();
+  // After this point, any remaining flow should stop and the actor terminate.
 }
 
 // -- convenience functions ----------------------------------------------------
@@ -546,7 +572,7 @@ bool core_actor_state::is_subscribed_to(endpoint_id id, const topic& what) {
 
 std::optional<network_info> core_actor_state::addr_of(endpoint_id id) const {
   if (auto i = peers.find(id); i != peers.end())
-    return i->second.addr;
+    return i->second->addr();
   else
     return std::nullopt;
 }
@@ -559,42 +585,6 @@ std::vector<endpoint_id> core_actor_state::peer_ids() const {
 }
 
 // -- callbacks ----------------------------------------------------------------
-
-void core_actor_state::peer_discovered(endpoint_id peer_id) {
-  BROKER_TRACE(BROKER_ARG(peer_id));
-  emit(endpoint_info{peer_id}, sc_constant<sc::endpoint_discovered>(),
-       "found a new peer in the network");
-}
-
-void core_actor_state::peer_connected(endpoint_id peer_id,
-                                      const network_info& addr) {
-  BROKER_TRACE(BROKER_ARG(peer_id) << BROKER_ARG(addr));
-  emit(endpoint_info{peer_id, addr}, sc_constant<sc::peer_added>(),
-       "handshake successful");
-}
-
-void core_actor_state::peer_disconnected(endpoint_id peer_id,
-                                         const network_info& addr) {
-  BROKER_TRACE(BROKER_ARG(peer_id) << BROKER_ARG(addr));
-  emit(endpoint_info{peer_id, addr}, sc_constant<sc::peer_lost>(),
-       "lost connection to remote peer");
-  peer_filters.erase(peer_id);
-}
-
-void core_actor_state::peer_removed(endpoint_id peer_id,
-                                    const network_info& addr) {
-  BROKER_TRACE(BROKER_ARG(peer_id));
-  emit(endpoint_info{peer_id, addr}, sc_constant<sc::peer_removed>(),
-       "removed connection to remote peer");
-  peer_filters.erase(peer_id);
-}
-
-void core_actor_state::peer_unreachable(endpoint_id peer_id) {
-  BROKER_TRACE(BROKER_ARG(peer_id));
-  emit(endpoint_info{peer_id}, sc_constant<sc::endpoint_unreachable>(),
-       "lost the last path");
-  peer_filters.erase(peer_id);
-}
 
 void core_actor_state::cannot_remove_peer(endpoint_id peer_id) {
   BROKER_TRACE(BROKER_ARG(peer_id));
@@ -664,8 +654,8 @@ void core_actor_state::try_connect(const network_info& addr,
         // Override the address if this one has a retry field. This makes
         // sure we "prefer" a user-defined address over addresses we read
         // from sockets for incoming peerings.
-        if (addr.has_retry_time() && !i->second.addr.has_retry_time())
-          i->second.addr = addr;
+        if (addr.has_retry_time() && !i->second->addr().has_retry_time())
+          i->second->addr(addr);
         rp.deliver(atom::peer_v, atom::ok_v, peer);
       } else {
         // Race on the state. May happen if the remote peer already
@@ -677,8 +667,8 @@ void core_actor_state::try_connect(const network_info& addr,
         self->run_delayed(1ms, [this, peer, addr, rp]() mutable {
           BROKER_TRACE(BROKER_ARG(peer) << BROKER_ARG(addr));
           if (auto i = peers.find(peer); i != peers.end()) {
-            if (addr.has_retry_time() && !i->second.addr.has_retry_time())
-              i->second.addr = addr;
+            if (addr.has_retry_time() && !i->second->addr().has_retry_time())
+              i->second->addr(addr);
             rp.deliver(atom::peer_v, atom::ok_v, peer);
           } else {
             try_connect(addr, rp);
@@ -691,41 +681,6 @@ void core_actor_state::try_connect(const network_info& addr,
       rp.deliver(what);
       peer_unavailable(addr);
     });
-}
-
-void core_actor_state::handle_peer_close_event(endpoint_id peer_id,
-                                               lamport_timestamp ts,
-                                               caf::error& reason) {
-  if (auto i = peers.find(peer_id);
-      i != peers.end() && !i->second.invalidated && i->second.ts == ts) {
-    // Update our 'global' state for this peer.
-    auto status = peer_status::peered;
-    if (peer_statuses->update(peer_id, status, peer_status::disconnected)) {
-      BROKER_DEBUG(peer_id << ":: peered -> disconnected");
-    } else {
-      BROKER_ERROR("invalid status for new peer" << BROKER_ARG(peer_id)
-                                                 << BROKER_ARG(status));
-      // TODO: we could also consider this a fatal error instead. Probably worth
-      //       a discussion or two. For now, we just assume so other part of the
-      //       system is doing something with this peer and leave the state.
-      return;
-    }
-    // Close any pending flows and mark as disconnected / invalid.
-    i->second.invalidated = true;
-    i->second.in.dispose();
-    i->second.out.dispose();
-    // Trigger events.
-    peer_disconnected(peer_id, i->second.addr);
-    peer_unreachable(peer_id);
-    // If there is a retry time, it means that we have established the peering.
-    // Try reconnecting.
-    if (i->second.addr.has_retry_time()) {
-      try_connect(i->second.addr, caf::response_promise{});
-    }
-  } else {
-    // Nothing to do. We have already cleaned up this state, probably as a
-    // result of unpeering.
-  }
 }
 
 // -- flow management ----------------------------------------------------------
@@ -742,7 +697,7 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer_id,
   }
   // Sanity checking: make sure this isn't a repeated handshake.
   auto i = peers.find(peer_id);
-  if (i != peers.end() && !i->second.invalidated)
+  if (i != peers.end())
     return caf::make_error(ec::repeated_peering_handshake_request);
   // Set the status for this peer to 'peered'. The only legal transitions are
   // 'nil -> peered' and 'connected -> peered'.
@@ -763,71 +718,64 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer_id,
   // Store the filter for is_subscribed_to.
   peer_filters[peer_id] = filter;
   // Hook into the central merge point for forwarding the data to the peer.
-  auto out = central_merge
-               // Select by subscription and sender/receiver fields.
-               .filter([this, pid = peer_id](const node_message& msg) {
-                 if (get_sender(msg) == pid)
-                   return false;
-                 if (disable_forwarding && get_sender(msg) != id)
-                   return false;
-                 auto receiver = get_receiver(msg);
-                 return receiver == pid
-                        || (!receiver && is_subscribed_to(pid, get_topic(msg)));
-               })
-               // Override the sender field. This makes sure the sender field
-               // always reflects the last hop. Since we only need this
-               // information to avoid forwarding loops, "sender" really just
-               // means "last hop" right now.
-               .map([this](const node_message& msg) {
-                 if (get_sender(msg) == id) {
-                   return msg;
-                 } else {
-                   using std::get;
-                   auto cpy = msg;
-                   get<0>(cpy.unshared()) = id;
-                   return cpy;
-                 }
-               })
-               .do_finally([this, peer_id] {
-                 BROKER_DEBUG("close output flow to" << peer_id); //
-               })
-               // Emit values to the producer resource.
-               .subscribe(std::move(out_res));
-  // Increase the logical time for this connection. This timestamp is crucial
-  // for our do_finally handler, because this handler must do nothing if we have
-  // already removed the connection manually, e.g., as a result of unpeering.
-  // Otherwise, we might drop a re-connected peer on accident.
-  auto ts = (i == peers.end()) ? lamport_timestamp{} : ++i->second.ts;
-  // Read messages from the peer.
-  auto [in, ks] = self->make_observable()
-                    .from_resource(std::move(in_res))
-                    .do_on_next([this](const node_message& msg) {
-                      metrics_for(get_type(msg)).buffered->inc();
-                    })
-                    // If the peer closes this buffer, we assume a disconnect.
-                    .do_finally([this, peer_id, ts] { //
-                      BROKER_DEBUG("close input flow from" << peer_id);
-                      metrics.native_connections->dec();
-                      caf::error reason;
-                      handle_peer_close_event(peer_id, ts, reason);
-                    })
-                    // Ignore any errors from the peer.
-                    .on_error_complete()
-                    .compose(add_killswitch_t{});
+  auto ptr = std::make_shared<peering>(id, peer_id);
+  auto in = ptr->setup(
+    self, std::move(in_res), std::move(out_res),
+    central_merge
+      // Select by subscription and sender/receiver fields.
+      .filter([this, pid = peer_id](const node_message& msg) {
+        if (get_sender(msg) == pid)
+          return false;
+        if (disable_forwarding && get_sender(msg) != id)
+          return false;
+        auto receiver = get_receiver(msg);
+        return receiver == pid
+               || (!receiver && is_subscribed_to(pid, get_topic(msg)));
+      })
+      // Override the sender field. This makes sure the sender field
+      // always reflects the last hop. Since we only need this
+      // information to avoid forwarding loops, "sender" really just
+      // means "last hop" right now.
+      .map([this](const node_message& msg) {
+        if (get_sender(msg) == id) {
+          return msg;
+        } else {
+          using std::get;
+          auto cpy = msg;
+          get<0>(cpy.unshared()) = id;
+          return cpy;
+        }
+      })
+      .as_observable());
   // Push messages received from the peer into the central merge point.
-  flow_inputs.push(in);
-  // Store some state to allow us to unpeer() from the node later.
-  subscriptions.emplace_back(ks);
-  if (i == peers.end()) {
-    i = peers.emplace(peer_id, peer_state{ks, std::move(out), addr}).first;
-  } else {
-    i->second.in = ks;
-    i->second.out = std::move(out);
-    i->second.invalidated = false;
-  }
-  // Emit status updates.
-  peer_discovered(peer_id);
-  peer_connected(peer_id, i->second.addr);
+  flow_inputs.push( //
+    in
+      // Add instrumentation for metrics.
+      .do_on_next([this](const node_message& msg) {
+        metrics_for(get_type(msg)).buffered->inc();
+      })
+      // Handle peer disconnect events.
+      .do_on_complete([this, peer_id, ptr] {
+        // Update our 'global' state for this peer.
+        auto status = peer_status::peered;
+        if (peer_statuses->update(peer_id, status, peer_status::disconnected)) {
+          BROKER_DEBUG(peer_id << ":: peered -> disconnected");
+        } else {
+          BROKER_ERROR("invalid status for disconnected peer"
+                       << BROKER_ARG(peer_id) << BROKER_ARG(status));
+          // TODO: maybe we should consider this a fatal error?
+        }
+        // Clean up state our local state.
+        peer_filters.erase(peer_id);
+        peers.erase(peer_id);
+        // Trigger a reconnect if we have initiated the peering and did not
+        // disconnect this peer as a result of unpeering from it.
+        if (!ptr->removed() && !ptr->addr().address.empty()
+            && ptr->addr().has_retry_time())
+          try_connect(ptr->addr(), caf::response_promise{});
+      })
+      .as_observable());
+  peers.emplace(peer_id, ptr);
   // Notify clients that wait for this peering.
   if (auto [first, last] = awaited_peers.equal_range(peer_id); first != last) {
     for (auto i = first; i != last; ++i)
@@ -1104,43 +1052,18 @@ void core_actor_state::broadcast_subscriptions() {
 void core_actor_state::unpeer(endpoint_id peer_id) {
   BROKER_TRACE(BROKER_ARG(peer_id));
   if (auto i = peers.find(peer_id); i != peers.end())
-    unpeer(i);
+    i->second->remove(self, unsafe_inputs);
   else
     cannot_remove_peer(peer_id);
 }
 
-void core_actor_state::unpeer(const network_info& peer_addr) {
-  BROKER_TRACE(BROKER_ARG(peer_addr));
-  auto pred = [peer_addr](auto& kvp) { return kvp.second.addr == peer_addr; };
+void core_actor_state::unpeer(const network_info& addr) {
+  BROKER_TRACE(BROKER_ARG(addr));
+  auto pred = [&addr](auto& kvp) { return kvp.second->addr() == addr; };
   if (auto i = std::find_if(peers.begin(), peers.end(), pred); i != peers.end())
-    unpeer(i);
+    i->second->remove(self, unsafe_inputs);
   else
-    cannot_remove_peer(peer_addr);
-}
-
-void core_actor_state::unpeer(peer_state_map::iterator i) {
-  BROKER_TRACE("");
-  if (i == peers.end()) {
-    // Nothing to do.
-  } else if (auto& st = i->second; st.invalidated) {
-    BROKER_DEBUG(i->first << "already unpeered (invalidated)");
-  } else {
-    auto peer_id = i->first;
-    BROKER_DEBUG("drop state for" << peer_id);
-    // Drop local state for this peer.
-    st.invalidated = true;
-    st.in.dispose();
-    st.out.dispose();
-    auto addr = std::move(st.addr);
-    peers.erase(i);
-    // Drop shared state for this peer.
-    auto& psm = *peer_statuses;
-    BROKER_DEBUG(peer_id << "::" << psm.get(peer_id) << "-> ()");
-    psm.remove(peer_id);
-    // Emit events.
-    peer_removed(peer_id, addr);
-    peer_unreachable(peer_id);
-  }
+    cannot_remove_peer(addr);
 }
 
 bool core_actor_state::shutting_down() {

--- a/src/internal/peering.cc
+++ b/src/internal/peering.cc
@@ -1,0 +1,216 @@
+#include "broker/internal/peering.hh"
+
+#include "broker/data.hh"
+#include "broker/internal/killswitch.hh"
+#include "broker/internal/type_id.hh"
+#include "broker/topic.hh"
+
+#include <caf/binary_serializer.hpp>
+#include <caf/scheduled_actor/flow.hpp>
+
+namespace broker::internal {
+
+namespace {
+
+// ASCII sequence 'BYE' followed by our 64-bit bye ID.
+constexpr size_t bye_token_size = 11;
+
+class affix_generator {
+public:
+  using output_type = node_message;
+
+  affix_generator(peering_ptr ptr) : ptr_(std::move(ptr)) {}
+
+  template <class Step, class... Steps>
+  void pull(size_t n, Step& step, Steps&... steps) {
+    while (n > 0) {
+      switch (emitted_) {
+        case 0:{
+          if (!step.on_next(first(), steps...))
+            return;
+          break;
+          }
+        case 1: {
+          if (!step.on_next(second(), steps...))
+            return;
+          break;
+        }
+        default: {
+          step.on_complete(steps...);
+          return;
+        }
+      }
+      ++emitted_;
+      --n;
+    }
+  }
+
+  template <class Info, sc S>
+  node_message make_status_msg(Info&& ep, sc_constant<S> code,
+                               const char* msg) const {
+    auto val = status::make(code, std::forward<Info>(ep), msg);
+    auto content = get_as<data>(val);
+    caf::byte_buffer buf;
+    caf::binary_serializer snk{nullptr, buf};
+    std::ignore = snk.apply(content);
+    // TODO: this conversion is going to become superfluous with CAF 0.19.
+    auto first = reinterpret_cast<std::byte*>(buf.data());
+    std::vector<std::byte> bytes{first, first + buf.size()};
+    auto pmsg = make_packed_message(packed_message_type::data, defaults::ttl,
+                                    topic{std::string{topic::statuses_str}},
+                                    std::move(bytes));
+    return make_node_message(ptr_->id(), ptr_->id(), std::move(pmsg));
+  }
+
+  virtual node_message first() = 0;
+
+  virtual node_message second() = 0;
+
+protected:
+  peering_ptr ptr_;
+
+private:
+  size_t emitted_ = 0;
+};
+
+class prefix_generator : public affix_generator {
+public:
+  using super = affix_generator;
+
+  using super::super;
+
+  node_message first() override {
+    return make_status_msg(endpoint_info{ptr_->peer_id()},
+                           sc_constant<sc::endpoint_discovered>(),
+                           "found a new peer in the network");
+  }
+
+  node_message second() override {
+    return make_status_msg(endpoint_info{ptr_->peer_id(), ptr_->addr()},
+                           sc_constant<sc::peer_added>(),
+                           "handshake successful");
+  }
+};
+
+class suffix_generator : public affix_generator {
+public:
+  using super = affix_generator;
+
+  using super::super;
+
+  node_message first() override {
+    if (ptr_->removed()) {
+      return make_status_msg(endpoint_info{ptr_->peer_id(), ptr_->addr()},
+                             sc_constant<sc::peer_removed>(),
+                             "removed connection to remote peer");
+    } else {
+      return make_status_msg(endpoint_info{ptr_->peer_id(), ptr_->addr()},
+                             sc_constant<sc::peer_lost>(),
+                             "lost connection to remote peer");
+    }
+  }
+
+  node_message second() override {
+    return make_status_msg(endpoint_info{ptr_->peer_id()},
+                           sc_constant<sc::endpoint_unreachable>(),
+                           "lost the last path");
+  }
+};
+
+} // namespace
+
+void peering::on_bye_ack() {
+  in_.dispose();
+  out_.dispose();
+  bye_timeout_.dispose();
+}
+
+void peering::force_disconnect() {
+  assert(removed_);
+  in_.dispose();
+  out_.dispose();
+}
+
+void peering::schedule_bye_timeout(caf::scheduled_actor* self) {
+  bye_timeout_.dispose();
+  bye_timeout_ =
+    self->run_delayed(defaults::unpeer_timeout,
+                      [ptr = shared_from_this()] { ptr->force_disconnect(); });
+}
+
+std::vector<std::byte> peering::make_bye_token() {
+  std::vector<std::byte> result;
+  result.resize(bye_token_size);
+  const auto* prefix = "BYE";
+  const auto* suffix = &bye_id_;
+  memcpy(result.data(), prefix, 3);
+  memcpy(result.data() + 3, suffix, 8);
+  return result;
+}
+
+node_message peering::make_bye_message() {
+  auto packed = make_packed_message(packed_message_type::ping, defaults::ttl,
+                                    topic{std::string{topic::reserved}},
+                                    make_bye_token());
+  return make_node_message(id_, peer_id_, std::move(packed));
+}
+
+caf::flow::observable<node_message>
+peering::setup(caf::scheduled_actor* self, node_consumer_res in_res,
+               node_producer_res out_res,
+               caf::flow::observable<node_message> src) {
+  // Construct the BYE message that we emit at the end.
+  bye_id_ = self->new_u64_id();
+  auto bye_packed_msg = make_packed_message(packed_message_type::ping, //
+                                            defaults::ttl,
+                                            topic{std::string{topic::reserved}},
+                                            make_bye_token());
+  auto bye_msg = make_node_message(id_, peer_id_, std::move(bye_packed_msg));
+  // Inject our kill switch to allow us to cancel this peering later on.
+  src.compose(inject_killswitch_t{&out_}).subscribe(out_res);
+  // Read inputs and surround them with connect/disconnect status messages.
+  return self //
+    ->make_observable()
+    .from_generator(prefix_generator{shared_from_this()})
+    .concat( //
+      self->make_observable()
+        .from_resource(in_res)
+        .on_error_complete()
+        .compose(inject_killswitch_t{&in_})
+        .do_on_next([ptr = shared_from_this(),
+                     token = make_bye_token()](const node_message& msg) {
+          // When unpeering, we send a BYE ping message. When
+          // receiving the corresponding pong message, we can safely
+          // discard the input (this flow).
+          if (get_type(msg) != packed_message_type::pong)
+            return;
+          if (auto& payload = get_payload(msg); payload == token)
+            ptr->on_bye_ack();
+        }),
+      self //
+        ->make_observable()
+        .from_generator(suffix_generator{shared_from_this()}));
+}
+
+void peering::remove(caf::scheduled_actor* self,
+                     caf::flow::item_publisher<node_message>& snk,
+                     bool with_timeout) {
+  if (removed_)
+    return;
+  // Tag as about-to-be-removed and schedule a timeout.
+  removed_ = true;
+  if (with_timeout)
+    schedule_bye_timeout(self);
+  // TODO: ideally, we would guarantee that Broker sends all pending messages to
+  //       the peer before shutting down the connection. By pushing to
+  //       `unsafe_inputs`, we only have this guarantee for messages published
+  //       via asynchronous message. That's how Zeek publishes it data at the
+  //       moment, but it means that we can still cut off the connection before
+  //       currently buffered messages on other sources were shipped. We do have
+  //       the BYE handshake at the end and close the connection only after
+  //       seeing the ACK, so pending data may still "slip by" after the BYE.
+  //       That's not reliable, though.
+  snk.push(make_bye_message());
+}
+
+} // namespace broker::internal

--- a/src/internal/peering.cc
+++ b/src/internal/peering.cc
@@ -213,4 +213,9 @@ void peering::remove(caf::scheduled_actor* self,
   snk.push(make_bye_message());
 }
 
+bool peering::is_subscribed_to(const topic& what) const {
+  detail::prefix_matcher f;
+  return f(filter_, what);
+}
+
 } // namespace broker::internal

--- a/src/internal/peering.cc
+++ b/src/internal/peering.cc
@@ -129,8 +129,7 @@ void peering::on_bye_ack() {
 
 void peering::force_disconnect() {
   assert(removed_);
-  in_.dispose();
-  out_.dispose();
+  on_bye_ack();
 }
 
 void peering::schedule_bye_timeout(caf::scheduled_actor* self) {

--- a/src/internal/peering.cc
+++ b/src/internal/peering.cc
@@ -169,14 +169,14 @@ peering::setup(caf::scheduled_actor* self, node_consumer_res in_res,
                                             make_bye_token());
   auto bye_msg = make_node_message(id_, peer_id_, std::move(bye_packed_msg));
   // Inject our kill switch to allow us to cancel this peering later on.
-  src.compose(inject_killswitch_t{&out_}).subscribe(out_res);
+  src.compose(inject_killswitch_t{&out_}).subscribe(std::move(out_res));
   // Read inputs and surround them with connect/disconnect status messages.
   return self //
     ->make_observable()
     .from_generator(prefix_generator{shared_from_this()})
     .concat( //
       self->make_observable()
-        .from_resource(in_res)
+        .from_resource(std::move(in_res))
         .on_error_complete()
         .compose(inject_killswitch_t{&in_})
         .do_on_next([ptr = shared_from_this(), token = make_bye_token()](


### PR DESCRIPTION
This set of changes achieves a couple of things:

- Move all state related to a single peering into a new class to have single "point of concern".
- Add a new "handshake" for gracefully removing peers. We use the already existing ping/pong messages for this in order to avoid changing the network protocol. This also means that this is a backwards compatible change. With this new handshake, I couldn't reproduce #293 locally anymore. Before the changes, one run out of a couple dozens would fail. After the changes, I couldn't get this to reproduce in 10k runs.
- Create a single observable for peerings that "surrounds" the peer messages with the peering-related status messages. Before, these events would take a different path through the pipeline, which means peering-added events may be observed after the first message and peering-removed events before the last message. We've seen Zeek's `broker.disconnect` fail for this reason recently.

Closes #293.