### PR TITLE
Add timestamps to Zeek events

### DIFF
--- a/bindings/python/broker/zeek.py
+++ b/bindings/python/broker/zeek.py
@@ -7,13 +7,14 @@ except ImportError:
 import broker
 
 class Event(_broker.zeek.Event):
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         if len(args) == 1 and not isinstance(args[0], str):
             # Parse raw broker message as event.
             _broker.zeek.Event.__init__(self, broker.Data.from_py(args[0]))
         else:
-            # (name, arg1, arg2, ...)
-            _broker.zeek.Event.__init__(self, args[0], broker.Data.from_py(args[1:]))
+            # (name, arg1, arg2, ...[, ts])
+            _broker.zeek.Event.__init__(self, args[0], broker.Data.from_py(args[1:]),
+                kwargs.get("ts"))
 
     def args(self):
         return [broker.Data.to_py(a) for a in _broker.zeek.Event.args(self)]

--- a/bindings/python/zeek.cpp
+++ b/bindings/python/zeek.cpp
@@ -8,6 +8,7 @@
 #  pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif
@@ -27,9 +28,15 @@ void init_zeek(py::module& m) {
   py::class_<broker::zeek::Event, broker::zeek::Message>(m, "Event")
     .def(py::init(
       [](broker::data data) { return broker::zeek::Event(std::move(data)); }))
-    .def(py::init([](std::string name, broker::data args) {
-      return broker::zeek::Event(std::move(name),
-                                 std::move(broker::get<broker::vector>(args)));
+    .def(py::init([](std::string name, broker::data args,
+                     std::optional<double> ts) {
+      if (ts)
+        return broker::zeek::Event(std::move(name),
+                                   std::move(broker::get<broker::vector>(args)),
+                                   broker::to_timestamp(*ts));
+      else
+        return broker::zeek::Event(
+          std::move(name), std::move(broker::get<broker::vector>(args)));
     }))
     .def("valid",
          [](const broker::zeek::Event& ev) -> bool {
@@ -48,6 +55,23 @@ void init_zeek(py::module& m) {
              throw std::invalid_argument("invalid Event data");
            }
            return ev.name();
+         })
+    .def("timestamp",
+         [](const broker::zeek::Event& ev) -> const std::optional<double> {
+           auto t = broker::zeek::Message::type(ev.as_data());
+           if (t != broker::zeek::Message::Type::Event) {
+             throw std::invalid_argument("invalid Event data/type");
+           }
+           if (!ev.valid()) {
+             throw std::invalid_argument("invalid Event data");
+           }
+           if (auto ev_ts = ev.ts()) {
+             double ts;
+             broker::convert(*ev_ts, ts);
+             return ts;
+           }
+
+           return std::nullopt;
          })
     .def("args", [](const broker::zeek::Event& ev) -> const broker::vector& {
       auto t = broker::zeek::Message::type(ev.as_data());

--- a/include/broker/zeek.hh
+++ b/include/broker/zeek.hh
@@ -95,6 +95,9 @@ public:
   Event(std::string name, vector args)
     : Message(Message::Type::Event, {std::move(name), std::move(args)}) {}
 
+  Event(std::string name, vector args, timestamp ts)
+    : Message(Message::Type::Event, {std::move(name), std::move(args), ts}) {}
+
   Event(data msg) : Message(std::move(msg)) {}
 
   const std::string& name() const {
@@ -103,6 +106,22 @@ public:
 
   std::string& name() {
     return get<std::string>(get<vector>(as_vector()[2])[0]);
+  }
+
+  const std::optional<timestamp> ts() const {
+    auto ev_vec = get<vector>(as_vector()[2]);
+    if (ev_vec.size() > 2)
+      return get<timestamp>(ev_vec[2]);
+
+    return std::nullopt;
+  }
+
+  std::optional<timestamp> ts() {
+    auto ev_vec = get<vector>(as_vector()[2]);
+    if (ev_vec.size() > 2)
+      return get<timestamp>(ev_vec[2]);
+
+    return std::nullopt;
   }
 
   const vector& args() const {
@@ -137,7 +156,22 @@ public:
     if (!args_ptr)
       return false;
 
+    // Optional event timestamp
+    if (v.size() > 2) {
+      auto ts_ptr = get_if<timestamp>(&v[2]);
+
+      if (!ts_ptr)
+        return false;
+    }
+
     return true;
+  }
+
+  bool has_ts() const {
+    if (!valid())
+      return false;
+
+    return get<vector>(as_vector()[2]).size() > 2;
   }
 };
 

--- a/tests/cpp/zeek.cc
+++ b/tests/cpp/zeek.cc
@@ -10,13 +10,25 @@
 #include <utility>
 
 #include "broker/data.hh"
+#include "broker/time.hh"
 
 using namespace broker;
+using namespace std::chrono_literals;
 
 TEST(event) {
   auto args = vector{1, "s", port(42, port::protocol::tcp)};
   zeek::Event ev("test", vector(args));
   zeek::Event ev2(std::move(ev));
   CHECK_EQUAL(ev2.name(), "test");
+  CHECK_EQUAL(ev2.ts(), std::nullopt);
+  CHECK_EQUAL(ev2.args(), args);
+}
+
+TEST(event_ts) {
+  auto args = vector{1, "s", port(42, port::protocol::tcp)};
+  zeek::Event ev("test", vector(args), broker::timestamp(12s));
+  zeek::Event ev2(std::move(ev));
+  CHECK_EQUAL(ev2.name(), "test");
+  CHECK_EQUAL(ev2.ts(), broker::timestamp(12s));
   CHECK_EQUAL(ev2.args(), args);
 }


### PR DESCRIPTION
This adds timestamps to the Zeek event message type for https://github.com/zeek/zeek/pull/2929. Currently, the changeset would be missing a protocol version bump. @Neverlord brought up that a new protocol version is a far-reaching change and suggested to introduce a new message type for timestamped events. My gut feeling is that a clear-cut by bumping the version would be the easiest as it avoids the complexity of maintaining some meaningful interoperability. However, I can see this would be a rather radical measure for a tiny feature. To decide which path to go, we are looking for some feedback (tagging @ckreibich, @rsmmr, @timwoj and @awelzel).