### PR TITLE
A few minor updates for the 2.3 release branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -258,4 +258,4 @@ windows_task:
     BROKER_CI_CPUS: 8
     # Give verbose error output on a test failure.
     CTEST_OUTPUT_ON_FAILURE: 1
-
+  << : *BRANCH_WHITELIST

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,6 +70,14 @@ fedora36_task:
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
+fedora37_task:
+  container:
+    # Fedora 37 EOL: Around Dec 2024
+    dockerfile: ci/fedora-37/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *UNIX_ENV
+
 centosstream9_task:
   container:
     # Stream 9 EOL: Around Dec 2027

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -168,16 +168,16 @@ ubuntu18_task:
 
 # Apple doesn't publish official long-term support timelines.
 # We aim to support both the current and previous macOS release.
-macos_monterey_task:
+macos_ventura_task:
   macos_instance:
-    image: monterey-base
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_RESOURCES_TEMPLATE
 
-macos_big_sur_task:
+macos_monterey_task:
   macos_instance:
-    image: big-sur-base
+    image: ghcr.io/cirruslabs/macos-monterey-base:latest
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_RESOURCES_TEMPLATE

--- a/ci/fedora-37/Dockerfile
+++ b/ci/fedora-37/Dockerfile
@@ -1,0 +1,20 @@
+FROM fedora:37
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20221127
+
+RUN dnf -y install \
+    clang \
+    clang-tools-extra \
+    cmake \
+    diffutils \
+    gcc \
+    gcc-c++ \
+    git \
+    make \
+    openssl \
+    openssl-devel \
+    python3 \
+    python3-devel \
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/tests/btest/scripts/wire_format.py
+++ b/tests/btest/scripts/wire_format.py
@@ -176,12 +176,17 @@ def unpack_responder_syn_ack(buf):
 
 # -- utility functions for socket I/O on handshake messages --------------------
 
+def enum_to_str(e):
+    # For compatibility around Python 3.11, this dictates how to render an enum
+    # to a string. This changed in 3.11 for some enum types.
+    return type(e).__name__ + '.' + e.name
+
 # Reads a handshake message (phase 1 and phase 2).
 def read_hs_msg(fd):
     # -1 since we extract the tag right away
     msg_len = int.from_bytes(fd.recv(4), byteorder='big', signed=False) - 1
     tag = MessageType(fd.recv(1)[0])
-    tag_str = str(tag)
+    tag_str = enum_to_str(tag)
     print(f'received a {tag_str} message with {msg_len} bytes')
     unpack_tbl = {
         MessageType.HELLO: unpack_hello,
@@ -201,7 +206,7 @@ def write_hs_msg(fd, tag, buf):
     fd.send(payload_len.to_bytes(4, byteorder='big', signed=False))
     fd.send(int(tag).to_bytes(1, byteorder='big', signed=False))
     fd.send(buf)
-    tag_str = str(tag)
+    tag_str = enum_to_str(tag)
     print(f'sent {tag_str} message with {payload_len} bytes')
 
 
@@ -236,7 +241,7 @@ def read_op_msg(fd):
     topic_len = int.from_bytes(fd.recv(2), byteorder='big', signed=False)
     topic = fd.recv(topic_len).decode()
     buf = fd.recv(msg_len - topic_len)
-    tag_str = str(tag)
+    tag_str = enum_to_str(tag)
     print(f'received a {tag_str} with a payload of {msg_len} bytes')
     unpack_tbl = {
         MessageType.PING: unpack_ping,
@@ -257,7 +262,7 @@ def write_op_msg(fd, src, dst, tag, topic, buf):
     fd.send(len(topic).to_bytes(2, byteorder='big', signed=False))
     fd.send(topic.encode())
     fd.send(buf)
-    tag_str = str(tag)
+    tag_str = enum_to_str(tag)
     print(f'sent {tag_str} message with a payload of {payload_len} bytes')
 
 


### PR DESCRIPTION
- Update pybind to the latest version to fix a Zeek 5.0.4 build failure with python 3.11
- Backport a patch for the Cirrus config to avoid doing Windows builds with every push
- Add a Fedora 37 build to the Cirrus config