### PR TITLE
Extensible event metadata 

### DIFF
--- a/bindings/python/broker/zeek.py
+++ b/bindings/python/broker/zeek.py
@@ -7,12 +7,11 @@ except ImportError:
 import broker
 
 # Keep this in sync with zeek.hh
-class Metadata:
-    NETWORK_TIMESTAMP = broker.Count(1)
-    USER_METADATA_START = broker.Count(200)
+class MetadataType:
+    NetworkTimestamp = broker.Count(1)
+    UserMetadataStart = broker.Count(200)
 
 class Event(_broker.zeek.Event):
-
     def __init__(self, *args, metadata=None):
         if len(args) == 1 and not isinstance(args[0], str):
             # Parse raw broker message as event.

--- a/bindings/python/broker/zeek.py
+++ b/bindings/python/broker/zeek.py
@@ -7,13 +7,14 @@ except ImportError:
 import broker
 
 class Event(_broker.zeek.Event):
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         if len(args) == 1 and not isinstance(args[0], str):
             # Parse raw broker message as event.
             _broker.zeek.Event.__init__(self, broker.Data.from_py(args[0]))
         else:
-            # (name, arg1, arg2, ...)
-            _broker.zeek.Event.__init__(self, args[0], broker.Data.from_py(args[1:]))
+            # (name, arg1, arg2, ...[, ts])
+            _broker.zeek.Event.__init__(self, args[0], broker.Data.from_py(args[1:]),
+                kwargs.get("ts"))
 
     def args(self):
         return [broker.Data.to_py(a) for a in _broker.zeek.Event.args(self)]

--- a/bindings/python/broker/zeek.py
+++ b/bindings/python/broker/zeek.py
@@ -6,18 +6,43 @@ except ImportError:
 
 import broker
 
+# Keep this in sync with zeek.hh
+class Metadata:
+    NETWORK_TIMESTAMP = broker.Count(1)
+    USER_METADATA_START = broker.Count(200)
+
 class Event(_broker.zeek.Event):
-    def __init__(self, *args, **kwargs):
+
+    def __init__(self, *args, metadata=None):
         if len(args) == 1 and not isinstance(args[0], str):
             # Parse raw broker message as event.
             _broker.zeek.Event.__init__(self, broker.Data.from_py(args[0]))
         else:
-            # (name, arg1, arg2, ...[, ts])
+            # (name, arg1, arg2, ..., [metadata={...}])
+            broker_metadata = None
+            if metadata is not None:
+                # Convert dicts to lists and make a copy so we don't
+                # modify the callers argument.
+                metadata = list(metadata.items() if hasattr(metadata, "items") else metadata)
+                # Convert non-counts to counts for convencience.
+                for i, m in enumerate(metadata):
+                    if not isinstance(m[0], broker.Count):
+                        metadata[i] = (broker.Count(m[0]), m[1])
+
+                broker_metadata = broker.Data.from_py(metadata)
+
             _broker.zeek.Event.__init__(self, args[0], broker.Data.from_py(args[1:]),
-                kwargs.get("ts"))
+                                        metadata=broker_metadata)
 
     def args(self):
         return [broker.Data.to_py(a) for a in _broker.zeek.Event.args(self)]
+
+    def metadata(self):
+        """Returns metadata as a list of (count, data) tuples of the event or None."""
+        metadata = _broker.zeek.Event.metadata(self)
+        if metadata is not None:
+            metadata = [broker.Data.to_py(m) for m in metadata]
+        return metadata
 
 # Similar to the Subscriber vs SafeSubscriber specialization, this is an event
 # specialization that is robust to Python's limitations regarding hashable

--- a/bindings/python/zeek.cpp
+++ b/bindings/python/zeek.cpp
@@ -8,6 +8,7 @@
 #  pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif
