### PR TITLE
sqlite_backend: Add a few more backend_options

### DIFF
--- a/include/broker/detail/sqlite_backend.hh
+++ b/include/broker/detail/sqlite_backend.hh
@@ -14,6 +14,16 @@ public:
   /// Required parameters:
   ///   - `path`: a `std::string` representing the location of the database on
   ///             the filesystem.
+  /// Optional parameters:
+  ///   - `synchronous`: a `broker::enum_value` representing the value
+  ///                    to be used for PRAGMA synchronous.
+  ///   - `journal_mode`: a `broker::enum_value` representing the value
+  ///                    to be used for PRAGMA journal_mode.
+  ///   - `failure_mode`: a `broker::enum_value` allowing "Broker::DELETE"
+  ///                     to indicate deletion of the database file when
+  ///                     initialization fails is acceptable.
+  ///   - `integrity_check`: a `broker::boolean` toggling PRAGMA integrity_check
+  ///                        execution during initialization.
   sqlite_backend(backend_options opts = backend_options{});
 
   ~sqlite_backend() override;


### PR DESCRIPTION
sqlite_backend: Add a few more backend_options

* synchronous to run 'PRAGMA synchronous=<value>' during initialization.
* journal_mode to run 'PRAGMA journal_mode=<value>' during initialization.
* failure_mode to delete the database and reopen it when
  an error occurs during initialization.
* integrity_check to run PRAGMA integrity_check during initialization to
  reliably detect corrupted databases.

Also a bit more verbose logging when failing to create the initial
tables or failing to create directories.
