### PR TITLE
Allow reading port parameters as integers

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -471,19 +471,31 @@ void configuration::set_bool(std::string_view key, bool val) {
 std::optional<int64_t> configuration::read_i64(std::string_view key,
                                                int64_t min_val,
                                                int64_t max_val) const {
+  // Read the value as an int64_t and perform a range check. On success, return
+  // the value.
   if (auto res = caf::get_as<int64_t>(*impl_, key);
       res && *res >= min_val && *res <= max_val)
     return {*res};
-  else
-    return {};
+  // Special case: if the value is a port, we allow a conversion here.
+  if (auto res = caf::get_as<port>(*impl_, key);
+      res && res->number() >= min_val && res->number() <= max_val)
+    return {static_cast<int64_t>(res->number())};
+  // No matching conversion: return nullopt.
+  return {};
 }
 
 std::optional<uint64_t> configuration::read_u64(std::string_view key,
                                                 uint64_t max_val) const {
+  // Read the value as an uint64_t and perform a range check. On success, return
+  // the value.
   if (auto res = caf::get_as<uint64_t>(*impl_, key); res && *res <= max_val)
     return {*res};
-  else
-    return {};
+  // Special case: if the value is a port, we allow a conversion here.
+  if (auto res = caf::get_as<port>(*impl_, key);
+      res && res->number() <= max_val)
+    return {static_cast<uint64_t>(res->number())};
+  // No matching conversion: return nullopt.
+  return {};
 }
 
 std::optional<timespan> configuration::read_ts(std::string_view key) const {


### PR DESCRIPTION
Restore backwards compatibility (in particular with Zeek) that expect the port parameters to be accessible as 16-bit integers.

Closes #350.

@timwoj with this patch, Zeek seems to happy again:

````
$ BROKER_METRICS_PORT=1234 zeek Broker::metrics_port=9911/tcp -e 'event zeek_init() { print Broker::metrics_port; }'
1234/tcp

$ BROKER_METRICS_PORT=1234 zeek  -e 'event zeek_init() { print Broker::metrics_port; }'
1234/tcp

$ zeek Broker::metrics_port=9911/tcp -e 'event zeek_init() { print Broker::metrics_port; }'
9911/tcp
```