@@ -27,9 +28,15 @@ void init_zeek(py::module& m) {
   py::class_<broker::zeek::Event, broker::zeek::Message>(m, "Event")
     .def(py::init(
       [](broker::data data) { return broker::zeek::Event(std::move(data)); }))
-    .def(py::init([](std::string name, broker::data args) {
-      return broker::zeek::Event(std::move(name),
-                                 std::move(broker::get<broker::vector>(args)));
+    .def(py::init([](std::string name, broker::data args,
+                     std::optional<double> ts) {
+      if (ts)
+        return broker::zeek::Event(std::move(name),
+                                   std::move(broker::get<broker::vector>(args)),
+                                   broker::to_timestamp(*ts));
+      else
+        return broker::zeek::Event(
+          std::move(name), std::move(broker::get<broker::vector>(args)));
     }))
     .def("valid",
          [](const broker::zeek::Event& ev) -> bool {
@@ -48,6 +55,23 @@ void init_zeek(py::module& m) {
              throw std::invalid_argument("invalid Event data");
            }
            return ev.name();
+         })
+    .def("timestamp",
+         [](const broker::zeek::Event& ev) -> const std::optional<double> {
+           auto t = broker::zeek::Message::type(ev.as_data());
+           if (t != broker::zeek::Message::Type::Event) {
+             throw std::invalid_argument("invalid Event data/type");
+           }
+           if (!ev.valid()) {
+             throw std::invalid_argument("invalid Event data");
+           }
+           if (auto ev_ts = ev.ts()) {
+             double ts;
+             broker::convert(*ev_ts, ts);
+             return ts;
+           }
+
+           return std::nullopt;
          })
     .def("args", [](const broker::zeek::Event& ev) -> const broker::vector& {
       auto t = broker::zeek::Message::type(ev.as_data());

--- a/bindings/python/zeek.cpp
+++ b/bindings/python/zeek.cpp
@@ -57,22 +57,21 @@ void init_zeek(py::module& m) {
            }
            return ev.name();
          })
-    .def(
-      "metadata",
-      [](const broker::zeek::Event& ev) -> const std::optional<broker::vector> {
-        auto t = broker::zeek::Message::type(ev.as_data());
-        if (t != broker::zeek::Message::Type::Event) {
-          throw std::invalid_argument("invalid Event data/type");
-        }
-        if (!ev.valid()) {
-          throw std::invalid_argument("invalid Event data");
-        }
+    .def("metadata",
+         [](const broker::zeek::Event& ev) -> std::optional<broker::vector> {
+           auto t = broker::zeek::Message::type(ev.as_data());
+           if (t != broker::zeek::Message::Type::Event) {
+             throw std::invalid_argument("invalid Event data/type");
+           }
+           if (!ev.valid()) {
+             throw std::invalid_argument("invalid Event data");
+           }
 
-        if (const auto& md = ev.metadata())
-          return md->as_vector();
+           if (const auto vec = ev.metadata().get_vector())
+             return *vec;
 
-        return std::nullopt;
-      })
+           return std::nullopt;
+         })
     .def("args", [](const broker::zeek::Event& ev) -> const broker::vector& {
       auto t = broker::zeek::Message::type(ev.as_data());
       if (t != broker::zeek::Message::Type::Event) {

--- a/include/broker/zeek.hh
+++ b/include/broker/zeek.hh
@@ -105,14 +105,18 @@ protected:
 
 /// Support iteration with structured binding.
 class MetadataIterator {
+public:
   using iterator_category = std::forward_iterator_tag;
   using difference_type = std::ptrdiff_t;
   using value_type = std::pair<count, const data&>;
   using pointer = value_type*;
   using reference = value_type&;
 
-public:
   explicit MetadataIterator(const broker::data* ptr) noexcept : ptr_(ptr) {}
+
+  MetadataIterator(const MetadataIterator&) noexcept = default;
+
+  MetadataIterator& operator=(const MetadataIterator&) noexcept = default;
 
   value_type operator*() const {
     auto entry_ptr = get_if<vector>(*ptr_);
@@ -203,12 +207,11 @@ public:
   }
 
   MetadataWrapper metadata() const {
-    const vector* md_vec_ptr = nullptr;
-    auto ev_vec_ptr = get_if<vector>(as_vector()[2]);
-    if (ev_vec_ptr && ev_vec_ptr->size() >= 3)
-      md_vec_ptr = get_if<vector>((*ev_vec_ptr)[2]);
+    if (const auto* ev_vec_ptr = get_if<vector>(as_vector()[2]);
+        ev_vec_ptr && ev_vec_ptr->size() >= 3)
+      return MetadataWrapper{get_if<vector>((*ev_vec_ptr)[2])};
 
-    return MetadataWrapper{md_vec_ptr};
+    return MetadataWrapper{nullptr};
   }
 
   const std::optional<timestamp> ts() const {

--- a/include/broker/zeek.hh
+++ b/include/broker/zeek.hh
@@ -1,10 +1,24 @@
 #pragma once
 
+#include <cstddef>
+#include <iterator>
+#include <optional>
+
 #include "broker/data.hh"
+#include "broker/detail/assert.hh"
 
 namespace broker::zeek {
 
 const count ProtocolVersion = 1;
+
+/// Metadata attached to Zeek events.
+enum class Metadata : uint8_t {
+  NETWORK_TIMESTAMP = 1,
+  // 1 - 199 is reserved for Zeek. Otherwise free for external
+  // users to experiment with before potentially including
+  // in the reserved range.
+  USER_METADATA_START = 200,
+};
 
 /// Generic Zeek-level message.
 class Message {
@@ -96,7 +110,15 @@ public:
     : Message(Message::Type::Event, {std::move(name), std::move(args)}) {}
 
   Event(std::string name, vector args, timestamp ts)
-    : Message(Message::Type::Event, {std::move(name), std::move(args), ts}) {}
+    : Message(
+      Message::Type::Event,
+      {std::move(name), std::move(args),
+       vector{{vector{static_cast<count>(Metadata::NETWORK_TIMESTAMP), ts}}}}) {
+  }
+
+  Event(std::string name, vector args, vector metadata)
+    : Message(Message::Type::Event,
+              {std::move(name), std::move(args), std::move(metadata)}) {}
 
   Event(data msg) : Message(std::move(msg)) {}
 
@@ -108,18 +130,100 @@ public:
     return get<std::string>(get<vector>(as_vector()[2])[0]);
   }
 
-  const std::optional<timestamp> ts() const {
-    auto ev_vec = get<vector>(as_vector()[2]);
-    if (ev_vec.size() > 2)
-      return get<timestamp>(ev_vec[2]);
+  /// Support iteration with structured binding.
+  class metadata_iterator {
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = std::pair<count, const data&>;
+    using pointer = value_type*;
+    using reference = value_type&;
 
-    return std::nullopt;
+  public:
+    metadata_iterator(const broker::data* ptr) : ptr_(ptr) {}
+
+    const std::pair<count, const data&> operator*() const {
+      auto entry_ptr = get_if<vector>(*ptr_);
+      BROKER_ASSERT(entry_ptr && entry_ptr->size() == 2);
+      const auto& entry = *entry_ptr;
+      return {get<count>(entry[0]), entry[1]};
+    }
+
+    metadata_iterator operator++() {
+      ++ptr_;
+      return *this;
+    }
+
+    metadata_iterator operator++(int) {
+      auto tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+
+    bool operator!=(metadata_iterator& other) {
+      return ptr_ != other.ptr_;
+    }
+
+  private:
+    const broker::data* ptr_;
+  };
+
+  /// Supports iteration over metadata
+  class metadata_wrapper {
+  public:
+    metadata_wrapper(const vector* v) : v_(v) {}
+
+    metadata_iterator begin() const {
+      return metadata_iterator{v_->data()};
+    }
+
+    metadata_iterator end() const {
+      return metadata_iterator{v_->data() + v_->size()};
+    }
+
+    const data* value(Metadata key) const {
+      return value(static_cast<count>(key));
+    }
+
+    const data* value(count key) const {
+      for (const auto& [k, v] : *this) {
+        if (k == key)
+          return &v;
+      }
+      return nullptr;
+    }
+
+    const auto& as_vector() const {
+      return *v_;
+    }
+
+  private:
+    const vector* v_;
+  };
+
+  const std::optional<metadata_wrapper> metadata() const {
+    auto ret = std::optional<metadata_wrapper>();
+    auto ev_vec_ptr = get_if<vector>(as_vector()[2]);
+    if (ev_vec_ptr && ev_vec_ptr->size() >= 3) {
+      if (auto md_ptr = get_if<vector>((*ev_vec_ptr)[2]))
+        ret = std::optional<metadata_wrapper>(md_ptr);
+    }
+
+    return ret;
   }
 
-  std::optional<timestamp> ts() {
-    auto ev_vec = get<vector>(as_vector()[2]);
-    if (ev_vec.size() > 2)
-      return get<timestamp>(ev_vec[2]);
+  const data* metadata(count key) const {
+    if (const auto& md = metadata())
+      return md->value(key);
+    return nullptr;
+  }
+
+  const data* metadata(Metadata key) const {
+    return metadata(static_cast<count>(key));
+  }
+
+  const std::optional<timestamp> ts() const {
+    if (auto ts_ptr = metadata(Metadata::NETWORK_TIMESTAMP))
+      return get<timestamp>(*ts_ptr);
 
     return std::nullopt;
   }
@@ -156,22 +260,41 @@ public:
     if (!args_ptr)
       return false;
 
-    // Optional event timestamp
+    // Optional event metadata verification.
+    //
+    // Verify this is vector<vector<count, data>> and also
+    // check that the NETWORK_TIMESTAMP metadata has the
+    // right type because we know down here what to expect.
     if (v.size() > 2) {
-      auto ts_ptr = get_if<timestamp>(&v[2]);
-
-      if (!ts_ptr)
+      auto md_ptr = get_if<vector>(&v[2]);
+      if (!md_ptr)
         return false;
+
+      for (const auto& mde : *md_ptr) {
+        auto mdev_ptr = get_if<vector>(mde);
+        if (!mdev_ptr)
+          return false;
+
+        if (mdev_ptr->size() != 2)
+          return false;
+
+        const auto& mdev = *mdev_ptr;
+
+        auto mde_key_ptr = get_if<count>(mdev[0]);
+        if (!mde_key_ptr)
+          return false;
+
+        constexpr auto net_ts_key =
+          static_cast<count>(Metadata::NETWORK_TIMESTAMP);
+        if (*mde_key_ptr == net_ts_key) {
+          auto mde_val_ptr = get_if<timestamp>(mdev[1]);
+          if (!mde_val_ptr)
+            return false;
+        }
+      }
     }
 
     return true;
-  }
-
-  bool has_ts() const {
-    if (!valid())
-      return false;
-
-    return get<vector>(as_vector()[2]).size() > 2;
   }
 };
 

--- a/include/broker/zeek.hh
+++ b/include/broker/zeek.hh
@@ -95,6 +95,9 @@ public:
   Event(std::string name, vector args)
     : Message(Message::Type::Event, {std::move(name), std::move(args)}) {}
 
+  Event(std::string name, vector args, timestamp ts)
+    : Message(Message::Type::Event, {std::move(name), std::move(args), ts}) {}
+
   Event(data msg) : Message(std::move(msg)) {}
 
   const std::string& name() const {
@@ -103,6 +106,22 @@ public:
 
   std::string& name() {
     return get<std::string>(get<vector>(as_vector()[2])[0]);
+  }
+
+  const std::optional<timestamp> ts() const {
+    auto ev_vec = get<vector>(as_vector()[2]);
+    if (ev_vec.size() > 2)
+      return get<timestamp>(ev_vec[2]);
+
+    return std::nullopt;
+  }
+
+  std::optional<timestamp> ts() {
+    auto ev_vec = get<vector>(as_vector()[2]);
+    if (ev_vec.size() > 2)
+      return get<timestamp>(ev_vec[2]);
+
+    return std::nullopt;
   }
 
   const vector& args() const {
@@ -137,7 +156,22 @@ public:
     if (!args_ptr)
       return false;
 
+    // Optional event timestamp
+    if (v.size() > 2) {
+      auto ts_ptr = get_if<timestamp>(&v[2]);
+
+      if (!ts_ptr)
+        return false;
+    }
+
     return true;
+  }
+
+  bool has_ts() const {
+    if (!valid())
+      return false;
+
+    return get<vector>(as_vector()[2]).size() > 2;
   }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,6 +127,7 @@ if (BROKER_PYTHON_BINDINGS)
   # make_python_test(ssl-tests): re-enable after implementing SSL support
   make_python_test(store)
   make_python_test(topic)
+  make_python_test(zeek-module)
   # TODO: re-enable after updating generator files or adding backwards compatiblity
   # make_python_test(broker-cluster-benchmark
   #                  $<TARGET_FILE:broker-cluster-benchmark>)

--- a/tests/cpp/zeek.cc
+++ b/tests/cpp/zeek.cc
@@ -19,6 +19,7 @@ TEST(event) {
   auto args = vector{1, "s", port(42, port::protocol::tcp)};
   zeek::Event ev("test", vector(args));
   zeek::Event ev2(std::move(ev));
+  REQUIRE(ev2.valid());
   CHECK_EQUAL(ev2.name(), "test");
   CHECK_EQUAL(ev2.ts(), std::nullopt);
   CHECK_EQUAL(ev2.args(), args);
@@ -28,7 +29,55 @@ TEST(event_ts) {
   auto args = vector{1, "s", port(42, port::protocol::tcp)};
   zeek::Event ev("test", vector(args), broker::timestamp(12s));
   zeek::Event ev2(std::move(ev));
+  REQUIRE(ev2.valid());
   CHECK_EQUAL(ev2.name(), "test");
   CHECK_EQUAL(ev2.ts(), broker::timestamp(12s));
   CHECK_EQUAL(ev2.args(), args);
+}
+
+TEST(event_ts_metadata) {
+  auto args = vector{1, "s", port(42, port::protocol::tcp)};
+  auto ts_md = vector{static_cast<count>(zeek::Metadata::NETWORK_TIMESTAMP),
+                      broker::timestamp(12s)};
+  zeek::Event ev("test", vector(args), vector{{ts_md}});
+  zeek::Event ev2(std::move(ev));
+  REQUIRE(ev2.valid());
+  CHECK_EQUAL(ev2.name(), "test");
+  CHECK_EQUAL(ev2.ts(), broker::timestamp(12s));
+  CHECK_EQUAL(ev2.args(), args);
+}
+
+TEST(event_ts_metadata_extra) {
+  auto args = vector{1, "s", port(42, port::protocol::tcp)};
+  auto ts_md = vector{static_cast<count>(1), broker::timestamp(12s)};
+  auto extra_md = vector{static_cast<count>(4711),
+                         broker::enum_value(std::string("hello"))};
+  auto md = vector{ts_md, extra_md};
+
+  zeek::Event ev("test", vector(args), md);
+  zeek::Event ev2(std::move(ev));
+  REQUIRE(ev2.valid());
+  CHECK_EQUAL(ev2.metadata(0), nullptr);
+  CHECK_EQUAL(*get_if<timestamp>(
+                ev2.metadata(zeek::Metadata::NETWORK_TIMESTAMP)),
+              broker::timestamp(12s));
+  CHECK_EQUAL(*get_if<enum_value>(ev2.metadata(4711)),
+              broker::enum_value(std::string("hello")));
+}
+
+TEST(event_no_metadata) {
+  auto args = vector{1, "s", port(42, port::protocol::tcp)};
+  zeek::Event ev("test", vector(args));
+  zeek::Event ev2(std::move(ev));
+  REQUIRE(ev2.valid());
+  REQUIRE(!ev2.metadata());
+  REQUIRE(!ev2.metadata(1234));
+}
+
+TEST(event_ts_bad_type) {
+  auto args = vector{1, "s", port(42, port::protocol::tcp)};
+  auto ts_md = vector{static_cast<count>(1), broker::enum_value("invalid")};
+  auto md = vector{{ts_md}};
+  zeek::Event ev("test", vector(args), md);
+  REQUIRE(!ev.valid());
 }

--- a/tests/cpp/zeek.cc
+++ b/tests/cpp/zeek.cc
@@ -10,13 +10,25 @@
 #include <utility>
 
 #include "broker/data.hh"
+#include "broker/time.hh"
 
 using namespace broker;
+using namespace std::chrono_literals;
 
 TEST(event) {
   auto args = vector{1, "s", port(42, port::protocol::tcp)};
   zeek::Event ev("test", vector(args));
   zeek::Event ev2(std::move(ev));
   CHECK_EQUAL(ev2.name(), "test");
+  CHECK_EQUAL(ev2.ts(), std::nullopt);
+  CHECK_EQUAL(ev2.args(), args);
+}
+
+TEST(event_ts) {
+  auto args = vector{1, "s", port(42, port::protocol::tcp)};
+  zeek::Event ev("test", vector(args), broker::timestamp(12s));
+  zeek::Event ev2(std::move(ev));
+  CHECK_EQUAL(ev2.name(), "test");
+  CHECK_EQUAL(ev2.ts(), broker::timestamp(12s));
   CHECK_EQUAL(ev2.args(), args);
 }

--- a/tests/python/zeek-module.py
+++ b/tests/python/zeek-module.py
@@ -1,0 +1,77 @@
+"""
+Test the broker.zeek module without involving Zeek because speed.
+"""
+import datetime
+import unittest
+
+import broker
+import broker.zeek
+
+NETWORK_TIMESTAMP = broker.zeek.Metadata.NETWORK_TIMESTAMP
+
+class TestEventMetadata(unittest.TestCase):
+
+    dt = datetime.datetime(2023, 5, 3, 9, 27, 57, tzinfo=broker.utc)
+
+    def test_event_no_metadata(self):
+        e = broker.zeek.Event("a", [42, "a"])
+        self.assertTrue(e.valid())
+        self.assertIsNone(e.metadata())
+
+    def test_event_metadata_network_timestamp(self):
+        e = broker.zeek.Event("a", [42, "a"], metadata=[(NETWORK_TIMESTAMP, self.dt)])
+        self.assertTrue(e.valid())
+        metadata = e.metadata()
+        self.assertEqual(len(metadata), 1)
+        key, value = metadata[0]
+        self.assertEqual(key, NETWORK_TIMESTAMP)
+        self.assertEqual(value, self.dt)
+
+    def test_event_metadata_dict_integer_convenience(self):
+        e = broker.zeek.Event("a", [42, "a"], metadata={1: self.dt})
+        self.assertTrue(e.valid())
+        self.assertEqual(len(e.metadata()), 1)
+
+    def test_event_metadata_invalid_network_timestamp_1(self):
+        e = broker.zeek.Event("a", [42, "a"], metadata=[(NETWORK_TIMESTAMP, "invalid")])
+        self.assertFalse(e.valid())
+
+    def test_event_metadata_bad_timestamp_2(self):
+        e = broker.zeek.Event("a", [42, "a"], metadata=[(NETWORK_TIMESTAMP, 1.234)])
+        self.assertFalse(e.valid())
+
+class TestCommunication(unittest.TestCase):
+
+    dt = datetime.datetime(2023, 5, 3, 9, 27, 57, tzinfo=broker.utc)
+
+    def test_event_metadata(self):
+        with broker.Endpoint() as ep1, \
+             broker.Endpoint() as ep2, \
+             ep1.make_subscriber("/test") as s1:
+
+            port = ep1.listen("127.0.0.1", 0)
+            self.assertTrue(ep2.peer("127.0.0.1", port, 1.0))
+
+            ep1.await_peer(ep2.node_id())
+            ep2.await_peer(ep1.node_id())
+
+            metadata = {
+                NETWORK_TIMESTAMP: self.dt,
+                broker.Count(1234): "custom",
+            }
+
+            ev = broker.zeek.Event("ping", "X", metadata=metadata)
+            ep2.publish("/test", ev)
+            (t, d) = s1.get()
+            recv_ev = broker.zeek.Event(d)
+            self.assertTrue(recv_ev.valid())
+
+            metadata = recv_ev.metadata()
+            self.assertEqual(len(metadata), 2)
+            metadata_dict = dict(metadata)
+            self.assertEqual(metadata_dict[NETWORK_TIMESTAMP], self.dt)
+            self.assertEqual(metadata_dict[broker.Count(1234)], "custom")
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=3)

--- a/tests/python/zeek-module.py
+++ b/tests/python/zeek-module.py
@@ -7,7 +7,7 @@ import unittest
 import broker
 import broker.zeek
 
-NETWORK_TIMESTAMP = broker.zeek.Metadata.NETWORK_TIMESTAMP
+NetworkTimestamp = broker.zeek.MetadataType.NetworkTimestamp
 
 class TestEventMetadata(unittest.TestCase):
 
@@ -19,12 +19,12 @@ class TestEventMetadata(unittest.TestCase):
         self.assertIsNone(e.metadata())
 
     def test_event_metadata_network_timestamp(self):
-        e = broker.zeek.Event("a", [42, "a"], metadata=[(NETWORK_TIMESTAMP, self.dt)])
+        e = broker.zeek.Event("a", [42, "a"], metadata=[(NetworkTimestamp, self.dt)])
         self.assertTrue(e.valid())
         metadata = e.metadata()
         self.assertEqual(len(metadata), 1)
         key, value = metadata[0]
-        self.assertEqual(key, NETWORK_TIMESTAMP)
+        self.assertEqual(key, NetworkTimestamp)
         self.assertEqual(value, self.dt)
 
     def test_event_metadata_dict_integer_convenience(self):
@@ -33,11 +33,11 @@ class TestEventMetadata(unittest.TestCase):
         self.assertEqual(len(e.metadata()), 1)
 
     def test_event_metadata_invalid_network_timestamp_1(self):
-        e = broker.zeek.Event("a", [42, "a"], metadata=[(NETWORK_TIMESTAMP, "invalid")])
+        e = broker.zeek.Event("a", [42, "a"], metadata=[(NetworkTimestamp, "invalid")])
         self.assertFalse(e.valid())
 
     def test_event_metadata_bad_timestamp_2(self):
-        e = broker.zeek.Event("a", [42, "a"], metadata=[(NETWORK_TIMESTAMP, 1.234)])
+        e = broker.zeek.Event("a", [42, "a"], metadata=[(NetworkTimestamp, 1.234)])
         self.assertFalse(e.valid())
 
 class TestCommunication(unittest.TestCase):
@@ -56,7 +56,7 @@ class TestCommunication(unittest.TestCase):
             ep2.await_peer(ep1.node_id())
 
             metadata = {
-                NETWORK_TIMESTAMP: self.dt,
+                NetworkTimestamp: self.dt,
                 broker.Count(1234): "custom",
             }
 
@@ -69,7 +69,7 @@ class TestCommunication(unittest.TestCase):
             metadata = recv_ev.metadata()
             self.assertEqual(len(metadata), 2)
             metadata_dict = dict(metadata)
-            self.assertEqual(metadata_dict[NETWORK_TIMESTAMP], self.dt)
+            self.assertEqual(metadata_dict[NetworkTimestamp], self.dt)
             self.assertEqual(metadata_dict[broker.Count(1234)], "custom")
 
 

--- a/tests/python/zeek-unsafe-types.py
+++ b/tests/python/zeek-unsafe-types.py
@@ -57,7 +57,7 @@ class TestCommunication(unittest.TestCase):
             with self.assertRaises(TypeError) as ctx:
                 t, msg = sub.get()
 
-            self.assertEquals(str(ctx.exception), "unhashable type: 'dict'")
+            self.assertEqual(str(ctx.exception), "unhashable type: 'dict'")
 
     def test_safe(self):
         with broker.Endpoint() as ep, \
@@ -79,7 +79,7 @@ class TestCommunication(unittest.TestCase):
                 ev = broker.zeek.Event(msg)
                 args = ev.args()
 
-            self.assertEquals(str(ctx.exception), "unhashable type: 'dict'")
+            self.assertEqual(str(ctx.exception), "unhashable type: 'dict'")
 
             # broker.zeek.SafeEvent uses broker.ImmutableData, so can access
             # the arguments safely:

--- a/tests/python/zeek.py
+++ b/tests/python/zeek.py
@@ -82,12 +82,12 @@ class TestCommunication(unittest.TestCase):
                 ev_metadata = dict(ev_metadata)
                 self.assertIn(broker.zeek.Metadata.NETWORK_TIMESTAMP, ev_metadata)
                 ts_ev = ev_metadata[broker.zeek.Metadata.NETWORK_TIMESTAMP]
-                ts_now = datetime.now(broker.utc)
 
                 self.assertEqual(ev.name(), "ping")
                 self.assertEqual(s, expected_arg)
                 self.assertEqual(c, i)
-                # Test that the event timestamp is before current.
+                # Zeek's event timestamp should be before current time.
+                ts_now = datetime.now(broker.utc)
                 self.assertLess(ts_ev, ts_now)
 
                 dt = datetime.fromtimestamp(23.0 * c, broker.utc)

--- a/tests/python/zeek.py
+++ b/tests/python/zeek.py
@@ -80,8 +80,8 @@ class TestCommunication(unittest.TestCase):
                 ev_metadata = ev.metadata()
                 self.assertIsNotNone(ev_metadata)
                 ev_metadata = dict(ev_metadata)
-                self.assertIn(broker.zeek.Metadata.NETWORK_TIMESTAMP, ev_metadata)
-                ts_ev = ev_metadata[broker.zeek.Metadata.NETWORK_TIMESTAMP]
+                self.assertIn(broker.zeek.MetadataType.NetworkTimestamp, ev_metadata)
+                ts_ev = ev_metadata[broker.zeek.MetadataType.NetworkTimestamp]
 
                 self.assertEqual(ev.name(), "ping")
                 self.assertEqual(s, expected_arg)
@@ -91,7 +91,7 @@ class TestCommunication(unittest.TestCase):
                 self.assertLess(ts_ev, ts_now)
 
                 dt = datetime.fromtimestamp(23.0 * c, broker.utc)
-                metadata = [(broker.zeek.Metadata.NETWORK_TIMESTAMP, dt)]
+                metadata = [(broker.zeek.MetadataType.NetworkTimestamp, dt)]
 
                 if i < 3:
                     ev = broker.zeek.Event("pong", s + "X", c, metadata=metadata)


### PR DESCRIPTION
This builds on #331 adding the more flexible `vector<vector<count, data>>` encoding to support more than just the network timestamp for events in the future.

The `ts()` accessor as well as the timestamp constructor stay around so no changes to zeek/zeek#2929 needed.
