### PR TITLE
Optimize metric_collector::insert_or_update lookup

### DIFF
--- a/src/internal/metric_collector.cc
+++ b/src/internal/metric_collector.cc
@@ -118,8 +118,7 @@ private:
 // -- member types -------------------------------------------------------------
 
 metric_collector::remote_metric::remote_metric(
-  std::vector<caf::telemetry::label> labels,
-  const caf::telemetry::metric_family* parent)
+  label_list labels, const caf::telemetry::metric_family* parent)
   : super(std::move(labels)), parent_(parent) {
   // nop
 }
@@ -193,7 +192,6 @@ std::string_view metric_collector::prometheus_text() {
 }
 
 void metric_collector::clear() {
-  labels_.clear();
   label_names_.clear();
   prefixes_.clear();
   last_seen_.clear();
@@ -217,25 +215,28 @@ bool metric_collector::advance_time(const std::string& endpoint_name,
 
 // -- lookups ----------------------------------------------------------------
 
-metric_collector::label_span
-metric_collector::labels_for(const std::string& endpoint_name,
-                             metric_view row) {
+void metric_collector::labels_for(const std::string& endpoint_name,
+                                  metric_view row,
+                                  metric_collector::label_view_list& result) {
   using namespace std::literals;
-  auto name_less = [](const auto& lhs, const auto& rhs) {
-    return lhs.name() < rhs.name();
-  };
-  labels_.clear();
-  labels_.emplace_back("endpoint"sv, endpoint_name);
-  for (const auto& kvp : row.labels())
-    labels_.emplace_back(get<std::string>(kvp.first),
-                         get<std::string>(kvp.second));
-  std::sort(labels_.begin(), labels_.end(), name_less);
-  return labels_;
+  result.clear();
+  result.reserve(row.labels().size() + 1);
+  // Get insertion point for "endpoint" to keep the vector sorted. Then copy all
+  // labels to their final destination.
+  auto pos = row.labels().lower_bound(ep_key_);
+  for (auto i = row.labels().begin(); i != pos; ++i)
+    result.emplace_back(get<std::string>(i->first),
+                        get<std::string>(i->second));
+  result.emplace_back("endpoint"sv, endpoint_name);
+  for (auto i = pos; i != row.labels().end(); ++i)
+    result.emplace_back(get<std::string>(i->first),
+                        get<std::string>(i->second));
 }
 
 metric_collector::string_span
 metric_collector::label_names_for(metric_view row) {
   label_names_.clear();
+  label_names_.reserve(row.labels().size() + 1);
   label_names_.emplace_back("endpoint");
   for (const auto& kvp : row.labels())
     label_names_.emplace_back(get<std::string>(kvp.first));
@@ -259,8 +260,8 @@ auto owned(metric_collector::string_span xs) {
   return result;
 }
 
-auto owned(metric_collector::label_span xs) {
-  std::vector<caf::telemetry::label> result;
+auto owned(const metric_collector::label_view_list& xs) {
+  metric_collector::label_list result;
   if (!xs.empty()) {
     result.reserve(xs.size());
     for (auto& x : xs)
@@ -268,6 +269,50 @@ auto owned(metric_collector::label_span xs) {
   }
   return result;
 }
+
+/// Checks whether a list of labels LHS is less than another list of labels RHS.
+struct labels_less {
+  template <class T1, class T2>
+  bool operator()(const T1& lhs, const T2& rhs) const {
+    using remote_metric = std::unique_ptr<metric_collector::remote_metric>;
+    if constexpr (std::is_same_v<T1, remote_metric>) {
+      return (*this)(lhs->labels(), rhs);
+    } else if constexpr (std::is_same_v<T2, remote_metric>) {
+      return (*this)(lhs, rhs->labels());
+    } else {
+      if (lhs.size() != rhs.size())
+        return lhs.size() < rhs.size();
+      for (size_t index = 0; index < lhs.size(); ++index)
+        if (!(lhs[index] < rhs[index]))
+          return false;
+      return true;
+    }
+  }
+};
+
+constexpr labels_less labels_less_v{};
+
+/// Checks whether two lists of labels are equal.
+struct labels_equal {
+  template <class T1, class T2>
+  bool operator()(const T1& lhs, const T2& rhs) const {
+    using remote_metric = std::unique_ptr<metric_collector::remote_metric>;
+    if constexpr (std::is_same_v<T1, remote_metric>) {
+      return (*this)(lhs->labels(), rhs);
+    } else if constexpr (std::is_same_v<T2, remote_metric>) {
+      return (*this)(lhs, rhs->labels());
+    } else {
+      if (lhs.size() != rhs.size())
+        return false;
+      for (size_t index = 0; index < lhs.size(); ++index)
+        if (!(lhs[index] == rhs[index]))
+          return false;
+      return true;
+    }
+  }
+};
+
+constexpr labels_equal labels_equal_v{};
 
 } // namespace
 
@@ -282,49 +327,33 @@ metric_collector::instance(const std::string& endpoint_name, metric_view mv) {
     scope.family.reset(ptr);
   }
   auto* fptr = scope.family.get();
-  auto labels = labels_for(endpoint_name, mv);
-  auto labels_match = [lhs{labels}](const instance_ptr& ptr) {
-    BROKER_ASSERT(ptr != nullptr);
-    const auto& rhs = ptr->labels();
-    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
-  };
-  auto i = std::find_if(scope.instances.begin(), scope.instances.end(),
-                        labels_match);
-  if (i != scope.instances.end()) {
+  labels_for(endpoint_name, mv, labels_);
+  auto i = std::lower_bound(scope.instances.begin(), scope.instances.end(),
+                            labels_, labels_less_v);
+  if (i != scope.instances.end() && labels_equal_v((*i)->labels(), labels_))
     return i->get();
-  } else {
-    using ct::metric_type;
-    instance_ptr new_instance;
-    switch (mv.type()) {
-      case metric_type::int_counter:
-        new_instance = std::make_unique<remote_counter<integer>>(owned(labels),
-                                                                 fptr);
-        break;
-      case metric_type::dbl_counter:
-        new_instance = std::make_unique<remote_counter<real>>(owned(labels),
-                                                              fptr);
-        break;
-      case metric_type::int_gauge:
-        new_instance = std::make_unique<remote_gauge<integer>>(owned(labels),
-                                                               fptr);
-        break;
-      case metric_type::dbl_gauge:
-        new_instance = std::make_unique<remote_gauge<real>>(owned(labels),
-                                                            fptr);
-        break;
-      case metric_type::int_histogram:
-        new_instance =
-          std::make_unique<remote_histogram<integer>>(owned(labels), fptr);
-        break;
-      case metric_type::dbl_histogram:
-        new_instance = std::make_unique<remote_histogram<real>>(owned(labels),
-                                                                fptr);
-        break;
-      default:
-        return nullptr;
-    }
-    scope.instances.emplace_back(std::move(new_instance));
-    return scope.instances.back().get();
+  auto add = [&](auto* ptr) {
+    // Note: by inserting the new instance at the current position, we keep the
+    // vector sorted. This is required for lower_bound to work correctly.
+    scope.instances.insert(i, instance_ptr{ptr});
+    return ptr;
+  };
+  using ct::metric_type;
+  switch (mv.type()) {
+    case metric_type::int_counter:
+      return add(new remote_counter<integer>(owned(labels_), fptr));
+    case metric_type::dbl_counter:
+      return add(new remote_counter<real>(owned(labels_), fptr));
+    case metric_type::int_gauge:
+      return add(new remote_gauge<integer>(owned(labels_), fptr));
+    case metric_type::dbl_gauge:
+      return add(new remote_gauge<real>(owned(labels_), fptr));
+    case metric_type::int_histogram:
+      return add(new remote_histogram<integer>(owned(labels_), fptr));
+    case metric_type::dbl_histogram:
+      return add(new remote_histogram<real>(owned(labels_), fptr));
+    default:
+      return nullptr;
   }
 }
 

--- a/tests/cpp/internal/metric_collector.cc
+++ b/tests/cpp/internal/metric_collector.cc
@@ -81,6 +81,74 @@ bool contains(std::string_view str, std::string_view what) {
 
 FIXTURE_SCOPE(telemetry_collector_tests, fixture)
 
+TEST(less predicate) {
+  internal::metric_collector::labels_less less;
+  using labels_list = std::vector<caf::telemetry::label>;
+  { // Single label (equal).
+    auto lhs = labels_list{{"type", "native"}};
+    auto rhs = labels_list{{"type", "native"}};
+    CHECK(!less(lhs, rhs));
+    CHECK(!less(rhs, lhs));
+  }
+  { // Single label (unequal).
+    auto lhs = labels_list{{"type", "native"}};
+    auto rhs = labels_list{{"type", "web-socket"}};
+    CHECK(less(lhs, rhs));
+    CHECK(!less(rhs, lhs));
+  }
+  { // Two equal labels.
+    auto lhs = labels_list{{"endpoint", "exporter-1"}, {"type", "native"}};
+    auto rhs = labels_list{{"endpoint", "exporter-1"}, {"type", "native"}};
+    CHECK(!less(lhs, rhs));
+    CHECK(!less(rhs, lhs));
+  }
+  { // Two labels, with the first being smaller.
+    auto lhs = labels_list{{"endpoint", "exporter-1"}, {"type", "native"}};
+    auto rhs = labels_list{{"endpoint", "exporter-2"}, {"type", "native"}};
+    CHECK(less(lhs, rhs));
+    CHECK(!less(rhs, lhs));
+  }
+  { // Two labels, with the second being smaller.
+    auto lhs = labels_list{{"endpoint", "exporter-1"}, {"type", "native"}};
+    auto rhs = labels_list{{"endpoint", "exporter-1"}, {"type", "web-socket"}};
+    CHECK(less(lhs, rhs));
+    CHECK(!less(rhs, lhs));
+  }
+}
+
+TEST(equal predicate) {
+  internal::metric_collector::labels_equal equal;
+  using labels_list = std::vector<caf::telemetry::label>;
+  { // Single label (equal).
+    auto lhs = labels_list{{"type", "native"}};
+    auto rhs = labels_list{{"type", "native"}};
+    CHECK(equal(lhs, rhs));
+  }
+  { // Single label (unequal).
+    auto lhs = labels_list{{"type", "native"}};
+    auto rhs = labels_list{{"type", "web-socket"}};
+    CHECK(!equal(lhs, rhs));
+  }
+  { // Two equal labels.
+    auto lhs = labels_list{{"endpoint", "exporter-1"}, {"type", "native"}};
+    auto rhs = labels_list{{"endpoint", "exporter-1"}, {"type", "native"}};
+    CHECK(equal(lhs, rhs));
+    CHECK(equal(rhs, lhs));
+  }
+  { // Two labels, with the first being smaller.
+    auto lhs = labels_list{{"endpoint", "exporter-1"}, {"type", "native"}};
+    auto rhs = labels_list{{"endpoint", "exporter-2"}, {"type", "native"}};
+    CHECK(!equal(lhs, rhs));
+    CHECK(!equal(rhs, lhs));
+  }
+  { // Two labels, with the second being smaller.
+    auto lhs = labels_list{{"endpoint", "exporter-1"}, {"type", "native"}};
+    auto rhs = labels_list{{"endpoint", "exporter-1"}, {"type", "web-socket"}};
+    CHECK(!equal(lhs, rhs));
+    CHECK(!equal(rhs, lhs));
+  }
+}
+
 TEST(a collector consumes the output of an exporter) {
   MESSAGE("fill in some data");
   foo_g1->inc(1);


### PR DESCRIPTION
Apply a few optimizations to the remote metric lookups:

- In `metric_collector::labels_for`: instead of assembling the list and then sorting it, we look for the insertion point once and then assemble the `vector` such that it will be sorted.
- Call `reserve` on the vectors whenever we know the size in advance in reserve space for up to 64 instances in the metric scope to avoid frequent re-allocations
- Avoid calling `find_if`: use `lower_bound` instead and keep the vector always sorted. This gives us the same lookup complexity that `std::map` has, i.e., `O(log n)`.

Relates #366.

@awelzel can you give this a spin in your setup to see if performance is good enough with this change?