### PR TITLE
CI: a round of updates to align with Zeek

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,24 +56,24 @@ unix_env: &UNIX_ENV
 
 clang_tidy_task:
   container:
-    dockerfile: ci/fedora-36/Dockerfile
+    dockerfile: ci/debian-12/Dockerfile
     << : *RESOURCES_TEMPLATE
   sync_submodules_script: git submodule update --recursive --init
   build_script: ./ci/analyze.sh
   << : *UNIX_ENV
   << : *BRANCH_WHITELIST
 
-fedora36_task:
+fedora38_task:
   container:
-    # Fedora 36 EOL: Around May 2023
-    dockerfile: ci/fedora-36/Dockerfile
+    # Fedora 38 EOL: Around May 2024
+    dockerfile: ci/fedora-38/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
 fedora37_task:
   container:
-    # Fedora 37 EOL: Around Dec 2024
+    # Fedora 37 EOL: Around Dec 2023
     dockerfile: ci/fedora-37/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
@@ -89,7 +89,7 @@ centosstream9_task:
 
 centosstream8_task:
   container:
-    # Stream 8 support should be 5 years, so until 2024. but I cannot find a concrete timeline --cpk
+    # Stream 8 EOL: May 31, 2024
     dockerfile: ci/centos-stream-8/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
@@ -99,6 +99,14 @@ centos7_task:
   container:
     # CentOS 7 EOL: June 30, 2024
     dockerfile: ci/centos-7/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *UNIX_ENV
+
+debian12_task:
+  container:
+    # Debian 12 (bookworm) EOL: TBD
+    dockerfile: ci/debian-12/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *UNIX_ENV
@@ -119,18 +127,18 @@ debian10_task:
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
-opensuse_leap_15_4_task:
+opensuse_leap_15_5_task:
   container:
-    # Opensuse Leap 15.4 EOL: TBD
-    dockerfile: ci/opensuse-leap-15.4/Dockerfile
+    # Opensuse Leap 15.5 EOL: ~Dec 2024
+    dockerfile: ci/opensuse-leap-15.5/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
-opensuse_leap_15_3_task:
+opensuse_leap_15_4_task:
   container:
-    # Opensuse Leap 15.3 EOL: ~Dec 2022
-    dockerfile: ci/opensuse-leap-15.3/Dockerfile
+    # Opensuse Leap 15.4 EOL: ~Nov 2023
+    dockerfile: ci/opensuse-leap-15.4/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *UNIX_ENV
@@ -139,6 +147,14 @@ opensuse_tumbleweed_task:
   container:
     # Opensuse Tumbleweed has no EOL
     dockerfile: ci/opensuse-tumbleweed/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *UNIX_ENV
+
+ubuntu2210_task:
+  container:
+    # Ubuntu 22.10 EOL: July 2023
+    dockerfile: ci/ubuntu-22.10/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *UNIX_ENV
@@ -159,10 +175,12 @@ ubuntu20_task:
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
-ubuntu18_task:
+alpine_task:
   container:
-    # Ubuntu 18.04 EOL: April 2023
-    dockerfile: ci/ubuntu-18.04/Dockerfile
+    # Alpine releases typically happen every 6 months w/ support for 2 years.
+    # The Dockerfile simply tracks latest Alpine release and shouldn't
+    # generally need updating based on particular Alpine release timelines.
+    dockerfile: ci/alpine/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *UNIX_ENV
@@ -199,21 +217,10 @@ freebsd14_task:
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
-freebsd13_1_task:
-  freebsd_instance:
-    # FreeBSD 13.1 EOL: TBD (13.2 + 3 months)
-    image_family: freebsd-13-1
-    cpu: 8
-    # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
-    memory: 8GB
-  prepare_script: ./ci/freebsd/prepare.sh
-  << : *CI_TEMPLATE
-  << : *UNIX_ENV
-
 freebsd13_task:
   freebsd_instance:
     # FreeBSD 13 EOL: January 31, 2026
-    image_family: freebsd-13-0
+    image_family: freebsd-13-1
     cpu: 8
     # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
     memory: 8GB

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
     - uses: pre-commit/action@v3.0.0

--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:latest
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20230612
+
+RUN apk add --no-cache \
+  bash \
+  cmake \
+  curl \
+  diffutils \
+  flex-dev \
+  g++ \
+  git \
+  linux-headers \
+  make \
+  openssl-dev \
+  py3-pip \
+  python3 \
+  python3-dev
+
+RUN pip3 install websockets junit2html

--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:12
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20230612
+
+RUN apt-get update && apt-get -y install \
+    clang \
+    clang-tidy \
+    cmake \
+    curl \
+    g++ \
+    gcc \
+    git \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+    python3-pip \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Allow pip to interfere with externally managed environment:
+# https://peps.python.org/pep-0668/
+# https://stackoverflow.com/q/75608323
+RUN rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED

--- a/ci/fedora-37/Dockerfile
+++ b/ci/fedora-37/Dockerfile
@@ -5,8 +5,6 @@ FROM fedora:37
 ENV DOCKERFILE_VERSION 20221127
 
 RUN dnf -y install \
-    clang \
-    clang-tools-extra \
     cmake \
     diffutils \
     gcc \

--- a/ci/fedora-38/Dockerfile
+++ b/ci/fedora-38/Dockerfile
@@ -1,16 +1,18 @@
-FROM opensuse/leap:15.3
+FROM fedora:38
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230612
 
-RUN zypper in -y \
+RUN dnf -y install \
     cmake \
+    diffutils \
     gcc \
     gcc-c++ \
     git \
-    libopenssl-devel \
     make \
+    openssl \
+    openssl-devel \
     python3 \
     python3-devel \
-  && rm -rf /var/cache/zypp
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/opensuse-leap-15.5/Dockerfile
+++ b/ci/opensuse-leap-15.5/Dockerfile
@@ -1,20 +1,16 @@
-FROM fedora:36
+FROM opensuse/leap:15.5
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220615
+ENV DOCKERFILE_VERSION 20230612
 
-RUN dnf -y install \
-    clang \
-    clang-tools-extra \
+RUN zypper in -y \
     cmake \
-    diffutils \
     gcc \
     gcc-c++ \
     git \
+    libopenssl-devel \
     make \
-    openssl \
-    openssl-devel \
     python3 \
     python3-devel \
-  && dnf clean all && rm -rf /var/cache/dnf
+  && rm -rf /var/cache/zypp

--- a/ci/ubuntu-22.10/Dockerfile
+++ b/ci/ubuntu-22.10/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:22.10
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20230612
+
+RUN apt-get update && apt-get -y install \
+    cmake \
+    g++ \
+    git \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Drop Fedora 36, add Fedora 38
- Add Debian 12
- Drop openSUSE Leap 15.3, add openSUSE Leap 15.5
- Drop Ubuntu 18.04, add Ubuntu 22.10
- Add Alpine
- Drop FreeBSD 13.0, just run 13.1
- Bump pre-commit action versions

The clang-tidy job now uses Debian 12 instead of Fedora 36 because the checks currently fail on Fedora 37 (llvm 15) & 38 (llvm 16). Debian 12 uses llvm 14, just as Fedora 36 did.