### PR TITLE
ci/windows: choco --localonly is gone

### DIFF
--- a/ci/windows/prepare.cmd
+++ b/ci/windows/prepare.cmd
@@ -4,4 +4,4 @@ echo %BROKER_CI_CPUS%
 wmic cpu get NumberOfCores, NumberOfLogicalProcessors/Format:List
 systeminfo
 dir C:
-choco list --localonly
+choco list


### PR DESCRIPTION
This is a duplicate of https://github.com/zeek/zeek/pull/3108 for broker.