### PR TITLE
Fix urllib/openssl 1.0.2 error in readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,11 @@ version: 2
 formats:
   - htmlzip
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3
   install:
     - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,8 @@
 # Python dependencies for building the docs
-Sphinx>=2.0
-sphinx_rtd_theme
+#
+# If we don't pin, RTD installs a really old sphinx_rtd_theme (0.4.3)
+# together with a very new Sphinx 7.0.0. The latest sphinx_rtd_theme 1.2.0
+# requires Sphinx < 7.0, however, so pin things down.
+
+Sphinx==6.2.1
+sphinx_rtd_theme==1.2.0


### PR DESCRIPTION
Fix as per: readthedocs/readthedocs.org#10290 (comment)