### PR TITLE
Fix tick_interval usage in send_later

### DIFF
--- a/src/internal/store_actor.cc
+++ b/src/internal/store_actor.cc
@@ -151,7 +151,7 @@ void store_actor_state::on_down_msg(const caf::actor_addr& source,
 
 void store_actor_state::send_later(const caf::actor& hdl, timespan delay,
                                    caf::message msg) {
-  clock->send_later(facade(hdl), tick_interval, &msg);
+  clock->send_later(facade(hdl), delay, &msg);
 }
 
 } // namespace broker::internal


### PR DESCRIPTION
Seems all callers use tick_interval, so there shouldn't be a difference, but lets avoid surprises.