### PR TITLE
Use IPv6 mode for accept sockets by default

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -121,6 +121,7 @@ struct configuration::impl : public caf::actor_system_config {
       .add<size_t>("max-pending-inputs-per-source",
                    "maximum number of items we buffer per peer or publisher");
     opt_group{custom_options_, "broker.web-socket"} //
+      .add<string>("address", "bind address for the WebSocket server socket")
       .add<uint16_t>("port", "port for incoming WebSocket connections");
     opt_group{custom_options_, "broker.metrics"}
       .add<uint16_t>("port", "port for incoming Prometheus (HTTP) requests")

--- a/src/endpoint.cc
+++ b/src/endpoint.cc
@@ -585,7 +585,8 @@ endpoint::endpoint(configuration config, endpoint_id id) : id_(id) {
   }
   // Spin up a WebSocket server when requested.
   if (auto port = caf::get_as<uint16_t>(cfg, "broker.web-socket.port"))
-    web_socket_listen("0.0.0.0"s, *port);
+    web_socket_listen(caf::get_or(cfg, "broker.web-socket.address", ""s),
+                      *port);
 }
 
 endpoint::~endpoint() {

--- a/src/internal/connector.cc
+++ b/src/internal/connector.cc
@@ -1112,7 +1112,7 @@ struct connect_manager {
 
   void listen(connector_event_id event_id, std::string& addr, uint16_t port,
               bool reuse_addr) {
-  using namespace std::literals;
+    using namespace std::literals;
     BROKER_TRACE(BROKER_ARG(event_id) << BROKER_ARG(addr) << BROKER_ARG(port));
     caf::uri::authority_type authority;
     authority.host = addr;

--- a/src/internal/connector.cc
+++ b/src/internal/connector.cc
@@ -1112,12 +1112,10 @@ struct connect_manager {
 
   void listen(connector_event_id event_id, std::string& addr, uint16_t port,
               bool reuse_addr) {
+  using namespace std::literals;
     BROKER_TRACE(BROKER_ARG(event_id) << BROKER_ARG(addr) << BROKER_ARG(port));
     caf::uri::authority_type authority;
-    if (addr.empty())
-      authority.host = std::string{"0.0.0.0"};
-    else
-      authority.host = addr;
+    authority.host = addr;
     authority.port = port;
 #ifdef BROKER_WINDOWS
     // SO_REUSEADDR behaves quite differently on Windows. CAF currently does not

--- a/src/internal/web_socket.cc
+++ b/src/internal/web_socket.cc
@@ -114,6 +114,9 @@ expected<uint16_t> launch(caf::actor_system& sys,
                           uint16_t port, bool reuse_addr,
                           const std::string& allowed_path,
                           on_connect_t on_connect) {
+  BROKER_DEBUG("launch WebSocket server:"
+               << BROKER_ARG(addr) << BROKER_ARG(port) << BROKER_ARG(reuse_addr)
+               << BROKER_ARG(allowed_path));
   using namespace std::literals;
   // Open up the port.
   caf::uri::authority_type auth;


### PR DESCRIPTION
There were a few inconsistencies how Broker handled bind addresses when opening the accept socket for peering and WebSocket connections. Also pulls in a CAF fix, because it was platform-dependent whether a hostname (e.g. "localhost") would resolve to v4 or v6. Now, we always prefer the v6 address (when opening in V6 mode, we also set `IPV6_V6ONLY` to off to allow IPv4 clients as well). CAF also treated `0.0.0.0` and `::` the same, which it shouldn't do.

I've tested the new behavior by spinning up a `broker-benchmark` and have it open a peering port and a WebSocket port.

Without passing a bind address to Broker, it's trying to open the socket with `INADDR6_ANY ` but falls back to `INADDR_ANY` should that fail (i.e., on systems that don't have IPv6 enabled):

```
$ ./build/broker/asan/bin/broker-benchmark --broker.web-socket.port=9902 --server :9901
$ lsof -iTCP | grep broker
broker-be 13240 neverlord    8u  IPv6 0xd147f7e30c571b31      0t0  TCP *:9902 (LISTEN)
broker-be 13240 neverlord   11u  IPv6 0xd147f7e30c56d7b1      0t0  TCP *:9901 (LISTEN)
```

Then I've used the new `broker.web-socket.address` option to pass an explicit bind address (suppressing the output for port 9901 from here on, because it's always the same).

Passing `0.0.0.0` forces IPv4:

```
$ ./build/broker/asan/bin/broker-benchmark --broker.web-socket.port=9902 --broker.web-socket.address=0.0.0.0 --server :9901
$ lsof -iTCP | grep broker
broker-be 13375 neverlord    8u  IPv4 0xd147f7de44e7a3f9      0t0  TCP *:9902 (LISTEN)
```

Passing `::` forces IPv6:

```
$ ./build/broker/asan/bin/broker-benchmark --broker.web-socket.port=9902 --broker.web-socket.address=:: --server :9901
$ lsof -iTCP | grep broker
broker-be 13516 neverlord    8u  IPv6 0xd147f7e30c575f31      0t0  TCP *:9902 (LISTEN)
```

Passing `localhost` tries `::1` and then `127.0.0.1`.

```
$ ./build/broker/asan/bin/broker-benchmark --broker.web-socket.port=9902 --broker.web-socket.address=localhost --server :9901
$ lsof -iTCP | grep broker
broker-be 13986 neverlord    8u  IPv6 0xd147f7e30c575f31      0t0  TCP localhost:9902 (LISTEN)
```

Passing `::1` forces IPv6:

```
$ ./build/broker/asan/bin/broker-benchmark --broker.web-socket.port=9902 --broker.web-socket.address=::1 --server :9901
$ lsof -iTCP | grep broker
broker-be 14064 neverlord    8u  IPv6 0xd147f7e30c577d31      0t0  TCP localhost:9902 (LISTEN)
```

Passing `127.0.0.1` forces IPv4:

```
$ ./build/broker/asan/bin/broker-benchmark --broker.web-socket.port=9902 --broker.web-socket.address=127.0.0.1 --server :9901
$ lsof -iTCP | grep broker
broker-be 14136 neverlord    8u  IPv4 0xd147f7de44e7e139      0t0  TCP localhost:9902 (LISTEN)
```

@rsmmr mind double-checking on your end as well?

Fixes #256.