### PR TITLE
Implement new variant type and builder API

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,5 +37,7 @@ SpaceBeforeParens: ControlStatements
 SpacesBeforeTrailingComments: '1'
 Standard: Cpp11
 UseTab: Never
-
+---
+Language: Json
+DisableFormat: true
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@
           modernize-*,
           performance-*,
           -bugprone-easily-swappable-parameters,
+          -bugprone-forward-declaration-namespace,
           -clang-analyzer-cplusplus.NewDeleteLeaks,
           -clang-analyzer-security.insecureAPI.rand,
           -clang-analyzer-webkit*,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 #
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v13.0.0'
+  rev: 'v15.0.7'
   hooks:
   - id: clang-format
     exclude: ^tests/benchmark/readerwriterqueue/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ set(BROKER_SRC
   src/address.cc
   src/alm/multipath.cc
   src/alm/routing_table.cc
+  src/builder.cc
   src/configuration.cc
   src/convert.cc
   src/data.cc
@@ -313,8 +314,10 @@ set(BROKER_SRC
   src/endpoint_id.cc
   src/endpoint_info.cc
   src/entity_id.cc
+  src/envelope.cc
   src/error.cc
   src/filter_type.cc
+  src/format/bin.cc
   src/internal/clone_actor.cc
   src/internal/connector.cc
   src/internal/connector_adapter.cc
@@ -358,6 +361,11 @@ set(BROKER_SRC
   src/telemetry/metric_registry_impl.cc
   src/time.cc
   src/topic.cc
+  src/variant.cc
+  src/variant_data.cc
+  src/variant_list.cc
+  src/variant_set.cc
+  src/variant_table.cc
   src/version.cc
   src/worker.cc
 )

--- a/include/broker/builder.hh
+++ b/include/broker/builder.hh
@@ -1,0 +1,398 @@
+#pragma once
+
+#include "broker/address.hh"
+#include "broker/detail/promote.hh"
+#include "broker/detail/type_traits.hh"
+#include "broker/enum_value.hh"
+#include "broker/format/bin.hh"
+#include "broker/fwd.hh"
+#include "broker/none.hh"
+#include "broker/port.hh"
+#include "broker/subnet.hh"
+#include "broker/time.hh"
+
+#include <cstddef>
+#include <iterator>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+namespace broker{
+
+using builder_buffer = std::vector<std::byte>;
+
+class set_builder;
+class table_builder;
+class list_builder;
+
+// -- is_builder ---------------------------------------------------------------
+
+template <class T>
+struct is_builder_oracle : std::false_type {};
+
+template <>
+struct is_builder_oracle<set_builder> : std::true_type {};
+
+template <>
+struct is_builder_oracle<table_builder> : std::true_type {};
+
+template <>
+struct is_builder_oracle<list_builder> : std::true_type {};
+
+template <class T>
+inline constexpr bool is_builder = is_builder_oracle<T>::value;
+
+} // namespace broker
+
+namespace broker::detail {
+
+struct builder_access {
+  template <class Builder, class T>
+  static Builder& add(Builder& builder, T&& value) {
+    if constexpr (is_builder<std::decay_t<T>>) {
+      auto [first, last] = value.encoded_values();
+      format::bin::v1::write_sequence(value.tag(), value.num_values(), first,
+                                      last, builder.adder());
+    } else {
+      format::bin::v1::encode(std::forward<T>(value), builder.adder());
+    }
+    return builder;
+  }
+};
+
+} // namespace broker::detail
+
+namespace broker {
+
+// -- set_builder --------------------------------------------------------------
+
+/// A builder for constructing sets.
+class set_builder {
+public:
+  // -- friend types -----------------------------------------------------------
+
+  friend struct detail::builder_access;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  set_builder();
+
+  set_builder(set_builder&&) noexcept = default;
+
+  set_builder(const set_builder&) = default;
+
+  set_builder& operator=(set_builder&&) noexcept = default;
+
+  set_builder& operator=(const set_builder&) = default;
+
+  // -- properties -------------------------------------------------------------
+
+  /// The type of the sequence this builder is constructing.
+  static constexpr data::type tag() noexcept {
+    return data::type::set;
+  }
+
+  /// Returns the number of elements in the sequence.
+  size_t num_values() const noexcept {
+    return size_;
+  }
+
+  /// Returns the values in the builder as encoded bytes.
+  std::pair<const std::byte*, const std::byte*>
+  encoded_values() const noexcept {
+    return format::bin::v1::encoded_values(bytes_);
+  }
+
+  // -- adders ----------------------------------------------------------------
+
+  template <class T>
+  set_builder& add(T&& value) & {
+    auto&& pval = detail::promote<T>(value);
+    using val_t = std::decay_t<decltype(pval)>;
+    static_assert(variant_data::is_primitive<val_t> || is_builder<val_t>,
+                  "value must be a valid data type or a builder");
+    ++size_;
+    return detail::builder_access::add(*this, pval);
+  }
+
+  template <class T>
+  set_builder&& add(T&& value) && {
+    return std::move(add(std::forward<T>(value)));
+  }
+
+  /// Adds all elements as a nested vector.
+  template <class... Ts>
+  set_builder& add_list(Ts&&... xs) & {
+    start_inline_vector(sizeof...(xs));
+    (detail::builder_access::add(*this, detail::promote<Ts>(xs)), ...);
+    return *this;
+  }
+
+  template <class... Ts>
+  set_builder&& add_list(Ts&&... xs) && {
+    return std::move(add_list(std::forward<Ts>(xs)...));
+  }
+
+  /// Adds all elements as a nested set.
+  /// @pre The elements must be unique.
+  template <class... Ts>
+  set_builder& add_set(Ts&&... xs) & {
+    start_inline_set(sizeof...(xs));
+    (detail::builder_access::add(*this, detail::promote<Ts>(xs)), ...);
+    return *this;
+  }
+
+  template <class... Ts>
+  set_builder&& add_set(Ts&&... xs) && {
+    return std::move(add_set(std::forward<Ts>(xs)...));
+  }
+
+  // -- modifiers --------------------------------------------------------------
+
+  /// Writes meta data to the internal buffer and returns the bytes that the
+  /// builder would use when calling `build`.
+  std::pair<const std::byte*, size_t> bytes();
+
+  /// Converts the sequence into a @ref variant. The builder becomes invalid
+  /// after calling this function.
+  variant build() &&;
+
+protected:
+  auto adder() {
+    return std::back_inserter(bytes_);
+  }
+
+  void start_inline_vector(size_t num_elements) {
+    ++size_;
+    auto out = format::bin::v1::write_unsigned(data::type::vector, adder());
+    format::bin::v1::write_varbyte(num_elements, out);
+  }
+
+  void start_inline_set(size_t num_elements) {
+    ++size_;
+    auto out = format::bin::v1::write_unsigned(data::type::set, adder());
+    format::bin::v1::write_varbyte(num_elements, out);
+  }
+
+  size_t size_ = 0;
+  builder_buffer bytes_;
+};
+
+// -- table_builder ------------------------------------------------------------
+
+/// A builder for constructing vectors.
+class table_builder {
+public:
+  // -- friend types -----------------------------------------------------------
+
+  friend struct detail::builder_access;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  table_builder();
+
+  table_builder(table_builder&&) noexcept = default;
+
+  table_builder(const table_builder&) = default;
+
+  table_builder& operator=(table_builder&&) noexcept = default;
+
+  table_builder& operator=(const table_builder&) = default;
+
+  // -- properties -------------------------------------------------------------
+
+  /// The type of the sequence this builder is constructing.
+  static constexpr data::type tag() noexcept {
+    return data::type::table;
+  }
+
+  /// Returns the number of elements in the sequence.
+  size_t num_values() const noexcept {
+    return size_;
+  }
+
+  /// Returns the values in the builder as encoded bytes.
+  std::pair<const std::byte*, const std::byte*>
+  encoded_values() const noexcept {
+    return format::bin::v1::encoded_values(bytes_);
+  }
+
+  // -- adders ----------------------------------------------------------------
+
+  template <class Key, class Val>
+  table_builder& add(Key&& key_arg, Val&& val_arg) & {
+    auto&& key = detail::promote<Key>(key_arg);
+    auto&& val = detail::promote<Val>(val_arg);
+    using key_t = std::decay_t<decltype(key)>;
+    using val_t = std::decay_t<decltype(val)>;
+    static_assert(variant_data::is_primitive<key_t> || is_builder<key_t>,
+                  "key must be a valid data type or a builder");
+    static_assert(variant_data::is_primitive<val_t> || is_builder<val_t>,
+                  "value must be a valid data type or a builder");
+    ++size_;
+    detail::builder_access::add(*this, key);
+    detail::builder_access::add(*this, val);
+    return *this;
+  }
+
+  // -- rvalue overloads -------------------------------------------------------
+
+  template <class Key, class Value>
+  table_builder&& add(Key&& key, Value&& value) && {
+    return std::move(add(std::forward<Key>(key), std::forward<Value>(value)));
+  }
+
+  // -- modifiers --------------------------------------------------------------
+
+  /// Writes meta data to the internal buffer and returns the bytes that the
+  /// builder would use when calling `build`.
+  std::pair<const std::byte*, size_t> bytes();
+
+  /// Converts the sequence into a @ref variant. The builder becomes invalid
+  /// after calling this function.
+  variant build() &&;
+
+protected:
+  auto adder() {
+    return std::back_inserter(bytes_);
+  }
+
+  size_t size_ = 0;
+  builder_buffer bytes_;
+};
+
+/// A builder for constructing vectors.
+class list_builder {
+public:
+  // -- friend types -----------------------------------------------------------
+
+  friend struct detail::builder_access;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  list_builder();
+
+  list_builder(list_builder&&) noexcept = default;
+
+  list_builder(const list_builder&) = default;
+
+  list_builder& operator=(list_builder&&) noexcept = default;
+
+  list_builder& operator=(const list_builder&) = default;
+
+  // -- properties -------------------------------------------------------------
+
+  /// The type of the sequence this builder is constructing.
+  static constexpr data::type tag() noexcept {
+    return data::type::vector;
+  }
+
+  /// Returns the number of elements in the sequence.
+  size_t num_values() const noexcept {
+    return size_;
+  }
+
+  /// Returns the values in the builder as encoded bytes.
+  std::pair<const std::byte*, const std::byte*>
+  encoded_values() const noexcept {
+    return format::bin::v1::encoded_values(bytes_);
+  }
+
+  // -- adders ----------------------------------------------------------------
+
+  template <class T>
+  list_builder& add(T&& value) & {
+    auto&& pval = detail::promote<T>(value);
+    using val_t = std::decay_t<decltype(pval)>;
+    if constexpr (detail::is_tuple<val_t>) {
+      std::apply([&](auto&&... xs) { (add_list(xs), ...); }, pval);
+      return *this;
+    } else {
+      static_assert(variant_data::is_primitive<val_t> || is_builder<val_t>,
+                    "value must be a valid data type or a builder");
+      ++size_;
+      return detail::builder_access::add(*this, pval);
+    }
+  }
+
+  template <class T>
+  list_builder&& add(T&& value) && {
+    return std::move(add(std::forward<T>(value)));
+  }
+
+  /// Adds all elements as a nested vector.
+  template <class... Ts>
+  list_builder& add_list(Ts&&... xs) & {
+    start_inline_vector(sizeof...(xs));
+    (add_inline_vector_item(std::forward<Ts>(xs)), ...);
+    return *this;
+  }
+
+  template <class... Ts>
+  list_builder&& add_list(Ts&&... xs) && {
+    return std::move(add_list(std::forward<Ts>(xs)...));
+  }
+
+  /// Adds all elements as a nested set.
+  /// @pre The elements must be unique.
+  template <class... Ts>
+  list_builder& add_set(Ts&&... xs) & {
+    start_inline_set(sizeof...(xs));
+    (detail::builder_access::add(*this, detail::promote<Ts>(xs)), ...);
+    return *this;
+  }
+
+  template <class... Ts>
+  list_builder&& add_set(Ts&&... xs) && {
+    return std::move(add_set(std::forward<Ts>(xs)...));
+  }
+
+  // -- modifiers --------------------------------------------------------------
+
+  /// Writes meta data to the internal buffer and returns the bytes that the
+  /// builder would use when calling `build`.
+  std::pair<const std::byte*, size_t> bytes();
+
+  /// Converts the sequence into a @ref variant. The builder becomes invalid
+  /// after calling this function.
+  variant build() &&;
+
+protected:
+  auto adder() {
+    return std::back_inserter(bytes_);
+  }
+
+  template <class T>
+  void add_inline_vector_item(T&& value) {
+    auto&& pval = detail::promote<T>(value);
+    using val_t = std::decay_t<decltype(pval)>;
+    if constexpr (detail::is_tuple<val_t>) {
+      auto out = format::bin::v1::write_unsigned(data::type::vector, adder());
+      format::bin::v1::write_varbyte(std::tuple_size<val_t>::value, out);
+      std::apply([&](auto&&... xs) { (add_inline_vector_item(xs), ...); },
+                 pval);
+    } else {
+      static_assert(variant_data::is_primitive<val_t> || is_builder<val_t>,
+                    "value must be a valid data type or a builder");
+      detail::builder_access::add(*this, pval);
+    }
+  }
+
+  void start_inline_vector(size_t num_elements) {
+    ++size_;
+    auto out = format::bin::v1::write_unsigned(data::type::vector, adder());
+    format::bin::v1::write_varbyte(num_elements, out);
+  }
+
+  void start_inline_set(size_t num_elements) {
+    ++size_;
+    auto out = format::bin::v1::write_unsigned(data::type::set, adder());
+    format::bin::v1::write_varbyte(num_elements, out);
+  }
+
+
+  size_t size_ = 0;
+  builder_buffer bytes_;
+};
+
+} // namespace broker

--- a/include/broker/builder.hh
+++ b/include/broker/builder.hh
@@ -17,7 +17,7 @@
 #include <tuple>
 #include <vector>
 
-namespace broker{
+namespace broker {
 
 using builder_buffer = std::vector<std::byte>;
 
@@ -389,7 +389,6 @@ protected:
     auto out = format::bin::v1::write_unsigned(data::type::set, adder());
     format::bin::v1::write_varbyte(num_elements, out);
   }
-
 
   size_t size_ = 0;
   builder_buffer bytes_;

--- a/include/broker/data.hh
+++ b/include/broker/data.hh
@@ -20,10 +20,9 @@
 #include "broker/port.hh"
 #include "broker/subnet.hh"
 #include "broker/time.hh"
+#include "broker/variant_tag.hh"
 
 namespace broker {
-
-class data;
 
 /// A container of sequential data.
 using vector = std::vector<data>;
@@ -51,25 +50,7 @@ using data_variant = std::variant<none, boolean, count, integer, real,
 /// different primitive or compound types.
 class data {
 public:
-  // Warning: *must* have the same order as `data_variant`, because the integer
-  // value for this tag must be equal to `get_data().index()`.
-  enum class type : uint8_t {
-    none,
-    boolean,
-    count,
-    integer,
-    real,
-    string,
-    address,
-    subnet,
-    port,
-    timestamp,
-    timespan,
-    enum_value,
-    set,
-    table,
-    vector,
-  };
+  using type = variant_tag;
 
   template <class T>
   static constexpr auto tag_of() {
@@ -144,6 +125,11 @@ public:
   /// Returns the type tag of the stored type.
   type get_type() const;
 
+  /// Returns the type tag of the stored type.
+  type get_tag() const {
+    return get_type();
+  }
+
   static data from_type(type);
 
   /// Needed by `get` function overloads.
@@ -153,6 +139,16 @@ public:
 
   /// Needed by `get` function overloads.
   [[nodiscard]] const data_variant& get_data() const noexcept {
+    return data_;
+  }
+
+  /// Returns a reference to the `std::variant` stored in this object.
+  auto& stl_value() noexcept {
+    return data_;
+  }
+
+  /// Returns a reference to the `std::variant` stored in this object.
+  const auto& stl_value() const noexcept {
     return data_;
   }
 

--- a/include/broker/detail/monotonic_buffer_resource.hh
+++ b/include/broker/detail/monotonic_buffer_resource.hh
@@ -32,6 +32,59 @@ public:
     // nop
   }
 
+  template <class T>
+  class allocator {
+  public:
+    using value_type = T;
+
+    template <class U>
+    struct rebind {
+      using other = allocator<U>;
+    };
+
+    constexpr explicit allocator(monotonic_buffer_resource* mbr) : mbr_(mbr) {
+      // nop
+    }
+
+    constexpr allocator() : mbr_(nullptr) {
+      // nop
+    }
+
+    constexpr allocator(const allocator&) = default;
+
+    constexpr allocator& operator=(const allocator&) = default;
+
+    template <class U>
+    constexpr allocator(const allocator<U>& other) : mbr_(other.resource()) {
+      // nop
+    }
+
+    template <class U>
+    allocator& operator=(const allocator<U>& other) {
+      mbr_ = other.resource();
+      return *this;
+    }
+
+    T* allocate(size_t n) {
+      return static_cast<T*>(mbr_->allocate(sizeof(T) * n, alignof(T)));
+    }
+
+    constexpr void deallocate(void*, size_t) noexcept {
+      // nop
+    }
+
+    constexpr auto resource() const noexcept {
+      return mbr_;
+    }
+
+    friend bool operator==(allocator& lhs, allocator& rhs) {
+      return lhs.mbr_ == rhs.mbr_;
+    }
+
+  private:
+    monotonic_buffer_resource* mbr_;
+  };
+
 private:
   struct block {
     block* next;

--- a/include/broker/detail/promote.hh
+++ b/include/broker/detail/promote.hh
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "broker/fwd.hh"
+
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+namespace broker::detail {
+
+/// Promotes integral types to their corresponding Broker types, i.e., signed
+/// integer types to @ref integer and unsigned integer types to @ref count.
+/// Further, converts @ref enum_value to @ref enum_value_view and @ref
+/// std::string to @ref std::string_view. When not performing a conversion,
+/// returns the argument unchanged as if calling `std::forward`.
+template <class T>
+constexpr decltype(auto) promote(std::remove_reference_t<T>& val) noexcept {
+  using val_t = std::decay_t<T>;
+  if constexpr (std::is_integral_v<val_t> && !std::is_same_v<val_t, bool>) {
+    if constexpr (std::is_signed_v<val_t>)
+      return static_cast<integer>(val);
+    else
+      return static_cast<count>(val);
+  } else if constexpr (std::is_same_v<val_t, std::string>) {
+    return std::string_view{val};
+  } else if constexpr (std::is_same_v<val_t, enum_value>) {
+    return enum_value_view{val.name};
+  } else {
+    return static_cast<T&&>(val);
+  }
+}
+
+/// @copydoc promote
+template <class T>
+constexpr decltype(auto) promote(std::remove_reference_t<T>&& val) noexcept {
+  using val_t = std::decay_t<T>;
+  if constexpr (std::is_integral_v<val_t> && !std::is_same_v<val_t, bool>) {
+    if constexpr (std::is_signed_v<val_t>)
+      return static_cast<integer>(val);
+    else
+      return static_cast<count>(val);
+  } else if constexpr (std::is_same_v<val_t, std::string>) {
+    return std::string_view{val};
+  } else if constexpr (std::is_same_v<val_t, enum_value>) {
+    return enum_value_view{val.name};
+  } else {
+    static_assert(!std::is_lvalue_reference_v<T>,
+                  "cannot forward an rvalue as an lvalue");
+    return static_cast<T&&>(val);
+  }
+}
+
+} // namespace broker::detail

--- a/include/broker/detail/type_traits.hh
+++ b/include/broker/detail/type_traits.hh
@@ -44,8 +44,8 @@ struct are_same<A, B> {
 
 template <class A, class B, class C, class... Ts>
 struct are_same<A, B, C, Ts...> {
-  static constexpr bool value =
-    std::is_same_v<A, B> && are_same<B, C, Ts...>::value;
+  static constexpr bool value = std::is_same_v<A, B>
+                                && are_same<B, C, Ts...>::value;
 };
 
 template <class... Ts>
@@ -162,7 +162,6 @@ struct is_pair_oracle<std::pair<T, U>> : std::true_type {};
 
 template <class T>
 inline constexpr bool is_pair = is_pair_oracle<T>::value;
-
 
 // Trait that checks whether T is a std::tuple.
 template <class T>

--- a/include/broker/enum_value.hh
+++ b/include/broker/enum_value.hh
@@ -52,7 +52,7 @@ public:
   enum_value_view() = default;
 
   /// Construct enum value from a string.
-  explicit enum_value_view(std::string_view name) : name{std::move(name)} {
+  explicit enum_value_view(std::string_view name) : name{name} {
     // nop
   }
 

--- a/include/broker/enum_value.hh
+++ b/include/broker/enum_value.hh
@@ -3,6 +3,7 @@
 #include <functional>
 #include <ostream>
 #include <string>
+#include <string_view>
 
 #include "broker/detail/operators.hh"
 
@@ -41,6 +42,51 @@ bool inspect(Inspector& f, enum_value& e) {
 /// @relates enum_value
 inline void convert(const enum_value& e, std::string& str) {
   str = e.name;
+}
+
+/// Like enum_value, but wraps a value of type `std::string_view` instead.
+class enum_value_view : detail::totally_ordered<enum_value_view>,
+                        detail::totally_ordered<enum_value_view, enum_value> {
+public:
+  /// Default construct empty enum value name.
+  enum_value_view() = default;
+
+  /// Construct enum value from a string.
+  explicit enum_value_view(std::string_view name) : name{std::move(name)} {
+    // nop
+  }
+
+  std::string_view name;
+};
+
+/// @relates enum_value
+inline bool operator==(const enum_value_view& lhs, const enum_value_view& rhs) {
+  return lhs.name == rhs.name;
+}
+
+/// @relates enum_value_view
+inline bool operator<(const enum_value_view& lhs, const enum_value_view& rhs) {
+  return lhs.name < rhs.name;
+}
+
+/// @relates enum_value
+inline bool operator==(const enum_value_view& lhs, const enum_value& rhs) {
+  return lhs.name == rhs.name;
+}
+
+/// @relates enum_value_view
+inline bool operator<(const enum_value_view& lhs, const enum_value& rhs) {
+  return lhs.name < rhs.name;
+}
+
+/// @relates enum_value
+inline bool operator==(const enum_value& lhs, const enum_value_view& rhs) {
+  return lhs.name == rhs.name;
+}
+
+/// @relates enum_value_view
+inline bool operator<(const enum_value& lhs, const enum_value_view& rhs) {
+  return lhs.name < rhs.name;
 }
 
 } // namespace broker

--- a/include/broker/envelope.hh
+++ b/include/broker/envelope.hh
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "broker/fwd.hh"
+
+#include <memory>
+
+namespace broker {
+
+/// Wraps a value of type @ref variant and associates it with a @ref topic.
+class envelope : public std::enable_shared_from_this<envelope> {
+public:
+  virtual ~envelope();
+
+  /// Returns the contained value.
+  /// @pre `root != nullptr`
+  virtual variant value() const noexcept = 0;
+
+  /// Returns the topic for the data in this envelope.
+  virtual std::string_view topic() const noexcept = 0;
+
+  /// Checks whether `val` is the root value.
+  virtual bool is_root(const variant_data* val) const noexcept = 0;
+
+  /// Returns the contained value in its serialized form, if available. If the
+  /// envelope does not contain serialized data, returns `nullptr` and `0`.
+  virtual std::pair<const std::byte*, size_t> raw_bytes() const noexcept = 0;
+
+  /// Creates a new data envolope from the given @ref topic and @ref data.
+  static envelope_ptr make(broker::topic t, const data& d);
+
+  /// Creates a new data envolope from the given @ref topic and @ref data.
+  static envelope_ptr make(broker::topic t, variant d);
+
+protected:
+  /// Parses the data returned from @ref raw_bytes.
+  variant_data* do_parse(detail::monotonic_buffer_resource& buf, error& err);
+};
+
+/// A shared pointer to an @ref envelope.
+using envelope_ptr = std::shared_ptr<const envelope>;
+
+} // namespace broker

--- a/include/broker/format/bin.hh
+++ b/include/broker/format/bin.hh
@@ -1,0 +1,302 @@
+#pragma once
+
+#include "broker/config.hh"
+#include "broker/data.hh"
+#include "broker/variant.hh"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace broker::format::bin::v1 {
+
+/// Converts `value` from native to network byte order.
+uint16_t to_network_order(uint16_t value);
+
+/// Converts `value` from native to network byte order.
+uint64_t to_network_order(uint64_t value);
+
+/// Converts `value` from network to native byte order.
+template <class T>
+T from_network_order(T value) {
+  // swapping the bytes again gives the native order
+  return to_network_order(value);
+}
+
+/// Packs a double into a 64-bit integer, preserving the bit pattern.
+uint64_t real_to_network_representation(real value);
+
+/// Unpacks a double from a 64-bit integer, preserving the bit pattern.
+real real_from_network_representation(uint64_t value);
+
+/// The maximum size of a varbyte-encoded value.
+constexpr size_t max_varbyte_size = 10;
+
+template <class OutIter>
+struct value_type_oracle {
+  using type = typename std::iterator_traits<OutIter>::value_type;
+};
+
+template <class Container>
+struct value_type_oracle<std::back_insert_iterator<Container>> {
+  using type = typename Container::value_type;
+};
+
+/// Deduces the value type of an output iterator.
+template <class OutIter>
+using iter_value_t = typename value_type_oracle<OutIter>::type;
+
+template <class WriteFn>
+auto write_varbyte_impl(size_t value, WriteFn&& write) {
+  // Use varbyte encoding to compress sequence size on the wire.
+  // For 64-bit values, the encoded representation cannot get larger than 10
+  // bytes. A scratch space of 16 bytes suffices as upper bound.
+  uint8_t buf[16];
+  auto i = buf;
+  auto x = static_cast<uint32_t>(value);
+  while (x > 0x7f) {
+    *i++ = (static_cast<uint8_t>(x) & 0x7f) | 0x80;
+    x >>= 7;
+  }
+  *i++ = static_cast<uint8_t>(x) & 0x7f;
+  return write(reinterpret_cast<std::byte*>(buf),
+               reinterpret_cast<std::byte*>(i));
+}
+
+/// Returns the number of bytes required to encode `value` as a varbyte.
+inline size_t varbyte_size(size_t value) {
+  return write_varbyte_impl(value, [](auto* begin, auto* end) {
+    return static_cast<size_t>(end - begin);
+  });
+}
+
+/// Encodes `value` to a variable-length byte sequence and appends it to `out`.
+template <class OutIter>
+OutIter write_varbyte(size_t value, OutIter out) {
+  return write_varbyte_impl(value, [out](auto* begin, auto* end) {
+    using value_type = iter_value_t<OutIter>;
+    return std::copy(reinterpret_cast<value_type*>(begin),
+                     reinterpret_cast<value_type*>(end), out);
+  });
+}
+
+/// Encodes `value` to its binary representation and appends it to `out`.
+template <class T, class OutIter>
+OutIter write_unsigned(T value, OutIter out) {
+  if constexpr (std::is_enum_v<T>) {
+    return write_unsigned(static_cast<std::underlying_type_t<T>>(value), out);
+  } else if constexpr (sizeof(T) > 1) {
+    static_assert(std::is_unsigned_v<T> && !std::is_same_v<T, bool>);
+    auto tmp = to_network_order(value);
+    iter_value_t<OutIter> buf[sizeof(T)];
+    memcpy(buf, &tmp, sizeof(T));
+    return std::copy(buf, buf + sizeof(T), out);
+  } else {
+    *out++ = static_cast<iter_value_t<OutIter>>(value);
+    return out;
+  }
+}
+
+template <class T, class OutIter>
+OutIter write_bytes(const T* first, const T* last, OutIter out) {
+  static_assert(sizeof(T) == 1);
+  using val_t = iter_value_t<OutIter>;
+  return std::copy(reinterpret_cast<const val_t*>(first),
+                   reinterpret_cast<const val_t*>(last), out);
+}
+
+template <class Container, class OutIter>
+OutIter write_bytes(const Container& in, OutIter out) {
+  return write_bytes(in.data(), in.data() + in.size(), out);
+}
+
+/// Initializes a buffer for encoding a sequence of values.
+template <class Buffer>
+void encode_sequence_begin(Buffer& out) {
+  // When starting to encode a new sequence, we don't have the size yet. Hence,
+  // we reserve the maximum size of a varbyte-encoded value.
+  out.clear();
+  out.reserve(32);
+  out.resize(max_varbyte_size + 1); // +1 for the tag
+}
+
+/// Finalizes a buffer for encoding a sequence of values.
+/// @param tag The tag of the sequence.
+/// @param len The number of elements in the sequence.
+/// @param out The buffer to write to.
+/// @returns the offset for the buffer where the sequence starts.
+template <class Buffer>
+size_t encode_sequence_end(data::type tag, size_t len, Buffer& out) {
+  // Now that we know the size, we can encode it at the beginning of the buffer.
+  // We also encode the tag of the sequence.
+  auto len_size = varbyte_size(len);
+  auto offset = max_varbyte_size - len_size;
+  out[offset] = static_cast<std::byte>(tag);
+  write_varbyte(len, out.data() + offset + 1);
+  return offset;
+}
+
+/// Returns the byte range holding the encoded values of a sequence that was
+/// initialized with `encode_sequence_begin`.
+template <class Buffer>
+auto encoded_values(const Buffer& buf) {
+  constexpr size_t offset = max_varbyte_size + 1;
+  auto begin = buf.data() + offset;
+  auto end = begin + (buf.size() - offset);
+  return std::make_pair(begin, end);
+}
+
+template <class OutIter>
+OutIter encode(none, OutIter out) {
+  return write_unsigned(data::type::none, out);
+}
+
+template <class OutIter>
+OutIter encode(boolean value, OutIter out) {
+  out = write_unsigned(data::type::boolean, out);
+  return write_unsigned(static_cast<uint8_t>(value), out);
+}
+
+/// Encodes `value` to its binary representation and appends it to `out`.
+template <class OutIter>
+OutIter encode(count value, OutIter out) {
+  static_assert(sizeof(count) == sizeof(uint64_t));
+  out = write_unsigned(data::type::count, out);
+  return write_unsigned(value, out);
+}
+
+template <class OutIter>
+OutIter encode(integer value, OutIter out) {
+  static_assert(sizeof(integer) == sizeof(uint64_t));
+  out = write_unsigned(data::type::integer, out);
+  return write_unsigned(static_cast<count>(value), out);
+}
+
+template <class OutIter>
+OutIter encode(real value, OutIter out) {
+  out = write_unsigned(data::type::real, out);
+  return write_unsigned(real_to_network_representation(value), out);
+}
+
+template <class OutIter>
+OutIter encode(std::string_view value, OutIter out) {
+  out = write_unsigned(data::type::string, out);
+  out = write_varbyte(value.size(), out);
+  return write_bytes(value, out);
+}
+
+template <class OutIter>
+OutIter encode(address value, OutIter out) {
+  out = write_unsigned(data::type::address, out);
+  return write_bytes(value.bytes(), out);
+}
+
+template <class OutIter>
+OutIter encode(subnet value, OutIter out) {
+  out = write_unsigned(data::type::subnet, out);
+  out = write_bytes(value.network().bytes(), out);
+  return write_unsigned(value.length(), out);
+}
+
+template <class OutIter>
+OutIter encode(port value, OutIter out) {
+  out = write_unsigned(data::type::port, out);
+  out = write_unsigned(value.number(), out);
+  return write_unsigned(value.type(), out);
+}
+
+template <class OutIter>
+OutIter encode(timestamp value, OutIter out) {
+  out = write_unsigned(data::type::timestamp, out);
+  return write_unsigned(static_cast<count>(value.time_since_epoch().count()),
+                        out);
+}
+
+template <class OutIter>
+OutIter encode(timespan value, OutIter out) {
+  out = write_unsigned(data::type::timespan, out);
+  return write_unsigned(static_cast<count>(value.count()), out);
+}
+
+template <class OutIter>
+OutIter encode(enum_value_view value, OutIter out) {
+  out = write_unsigned(data::type::enum_value, out);
+  out = write_varbyte(value.name.size(), out);
+  return write_bytes(value.name, out);
+}
+
+template <class OutIter>
+OutIter encode(const enum_value& value, OutIter out) {
+  out = write_unsigned(data::type::enum_value, out);
+  out = write_varbyte(value.name.size(), out);
+  return write_bytes(value.name, out);
+}
+
+template <class OutIter>
+OutIter encode(const variant_data& value, OutIter out);
+
+template <class OutIter>
+OutIter encode(const variant_data::set* values, OutIter out);
+
+template <class OutIter>
+OutIter encode(const variant_data::table* values, OutIter out);
+
+template <class OutIter>
+OutIter encode(const variant_data::list* values, OutIter out);
+
+template <class OutIter>
+OutIter encode(const variant& value, OutIter out) {
+  return std::visit([&](auto&& x) { return encode(x, out); },
+                    value.stl_value());
+}
+
+template <class OutIter>
+OutIter encode(const variant_data& value, OutIter out) {
+  return std::visit([&](auto&& x) { return encode(x, out); },
+                    value.stl_value());
+}
+
+template <class OutIter>
+OutIter encode(const variant_data::set* values, OutIter out) {
+  out = write_unsigned(data::type::set, out);
+  out = write_varbyte(values->size(), out);
+  for (const auto& x : *values)
+    out = encode(x, out);
+  return out;
+}
+
+template <class OutIter>
+OutIter encode(const variant_data::table* values, OutIter out) {
+  out = write_unsigned(data::type::set, out);
+  out = write_varbyte(values->size(), out);
+  for (const auto& [key, val] : *values) {
+    out = encode(key, out);
+    out = encode(val, out);
+  }
+  return out;
+}
+
+template <class OutIter>
+OutIter encode(const variant_data::list* values, OutIter out) {
+  out = write_unsigned(data::type::list, out);
+  out = write_varbyte(values->size(), out);
+  for (const auto& x : *values)
+    out = encode(x, out);
+  return out;
+}
+
+/// Embeds an already encoded sequence into `out`.
+/// @param tag The tag of the sequence.
+/// @param num_elements The number of elements in the sequence.
+/// @param first The first byte of the encoded sequence.
+/// @param last The last byte of the encoded sequence.
+/// @param out The buffer to write to.
+/// @pre `first` and `last` must be a valid range.
+template <class InputIter, class Sentinel, class OutIter>
+OutIter write_sequence(data::type tag, size_t num_elements, InputIter first,
+                       Sentinel last, OutIter out) {
+  out = write_unsigned(tag, out);
+  out = write_varbyte(num_elements, out);
+  return write_bytes(first, last, out);
+}
+}

--- a/include/broker/format/bin.hh
+++ b/include/broker/format/bin.hh
@@ -186,13 +186,13 @@ OutIter encode(std::string_view value, OutIter out) {
 }
 
 template <class OutIter>
-OutIter encode(address value, OutIter out) {
+OutIter encode(const address& value, OutIter out) {
   out = write_unsigned(data::type::address, out);
   return write_bytes(value.bytes(), out);
 }
 
 template <class OutIter>
-OutIter encode(subnet value, OutIter out) {
+OutIter encode(const subnet& value, OutIter out) {
   out = write_unsigned(data::type::subnet, out);
   out = write_bytes(value.network().bytes(), out);
   return write_unsigned(value.length(), out);
@@ -299,4 +299,4 @@ OutIter write_sequence(data::type tag, size_t num_elements, InputIter first,
   out = write_varbyte(num_elements, out);
   return write_bytes(first, last, out);
 }
-}
+} // namespace broker::format::bin::v1

--- a/include/broker/format/txt.hh
+++ b/include/broker/format/txt.hh
@@ -70,7 +70,7 @@ OutIter encode(std::string_view value, OutIter out) {
 
 /// Renders `value` using the `convert` API and copies the result to `out`.
 template <class OutIter>
-OutIter encode(address value, OutIter out) {
+OutIter encode(const address& value, OutIter out) {
   std::string str;
   convert(value, str);
   return std::copy(str.begin(), str.end(), out);
@@ -78,7 +78,7 @@ OutIter encode(address value, OutIter out) {
 
 /// Renders `value` using the `convert` API and copies the result to `out`.
 template <class OutIter>
-OutIter encode(subnet value, OutIter out) {
+OutIter encode(const subnet& value, OutIter out) {
   std::string str;
   convert(value, str);
   return std::copy(str.begin(), str.end(), out);

--- a/include/broker/format/txt.hh
+++ b/include/broker/format/txt.hh
@@ -32,7 +32,8 @@ template <class OutIter>
 OutIter encode(count value, OutIter out) {
   // An integer can at most have 20 digits (UINT64_MAX).
   char buf[24];
-  auto size = std::snprintf(buf, 24, "%llu", value);
+  auto size = std::snprintf(buf, 24, "%llu",
+                            static_cast<long long unsigned>(value));
   return std::copy(buf, buf + size, out);
 }
 
@@ -41,7 +42,7 @@ template <class OutIter>
 OutIter encode(integer value, OutIter out) {
   // An integer can at most have 20 digits (UINT64_MAX).
   char buf[24];
-  auto size = std::snprintf(buf, 24, "%lld", value);
+  auto size = std::snprintf(buf, 24, "%lld", static_cast<long long>(value));
   return std::copy(buf, buf + size, out);
 }
 

--- a/include/broker/format/txt.hh
+++ b/include/broker/format/txt.hh
@@ -1,0 +1,235 @@
+#pragma once
+
+#include "broker/config.hh"
+#include "broker/data.hh"
+#include "broker/variant.hh"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace broker::format::txt::v1 {
+
+/// Render the `nil` value to `out`.
+template <class OutIter>
+OutIter encode(none, OutIter out) {
+  using namespace std::literals;
+  auto str = "nil"s;
+  return std::copy(str.begin(), str.end(), out);
+}
+
+/// Renders `value` to `out` as `T` for `true` and `F` for `false`.
+template <class OutIter>
+OutIter encode(boolean value, OutIter out) {
+  *out++ = value ? 'T' : 'F';
+  return out;
+}
+
+/// Writes `value` to `out` using `snprintf`.
+template <class OutIter>
+OutIter encode(count value, OutIter out) {
+  // An integer can at most have 20 digits (UINT64_MAX).
+  char buf[24];
+  auto size = std::snprintf(buf, 24, "%llu", value);
+  return std::copy(buf, buf + size, out);
+}
+
+/// Writes `value` to `out` using `snprintf`.
+template <class OutIter>
+OutIter encode(integer value, OutIter out) {
+  // An integer can at most have 20 digits (UINT64_MAX).
+  char buf[24];
+  auto size = std::snprintf(buf, 24, "%lld", value);
+  return std::copy(buf, buf + size, out);
+}
+
+/// Writes `value` to `out` using `snprintf`.
+template <class OutIter>
+OutIter encode(real value, OutIter out) {
+  auto size = std::snprintf(nullptr, 0, "%f", value);
+  if (size < 24) {
+    char buf[24];
+    auto size = std::snprintf(buf, 24, "%f", value);
+    return std::copy(buf, buf + size, out);
+  } else {
+    std::vector<char> buf;
+    buf.resize(size + 1); // +1 for the null terminator
+    std::snprintf(buf.data(), buf.size(), "%f", value);
+    return std::copy(buf.begin(), buf.end(), out);
+  }
+}
+
+/// Copies `value` to `out`.
+template <class OutIter>
+OutIter encode(std::string_view value, OutIter out) {
+  return std::copy(value.begin(), value.end(), out);
+}
+
+/// Renders `value` using the `convert` API and copies the result to `out`.
+template <class OutIter>
+OutIter encode(address value, OutIter out) {
+  std::string str;
+  convert(value, str);
+  return std::copy(str.begin(), str.end(), out);
+}
+
+/// Renders `value` using the `convert` API and copies the result to `out`.
+template <class OutIter>
+OutIter encode(subnet value, OutIter out) {
+  std::string str;
+  convert(value, str);
+  return std::copy(str.begin(), str.end(), out);
+}
+
+/// Renders `value` using the `convert` API and copies the result to `out`.
+template <class OutIter>
+OutIter encode(port value, OutIter out) {
+  std::string str;
+  convert(value, str);
+  return std::copy(str.begin(), str.end(), out);
+}
+
+/// Renders `value` to `out` in nanoseconds resolution.
+template <class OutIter>
+OutIter encode(timestamp value, OutIter out) {
+  using namespace std::literals;
+  auto suffix = "ns"sv;
+  out = encode(static_cast<integer>(value.time_since_epoch().count()), out);
+  return std::copy(suffix.begin(), suffix.end(), out);
+}
+
+/// Renders `value` to `out` in nanoseconds resolution.
+template <class OutIter>
+OutIter encode(timespan value, OutIter out) {
+  using namespace std::literals;
+  auto suffix = "ns"sv;
+  out = encode(static_cast<integer>(value.count()), out);
+  return std::copy(suffix.begin(), suffix.end(), out);
+}
+
+/// Copies the name of `value` to `out`.
+template <class OutIter>
+OutIter encode(enum_value_view value, OutIter out) {
+  return encode(value.name, out);
+}
+
+/// Copies the name of `value` to `out`.
+template <class OutIter>
+OutIter encode(const enum_value& value, OutIter out) {
+  return encode(value.name, out);
+}
+
+/// Recursively encodes `value` to `out`.
+template <class OutIter>
+OutIter encode(const variant_data& value, OutIter out);
+
+/// Renders `value` to `out` as a sequence, enclosing it in curly braces.
+template <class OutIter>
+OutIter encode(const variant_data::set* values, OutIter out);
+
+/// Renders `value` to `out` as a sequence, enclosing it in curly braces and
+/// displaying key/value pairs as `key -> value`.
+template <class OutIter>
+OutIter encode(const variant_data::table* values, OutIter out);
+
+/// Renders `value` to `out` as a sequence, enclosing it in square brackets.
+template <class OutIter>
+OutIter encode(const variant_data::list* values, OutIter out);
+
+/// Renders `value` to `out` as a sequence, enclosing it in curly braces.
+template <class OutIter>
+OutIter encode(const broker::set& values, OutIter out);
+
+/// Renders `value` to `out` as a sequence, enclosing it in curly braces and
+/// displaying key/value pairs as `key -> value`.
+template <class OutIter>
+OutIter encode(const broker::table& values, OutIter out);
+
+template <class OutIter>
+OutIter encode(const broker::vector& values, OutIter out);
+
+/// Renders `value` to `out` as a sequence, enclosing it in square brackets.
+template <class OutIter>
+OutIter encode(const variant& value, OutIter out) {
+  return std::visit([&](auto&& x) { return encode(x, out); },
+                    value.stl_value());
+}
+
+/// Recursively encodes `value` to `out`.
+template <class OutIter>
+OutIter encode(const variant_data& value, OutIter out) {
+  return std::visit([&](auto&& x) { return encode(x, out); },
+                    value.stl_value());
+}
+
+/// Renders `kvp` as `key -> value` to `out`.
+template <class Key, class Val, class OutIter>
+OutIter encode(const std::pair<Key, Val>& kvp, OutIter out) {
+  using namespace std::literals;
+  out = encode(kvp.first, out);
+  auto sep = " -> "sv;
+  out = std::copy(sep.begin(), sep.end(), out);
+  return encode(kvp.second, out);
+}
+
+/// Helper function to render a sequence of values to `out`.
+template <class Iterator, class Sentinel, class OutIter>
+OutIter encode_range(Iterator first, Sentinel last, char left, char right,
+                     OutIter out) {
+  using namespace std::literals;
+  *out++ = left;
+  if (first != last) {
+    out = encode(*first++, out);
+    auto sep = ", "sv;
+    while (first != last) {
+      out = std::copy(sep.begin(), sep.end(), out);
+      out = encode(*first++, out);
+    }
+  }
+  *out++ = right;
+  return out;
+}
+
+template <class OutIter>
+OutIter encode(const variant_data::set* values, OutIter out) {
+  return encode_range(values->begin(), values->end(), '{', '}', out);
+}
+
+template <class OutIter>
+OutIter encode(const variant_data::table* values, OutIter out) {
+  return encode_range(values->begin(), values->end(), '(', ')', out);
+}
+
+template <class OutIter>
+OutIter encode(const variant_data::list* values, OutIter out) {
+  return encode_range(values->begin(), values->end(), '{', '}', out);
+}
+
+// Unfortunately, broker::data is a nasty type due to its implicit conversions.
+// This template hackery is necessary to make sure this function accepts only
+// broker::data directly, without allowing to compiler to implicitly convert
+// other types to broker::data.
+template <class Data, class OutIter>
+std::enable_if_t<std::is_same_v<data, Data>, OutIter> encode(const Data& value,
+                                                             OutIter out) {
+  return std::visit([&](auto&& x) { return encode(x, out); }, value.get_data());
+}
+
+template <class OutIter>
+OutIter encode(const broker::set& values, OutIter out) {
+  return encode_range(values.begin(), values.end(), '{', '}', out);
+}
+
+template <class OutIter>
+OutIter encode(const broker::table& values, OutIter out) {
+  return encode_range(values.begin(), values.end(), '(', ')', out);
+}
+
+template <class OutIter>
+OutIter encode(const broker::vector& values, OutIter out) {
+  return encode_range(values.begin(), values.end(), '{', '}', out);
+}
+
+} // namespace broker::format::txt::v1

--- a/include/broker/fwd.hh
+++ b/include/broker/fwd.hh
@@ -52,6 +52,9 @@ class configuration;
 class data;
 class endpoint;
 class endpoint_id;
+class enum_value_view;
+class envelope;
+class error;
 class internal_command;
 class mailbox;
 class port;
@@ -63,6 +66,11 @@ class store;
 class subnet;
 class subscriber;
 class topic;
+class variant;
+class variant_data;
+class variant_list;
+class variant_set;
+class variant_table;
 class worker;
 
 // -- templates ----------------------------------------------------------------
@@ -80,6 +88,7 @@ enum class ec : uint8_t;
 enum class p2p_message_type : uint8_t;
 enum class packed_message_type : uint8_t;
 enum class sc : uint8_t;
+enum class variant_tag : uint8_t;
 
 // -- STD type aliases ---------------------------------------------------------
 
@@ -136,6 +145,7 @@ using routing_table = std::unordered_map<endpoint_id, routing_table_row>;
 
 namespace broker {
 
+using envelope_ptr = std::shared_ptr<const envelope>;
 using packed_message =
   cow_tuple<packed_message_type, uint16_t, topic, std::vector<std::byte>>;
 using command_message = cow_tuple<topic, internal_command>;
@@ -149,6 +159,7 @@ using node_message = cow_tuple<endpoint_id, endpoint_id, packed_message>;
 namespace broker::detail {
 
 class abstract_backend;
+class monotonic_buffer_resource;
 
 } // namespace broker::detail
 

--- a/include/broker/internal/stringifier.hh
+++ b/include/broker/internal/stringifier.hh
@@ -1,0 +1,90 @@
+#include "broker/data.hh"
+#include "broker/data_view.hh"
+
+#include "caf/detail/print.hpp"
+
+#include <string>
+#include <string_view>
+
+namespace broker::internal {
+
+struct stringifier {
+  using dvv = detail::data_view_value;
+
+  std::string& str;
+
+  template <class T>
+  void operator()(const T& value) {
+    if constexpr (std::is_same_v<T, std::string_view>
+                  || std::is_same_v<T, std::string>) {
+      str.insert(str.end(), value.begin(), value.end());
+    } else if constexpr (std::is_same_v<T, enum_value_view>
+                         || std::is_same_v<T, enum_value>) {
+      str.insert(str.end(), value.name.begin(), value.name.end());
+    } else if constexpr (std::is_same_v<T, dvv::set_view*>
+                         || std::is_same_v<T, set>) {
+      add_range(value, '{', '}');
+    } else if constexpr (std::is_same_v<T, dvv::table_view*>
+                         || std::is_same_v<T, table>) {
+      add_range(value, '{', '}');
+    } else if constexpr (std::is_same_v<T, dvv::vector_view*>
+                         || std::is_same_v<T, vector>) {
+      add_range(value, '(', ')');
+    } else if constexpr (std::is_same_v<T,bool>) {
+      if (value)
+        str += 'T';
+      else
+        str += 'F';
+    } else if constexpr (std::is_same_v<T, timespan>) {
+      str += std::to_string(value.count());
+      str += "ns";
+    } else if constexpr (std::is_same_v<T, timestamp>) {
+      (*this)(value.time_since_epoch());
+    } else {
+      using std::to_string;
+      str += to_string(value);
+    }
+  }
+
+  template <class T1, class T2>
+  void operator()(const std::pair<T1, T2>& kvp) {
+    (*this)(kvp.first);
+    str += " -> ";
+    (*this)(kvp.second);
+  }
+
+  void operator()(const data& value) {
+    std::visit(*this, value.get_data());
+  }
+
+  void operator()(const dvv& value) {
+    std::visit(*this, value.data);
+  }
+
+  void operator()(const data_view& value) {
+    std::visit(*this, value.as_variant());
+  }
+
+  template <class Iterator, class Sentinel>
+  void add_range(Iterator first, Sentinel last, char left, char right) {
+    str += left;
+    if (first != last) {
+      (*this)(*first++);
+      while (first != last) {
+        str += ", ";
+        (*this)(*first++);
+      }
+    }
+    str += right;
+  }
+
+  template <class Range>
+  void add_range(const Range& range, char left, char right) {
+    if constexpr (std::is_pointer_v<Range>)
+      add_range(range->begin(), range->end(), left, right);
+    else
+      add_range(range.begin(), range.end(), left, right);
+  }
+};
+
+} // namespace broker::internal

--- a/include/broker/internal/stringifier.hh
+++ b/include/broker/internal/stringifier.hh
@@ -30,7 +30,7 @@ struct stringifier {
     } else if constexpr (std::is_same_v<T, dvv::vector_view*>
                          || std::is_same_v<T, vector>) {
       add_range(value, '(', ')');
-    } else if constexpr (std::is_same_v<T,bool>) {
+    } else if constexpr (std::is_same_v<T, bool>) {
       if (value)
         str += 'T';
       else

--- a/include/broker/subnet.hh
+++ b/include/broker/subnet.hh
@@ -16,10 +16,12 @@ bool convert(const std::string& str, subnet& sn);
 class subnet : detail::totally_ordered<subnet> {
 public:
   /// Default construct empty subnet ::/0.
-  subnet();
+  subnet() noexcept;
+
+  subnet(const subnet&) noexcept = default;
 
   /// Construct subnet from an address and length.
-  subnet(const address& addr, uint8_t length);
+  subnet(const address& addr, uint8_t length) noexcept;
 
   /// @return whether an address is contained within this subnet.
   bool contains(const address& addr) const;

--- a/include/broker/variant.hh
+++ b/include/broker/variant.hh
@@ -15,8 +15,7 @@ namespace broker {
 template <class T>
 inline constexpr bool is_primtivie_data_v =
   detail::is_one_of_v<T, none, boolean, count, integer, real, std::string,
-                      address, subnet, port, timestamp, timespan,
-                      enum_value>;
+                      address, subnet, port, timestamp, timespan, enum_value>;
 
 /// Represents a value of any of the following types:
 /// - @ref none
@@ -203,7 +202,7 @@ public:
 
   /// Retrieves the @c address value or returns @p fallback if this object does
   /// not contain a @c address.
-  address to_address(address fallback = {}) const noexcept {
+  address to_address(const address& fallback = {}) const noexcept {
     if (auto* val = std::get_if<address>(&raw_->value))
       return *val;
     return fallback;
@@ -211,7 +210,7 @@ public:
 
   /// Retrieves the @c subnet value or returns @p fallback if this object does
   /// not contain a @c subnet.
-  subnet to_subnet(subnet fallback = {}) const noexcept {
+  subnet to_subnet(const subnet& fallback = {}) const noexcept {
     if (auto* val = std::get_if<subnet>(&raw_->value))
       return *val;
     return fallback;

--- a/include/broker/variant.hh
+++ b/include/broker/variant.hh
@@ -1,0 +1,352 @@
+#pragma once
+
+#include "broker/data.hh"
+#include "broker/envelope.hh"
+#include "broker/fwd.hh"
+#include "broker/variant_data.hh"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace broker {
+
+/// Evaluates to `true` if `T` represents a primitive type.
+template <class T>
+inline constexpr bool is_primtivie_data_v =
+  detail::is_one_of_v<T, none, boolean, count, integer, real, std::string,
+                      address, subnet, port, timestamp, timespan,
+                      enum_value>;
+
+/// Represents a value of any of the following types:
+/// - @ref none
+/// - @ref boolean
+/// - @ref count
+/// - @ref integer
+/// - @ref real
+/// - @ref std::string
+/// - @ref address
+/// - @ref subnet
+/// - @ref port
+/// - @ref timestamp
+/// - @ref timespan
+/// - @ref enum_value
+/// - @ref variant_set
+/// - @ref variant_table
+/// - @ref variant_list
+class variant {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  variant() : raw_(variant_data::nil()) {}
+
+  variant(variant&&) = default;
+
+  variant(const variant&) = default;
+
+  variant& operator=(variant&&) = default;
+
+  variant& operator=(const variant&) = default;
+
+  variant(const variant_data* value, envelope_ptr envelope) noexcept
+    : raw_(value), envelope_(std::move(envelope)) {
+    // nop
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  /// Checks whether this object is the root object in its envelope.
+  bool is_root() const noexcept;
+
+  /// Returns the type of the contained data.
+  variant_tag get_tag() const noexcept {
+    return raw_->get_tag();
+  }
+
+  /// Checks whether this view contains the `nil` value.
+  bool is_none() const noexcept {
+    return get_tag() == variant_tag::none;
+  }
+
+  /// Checks whether this view contains a boolean.
+  bool is_boolean() const noexcept {
+    return get_tag() == variant_tag::boolean;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_count() const noexcept {
+    return get_tag() == variant_tag::count;
+  }
+
+  /// Checks whether this view contains a integer.
+  bool is_integer() const noexcept {
+    return get_tag() == variant_tag::integer;
+  }
+
+  /// Checks whether this view contains a real.
+  bool is_real() const noexcept {
+    return get_tag() == variant_tag::real;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_string() const noexcept {
+    return get_tag() == variant_tag::string;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_address() const noexcept {
+    return get_tag() == variant_tag::address;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_subnet() const noexcept {
+    return get_tag() == variant_tag::subnet;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_port() const noexcept {
+    return get_tag() == variant_tag::port;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_timestamp() const noexcept {
+    return get_tag() == variant_tag::timestamp;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_timespan() const noexcept {
+    return get_tag() == variant_tag::timespan;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_enum_value() const noexcept {
+    return get_tag() == variant_tag::enum_value;
+  }
+
+  /// Checks whether this view contains a set.
+  bool is_set() const noexcept {
+    return get_tag() == variant_tag::set;
+  }
+
+  /// Checks whether this view contains a table.
+  bool is_table() const noexcept {
+    return get_tag() == variant_tag::table;
+  }
+
+  /// Checks whether this view contains a list.
+  bool is_list() const noexcept {
+    return get_tag() == variant_tag::vector;
+  }
+
+  /// Alias for @ref is_list.
+  bool is_vector() const noexcept {
+    return is_list();
+  }
+
+  // -- conversions ------------------------------------------------------------
+
+  /// Converts this view into a @c data object.
+  data to_data() const;
+
+  /// Retrieves the @c boolean value or returns @p fallback if this object does
+  /// not contain a @c boolean.
+  bool to_boolean(bool fallback = false) const noexcept {
+    if (auto* val = std::get_if<boolean>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c count value or returns @p fallback if this object does
+  /// not contain a @c count.
+  count to_count(count fallback = 0) const noexcept {
+    if (auto* val = std::get_if<count>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c integer value or returns @p fallback if this object does
+  /// not contain a @c integer.
+  integer to_integer(integer fallback = 0) const noexcept {
+    if (auto* val = std::get_if<integer>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c real value or returns @p fallback if this object does
+  /// not contain a @c real.
+  real to_real(real fallback = 0) const noexcept {
+    if (auto* val = std::get_if<real>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the string value or returns an empty string if this object does
+  /// not contain a string.
+  std::string_view to_string() const noexcept {
+    if (auto* val = std::get_if<std::string_view>(&raw_->value))
+      return *val;
+    return std::string_view{};
+  }
+
+  /// Retrieves the string value or returns @p fallback if this object does
+  /// not contain a string.
+  template <class StringView>
+  std::enable_if_t<std::is_same_v<std::string_view, StringView>, StringView>
+  to_string(StringView fallback) const noexcept {
+    // Note: we use enable_if to block implicit conversions. Otherwise, users
+    // could pass in a `std::string` rvalue and we would return a dangling
+    // reference.
+    if (auto* val = std::get_if<std::string_view>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c address value or returns @p fallback if this object does
+  /// not contain a @c address.
+  address to_address(address fallback = {}) const noexcept {
+    if (auto* val = std::get_if<address>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c subnet value or returns @p fallback if this object does
+  /// not contain a @c subnet.
+  subnet to_subnet(subnet fallback = {}) const noexcept {
+    if (auto* val = std::get_if<subnet>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c port value or returns @p fallback if this object does
+  /// not contain a @c port.
+  port to_port(port fallback = {}) const noexcept {
+    if (auto* val = std::get_if<port>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c timestamp value or returns @p fallback if this object
+  /// does not contain a @c timestamp.
+  timestamp to_timestamp(timestamp fallback = {}) const noexcept {
+    if (auto* val = std::get_if<timestamp>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c timespan value or returns @p fallback if this object does
+  /// not contain a @c timespan.
+  timespan to_timespan(timespan fallback = {}) const noexcept {
+    if (auto* val = std::get_if<timespan>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the enum_value value or returns @p fallback if this object does
+  /// not contain a enum_value.
+  enum_value_view to_enum_value(enum_value_view fallback = {}) const noexcept {
+    if (auto* val = std::get_if<enum_value_view>(&raw_->value))
+      return *val;
+    return fallback;
+  }
+
+  /// Returns the contained values as a @ref variant_set or an empty set if this
+  /// object does not contain a set.
+  variant_set to_set() const noexcept;
+
+  /// Returns the contained values as a @ref variant_table or an empty table if
+  /// this object does not contain a table.
+  variant_table to_table() const noexcept;
+
+  /// Returns the contained values as a @ref variant_list or an empty list if
+  /// this object does not contain a list.
+  variant_list to_list() const noexcept;
+
+  /// Alias for @ref to_list.
+  variant_list to_vector() const noexcept;
+
+  // -- accessors --------------------------------------------------------------
+
+  /// Grants access to the managed @ref variant_data object.
+  const auto* raw() const noexcept {
+    return raw_;
+  }
+
+  /// Returns a reference to the `std::variant` stored in this object.
+  const auto& stl_value() const noexcept {
+    return raw_->value;
+  }
+
+  /// Returns a shared pointer to the @ref envelope that owns the stored data.
+  auto shared_envelope() const noexcept {
+    return envelope_;
+  }
+
+  // -- operators --------------------------------------------------------------
+
+  /// Returns a pointer to the underlying data.
+  const variant* operator->() const noexcept {
+    // Note: this is only implemented for "drill-down" access from iterators.
+    return this;
+  }
+
+  // -- comparison operators ---------------------------------------------------
+
+  friend bool operator<(const variant& x, const variant& y) noexcept {
+    return x.raw_->value < y.raw_->value;
+  }
+
+  friend bool operator<=(const variant& x, const variant& y) noexcept {
+    return x.raw_->value <= y.raw_->value;
+  }
+
+  friend bool operator>(const variant& x, const variant& y) noexcept {
+    return x.raw_->value > y.raw_->value;
+  }
+
+  friend bool operator>=(const variant& x, const variant& y) noexcept {
+    return x.raw_->value >= y.raw_->value;
+  }
+
+  friend bool operator==(const variant& x, const variant& y) noexcept {
+    return x.raw_->value == y.raw_->value;
+  }
+
+  friend bool operator!=(const variant& x, const variant& y) noexcept {
+    return x.raw_->value != y.raw_->value;
+  }
+
+  friend bool operator==(const data& lhs, const variant& rhs) noexcept {
+    return lhs == *rhs.raw_;
+  }
+
+  friend bool operator==(const variant& lhs, const data& rhs) noexcept {
+    return *lhs.raw_ == rhs;
+  }
+
+private:
+  /// Pointer to the implementation.
+  const variant_data* raw_;
+
+  /// The envelope that holds (owns) the data.
+  envelope_ptr envelope_;
+};
+
+/// Checks whether a data object can be converted to `T`.
+template <class T>
+bool exact_match_or_can_convert_to(const variant& x) {
+  if constexpr (detail::data_tag_oracle<T>::specialized) {
+    return x.get_tag() == detail::data_tag_oracle<T>::value;
+  } else if constexpr (std::is_same_v<any_type, T>) {
+    return true;
+  } else {
+    return can_convert_to<T>(x);
+  }
+}
+
+/// Converts `what` to a string.
+void convert(const variant& what, std::string& out);
+
+/// Prints `what` to `out`.
+std::ostream& operator<<(std::ostream& out, const variant& what);
+
+} // namespace broker

--- a/include/broker/variant_data.hh
+++ b/include/broker/variant_data.hh
@@ -102,12 +102,12 @@ public:
 
 // -- free functions -----------------------------------------------------------
 
-bool operator==(const data& lhs, const variant_data& rhs) noexcept;
+bool operator==(const data& lhs, const variant_data& rhs);
 
-bool operator==(const variant_data& lhs, const data& rhs) noexcept;
+bool operator==(const variant_data& lhs, const data& rhs);
 
-bool operator==(const variant_data& lhs, const variant_data& rhs) noexcept;
+bool operator==(const variant_data& lhs, const variant_data& rhs);
 
-bool operator<(const variant_data& lhs, const variant_data& rhs) noexcept;
+bool operator<(const variant_data& lhs, const variant_data& rhs);
 
 } // namespace broker

--- a/include/broker/variant_data.hh
+++ b/include/broker/variant_data.hh
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "broker/address.hh"
+#include "broker/detail/monotonic_buffer_resource.hh"
+#include "broker/enum_value.hh"
+#include "broker/fwd.hh"
+#include "broker/none.hh"
+#include "broker/port.hh"
+#include "broker/subnet.hh"
+
+#include "broker/detail/type_traits.hh"
+
+#include <list>
+#include <map>
+#include <set>
+
+namespace broker {
+
+/// Holds the data of a @ref variant.
+class variant_data {
+public:
+  // -- member types -----------------------------------------------------------
+
+  /// Evaluates to `true` if `T` one of the primitive value types.
+  template <class T>
+  inline static constexpr bool is_primitive =
+    detail::is_one_of_v<T, none, boolean, count, integer, real,
+                        std::string_view, address, subnet, port, timestamp,
+                        timespan, enum_value_view>;
+
+  using less = std::less<>;
+
+  template <class T>
+  using allocator_t = detail::monotonic_buffer_resource::allocator<T>;
+
+  using list = std::list<variant_data, allocator_t<variant_data>>;
+
+  using list_iterator = list::const_iterator;
+
+  using set = std::set<variant_data, less, allocator_t<variant_data>>;
+
+  using set_iterator = set::const_iterator;
+
+  using key_value_pair = std::pair<const variant_data, variant_data>;
+
+  using table_allocator = allocator_t<key_value_pair>;
+
+  using table = std::map<variant_data, variant_data, less, table_allocator>;
+
+  using table_iterator = table::const_iterator;
+
+  using stl_type =
+    std::variant<none, boolean, count, integer, real, std::string_view, address,
+                 subnet, port, timestamp, timespan, enum_value_view, set*,
+                 table*, list*>;
+
+  // -- static factories -------------------------------------------------------
+
+  /// Singleton for empty data.
+  static const variant_data* nil() noexcept;
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns the type of the contained data.
+  variant_tag get_tag() const noexcept {
+    return static_cast<variant_tag>(value.index());
+  }
+
+  // -- conversion -------------------------------------------------------------
+
+  /// Converts this object to a @ref broker::data object. Performs a deep copy.
+  data to_data() const;
+
+  /// Returns a reference to the `std::variant` stored in this object.
+  const auto& stl_value() const noexcept {
+    return value;
+  }
+
+  // -- deserialization --------------------------------------------------------
+
+  std::pair<bool, const std::byte*>
+  parse_shallow(detail::monotonic_buffer_resource& buf, const std::byte* pos,
+                const std::byte* end);
+
+  std::pair<bool, const std::byte*>
+  parse_shallow(detail::monotonic_buffer_resource& buf, const std::byte* bytes,
+                size_t num_bytes) {
+    return parse_shallow(buf, bytes, bytes + num_bytes);
+  }
+
+  // -- member variables -------------------------------------------------------
+
+  stl_type value;
+};
+
+// -- free functions -----------------------------------------------------------
+
+bool operator==(const data& lhs, const variant_data& rhs) noexcept;
+
+bool operator==(const variant_data& lhs, const data& rhs) noexcept;
+
+bool operator==(const variant_data& lhs, const variant_data& rhs) noexcept;
+
+bool operator<(const variant_data& lhs, const variant_data& rhs) noexcept;
+
+} // namespace broker

--- a/include/broker/variant_data.hh
+++ b/include/broker/variant_data.hh
@@ -28,7 +28,14 @@ public:
                         std::string_view, address, subnet, port, timestamp,
                         timespan, enum_value_view>;
 
-  using less = std::less<>;
+  // Note: GCC-8 has a broken std::less<> implementation. Remove this workaround
+  //       once we drop support for GCC-8.
+  struct less {
+    template <class T, class U>
+    bool operator()(const T& x, const U& y) const {
+      return x < y;
+    }
+  };
 
   template <class T>
   using allocator_t = detail::monotonic_buffer_resource::allocator<T>;

--- a/include/broker/variant_list.hh
+++ b/include/broker/variant_list.hh
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "broker/detail/type_traits.hh"
+#include "broker/envelope.hh"
+#include "broker/variant.hh"
+#include "broker/variant_data.hh"
+
+namespace broker {
+
+/// A list of @ref variant values.
+class variant_list {
+public:
+  // -- friend types -----------------------------------------------------------
+
+  friend class variant;
+
+  // -- member types -----------------------------------------------------------
+
+  class iterator {
+  public:
+    friend class variant_list;
+
+    iterator() noexcept = default;
+
+    iterator(const iterator&) noexcept = default;
+
+    iterator& operator=(const iterator&) noexcept = default;
+
+    iterator& operator++() noexcept {
+      ++pos_;
+      return *this;
+    }
+
+    iterator operator++(int) noexcept {
+      auto tmp = *this;
+      ++pos_;
+      return tmp;
+    }
+
+    variant value() const noexcept {
+      return variant{std::addressof(*pos_), shared_envelope()};
+    }
+
+    variant operator*() const noexcept {
+      return value();
+    }
+
+    variant operator->() const noexcept {
+      return value();
+    }
+
+    friend bool operator==(const iterator& lhs, const iterator& rhs) noexcept {
+      return lhs.pos_ == rhs.pos_;
+    }
+
+    friend bool operator!=(const iterator& lhs, const iterator& rhs) noexcept {
+      return lhs.pos_ != rhs.pos_;
+    }
+
+  private:
+    using native_iterator = variant_data::list_iterator;
+
+    envelope_ptr shared_envelope() const {
+      if (envelope_)
+        return envelope_->shared_from_this();
+      return nullptr;
+    }
+
+    iterator(native_iterator pos, const envelope* envelope) noexcept
+      : pos_(pos), envelope_(envelope) {
+      // nop
+    }
+
+    native_iterator pos_;
+    const envelope* envelope_;
+  };
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  variant_list() noexcept = default;
+
+  variant_list(const variant_list&) noexcept = default;
+
+  bool empty() const noexcept {
+    return values_ ? values_->empty() : true;
+  }
+
+  size_t size() const noexcept {
+    return values_ ? values_->size() : 0u;
+  }
+
+  iterator begin() const noexcept {
+    return iterator{values_ ? values_->begin() : iterator::native_iterator{},
+                    envelope_.get()};
+  }
+
+  iterator end() const noexcept {
+    return iterator{values_ ? values_->end() : iterator::native_iterator{},
+                    envelope_.get()};
+  }
+
+  // -- element access ---------------------------------------------------------
+
+  // TODO: this is only implemented for compatibility with broker::vector API
+  //       and to have existing algorithms work with variant. Should be
+  //       removed eventually, because it is very inefficient.
+  variant operator[](size_t index) const noexcept {
+    auto i = values_->begin();
+    std::advance(i, index);
+    return variant{std::addressof(*i), envelope_};
+  }
+
+  variant front() const noexcept {
+    return variant{std::addressof(values_->front()), envelope_};
+  }
+
+  variant back() const noexcept {
+    return variant{std::addressof(values_->back()), envelope_};
+  }
+
+  /// Returns the first `N` elements of the list as an array. If the list has
+  /// less than `N` elements, the resulting array will be filled with
+  /// default-constructed variants, i.e., `nil` values.
+  template <size_t N>
+  std::array<variant, N> take() const noexcept {
+    std::array<variant, N> result;
+    auto i = values_->begin();
+    auto e = values_->end();
+    auto j = result.begin();
+    for (size_t n = 0; n < N; ++n) {
+      if (i == e)
+        break;
+      *j++ = variant{std::addressof(*i++), envelope_};
+    }
+    return result;
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  /// Returns a raw pointer to the managed object.
+  const auto* raw() const noexcept {
+    return values_;
+  }
+
+private:
+  variant_list(const variant_data::list* values, envelope_ptr envelope) noexcept
+    : values_(values), envelope_(std::move(envelope)) {
+    // nop
+  }
+
+  /// The list of values.
+  const variant_data::list* values_ = nullptr;
+
+  /// The envelope that holds the data.
+  envelope_ptr envelope_;
+};
+
+/// End of recursion for `contains`.
+inline bool contains_impl(variant_list::iterator, detail::parameter_pack<>) {
+  return true;
+}
+
+/// Recursively checks whether the types in `Ts` match the types in `pos`.
+template <class T, class... Ts>
+bool contains_impl(variant_list::iterator pos,
+                   detail::parameter_pack<T, Ts...>) {
+  if (!exact_match_or_can_convert_to<T>(*pos++))
+    return false;
+  return contains_impl(pos, detail::parameter_pack<Ts...>{});
+}
+
+/// Checks whether `xs` contains values of types `Ts...`. Performs "fuzzy"
+/// matching by calling `can_convert_to<T>` for any `T` that is not part of the
+/// variant.
+template <class... Ts>
+bool contains(const variant_list& xs) {
+  if (xs.size() != sizeof...(Ts))
+    return false;
+  return contains_impl(xs.begin(), detail::parameter_pack<Ts...>{});
+}
+
+/// Converts `what` to a string.
+void convert(const variant_list& what, std::string& out);
+
+/// Prints `what` to `out`.
+std::ostream& operator<<(std::ostream& out, const variant_list& what);
+
+} // namespace broker

--- a/include/broker/variant_set.hh
+++ b/include/broker/variant_set.hh
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "broker/detail/promote.hh"
+#include "broker/envelope.hh"
+#include "broker/variant.hh"
+#include "broker/variant_data.hh"
+
+namespace broker {
+
+/// A view into a set of data objects.
+class variant_set {
+public:
+  // -- friend types -----------------------------------------------------------
+
+  friend class variant;
+
+  // -- member types -----------------------------------------------------------
+
+  class iterator {
+  public:
+    friend class variant_set;
+
+    iterator() noexcept = default;
+
+    iterator(const iterator&) noexcept = default;
+
+    iterator& operator=(const iterator&) noexcept = default;
+
+    iterator& operator++() noexcept {
+      ++pos_;
+      return *this;
+    }
+
+    iterator operator++(int) noexcept {
+      auto tmp = *this;
+      ++pos_;
+      return tmp;
+    }
+
+    variant value() const noexcept {
+      return variant{std::addressof(*pos_), shared_envelope()};
+    }
+
+    variant operator*() const noexcept {
+      return value();
+    }
+
+    variant operator->() const noexcept {
+      return value();
+    }
+
+    friend bool operator==(const iterator& lhs, const iterator& rhs) noexcept {
+      return lhs.pos_ == rhs.pos_;
+    }
+
+    friend bool operator!=(const iterator& lhs, const iterator& rhs) noexcept {
+      return lhs.pos_ != rhs.pos_;
+    }
+
+  private:
+    using native_iterator = variant_data::set_iterator;
+
+    envelope_ptr shared_envelope() const {
+      if (envelope_)
+        return envelope_->shared_from_this();
+      return nullptr;
+    }
+
+    iterator(native_iterator pos, const envelope* envelope) noexcept
+      : pos_(pos), envelope_(envelope) {
+      // nop
+    }
+
+    native_iterator pos_;
+    const envelope* envelope_;
+  };
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  variant_set() noexcept = default;
+
+  variant_set(const variant_set&) noexcept = default;
+
+  variant_set(const variant_data::set* values, envelope_ptr envelope_) noexcept
+    : values_(values), envelope_(std::move(envelope_)) {
+    // nop
+  }
+
+  bool empty() const noexcept {
+    return values_ ? values_->empty() : true;
+  }
+
+  size_t size() const noexcept {
+    return values_ ? values_->size() : 0u;
+  }
+
+  iterator begin() const noexcept {
+    return iterator{values_ ? values_->begin() : iterator::native_iterator{},
+                    envelope_.get()};
+  }
+
+  iterator end() const noexcept {
+    return iterator{values_ ? values_->end() : iterator::native_iterator{},
+                    envelope_.get()};
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  /// Grants access to the managed object.
+  const auto* raw() const noexcept {
+    return values_;
+  }
+
+  /// Returns a shared pointer to the @ref envelope that owns the stored data.
+  auto shared_envelope() const noexcept {
+    return envelope_;
+  }
+
+  /// Checks whether this set contains `what`.
+  template <class T>
+  bool contains(T&& what) const noexcept {
+    auto&& pval = detail::promote<T>(what);
+    using val_t = std::decay_t<decltype(pval)>;
+    static_assert(variant_data::is_primitive<val_t>,
+                  "value must be a primitive variant_data type");
+    variant_data tmp{what};
+    return values_->find(tmp) != values_->end();
+  }
+
+private:
+  /// The list of values.
+  const variant_data::set* values_ = nullptr;
+
+  /// The envelope that holds the data.
+  envelope_ptr envelope_;
+};
+
+/// Converts `what` to a string.
+void convert(const variant_set& what, std::string& out);
+
+/// Prints `what` to `out`.
+std::ostream& operator<<(std::ostream& out, const variant_set& what);
+
+} // namespace broker

--- a/include/broker/variant_table.hh
+++ b/include/broker/variant_table.hh
@@ -1,0 +1,176 @@
+#pragma once
+
+#include "broker/variant.hh"
+#include "broker/variant_data.hh"
+
+namespace broker {
+
+/// A view into a map of data objects.
+class variant_table {
+public:
+  // -- friend types -----------------------------------------------------------
+
+  friend class variant;
+
+  // -- member types -----------------------------------------------------------
+
+  struct key_value_pair {
+    variant first;
+    variant second;
+
+    /// Returns a pointer to the underlying data.
+    const key_value_pair* operator->() const noexcept {
+      // Note: this is only implemented for "drill-down" access from iterators.
+      return this;
+    }
+  };
+
+  class iterator {
+  public:
+    friend class variant_table;
+
+    iterator() noexcept = default;
+
+    iterator(const iterator&) noexcept = default;
+
+    iterator& operator=(const iterator&) noexcept = default;
+
+    iterator& operator++() noexcept {
+      ++pos_;
+      return *this;
+    }
+
+    iterator operator++(int) noexcept {
+      auto tmp = *this;
+      ++pos_;
+      return tmp;
+    }
+
+    variant key() const noexcept {
+      return variant{std::addressof(pos_->first), shared_envelope()};
+    }
+
+    variant value() const noexcept {
+      return variant{std::addressof(pos_->second), shared_envelope()};
+    }
+
+    key_value_pair operator*() const noexcept {
+      return {key(), value()};
+    }
+
+    key_value_pair operator->() const noexcept {
+      return {key(), value()};
+    }
+
+    friend bool operator==(const iterator& lhs, const iterator& rhs) noexcept {
+      return lhs.pos_ == rhs.pos_;
+    }
+
+    friend bool operator!=(const iterator& lhs, const iterator& rhs) noexcept {
+      return lhs.pos_ != rhs.pos_;
+    }
+
+  private:
+    using native_iterator = variant_data::table_iterator;
+
+    envelope_ptr shared_envelope() const {
+      if (envelope_)
+        return envelope_->shared_from_this();
+      return nullptr;
+    }
+
+    iterator(native_iterator pos, const envelope* envelope) noexcept
+      : pos_(pos), envelope_(envelope) {
+      // nop
+    }
+
+    native_iterator pos_;
+    const envelope* envelope_;
+  };
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  variant_table() noexcept = default;
+
+  variant_table(variant_table&&) noexcept = default;
+
+  variant_table(const variant_table&) noexcept = default;
+
+  variant_table(const variant_data::table* values,
+                envelope_ptr envelope_) noexcept
+    : values_(values), envelope_(std::move(envelope_)) {
+    // nop
+  }
+
+  variant_table& operator=(variant_table&&) noexcept = default;
+
+  variant_table& operator=(const variant_table&) noexcept = default;
+
+  // -- properties -------------------------------------------------------------
+
+  bool empty() const noexcept {
+    return values_ ? values_->empty() : true;
+  }
+
+  size_t size() const noexcept {
+    return values_ ? values_->size() : 0u;
+  }
+
+  /// @private
+  const auto* raw() const noexcept {
+    return values_;
+  }
+
+  // -- iterator access --------------------------------------------------------
+
+  iterator begin() const noexcept {
+    return iterator{values_ ? values_->begin() : iterator::native_iterator{},
+                    envelope_.get()};
+  }
+
+  iterator end() const noexcept {
+    return iterator{values_ ? values_->end() : iterator::native_iterator{},
+                    envelope_.get()};
+  }
+
+  // -- key lookup -------------------------------------------------------------
+
+  iterator find(const variant& key) const noexcept {
+    return iterator{values_->find(*key->raw()), envelope_.get()};
+  }
+
+  variant operator[](const variant& key) const noexcept {
+    if (auto i = values_->find(*key.raw()); i != values_->end())
+      return variant{std::addressof(i->second), envelope_};
+    return variant{};
+  }
+
+  variant operator[](std::string_view key) const noexcept {
+    return do_lookup(key);
+  }
+
+private:
+  template <class T>
+  variant do_lookup(T key) const noexcept {
+    if (values_ == nullptr)
+      return variant{};
+    auto key_view = variant_data{key};
+    if (auto i = values_->find(key_view); i != values_->end())
+      return variant{std::addressof(i->second), envelope_};
+    return variant{};
+  }
+
+  /// The list of values.
+  const variant_data::table* values_ = nullptr;
+
+  /// The envelope that holds the data.
+  envelope_ptr envelope_;
+};
+
+/// Converts `what` to a string.
+void convert(const variant_table& what, std::string& out);
+
+/// Prints `what` to `out`.
+std::ostream& operator<<(std::ostream& out, const variant_table& what);
+
+} // namespace broker

--- a/include/broker/variant_tag.hh
+++ b/include/broker/variant_tag.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+
+namespace broker{
+
+/// A tag that discriminates the type of a @ref data or @ref variant object.
+enum class variant_tag : uint8_t {
+  // Warning: the values *must* have the same order as `data_variant`, because
+  // the integer value for this tag must be equal to `get_data().index()`.
+  none,
+  boolean,
+  count,
+  integer,
+  real,
+  string,
+  address,
+  subnet,
+  port,
+  timestamp,
+  timespan,
+  enum_value,
+  set,
+  table,
+  list,
+  vector = list, // alias for backward compatibility
+};
+
+} // namespace broker

--- a/include/broker/variant_tag.hh
+++ b/include/broker/variant_tag.hh
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace broker{
+namespace broker {
 
 /// A tag that discriminates the type of a @ref data or @ref variant object.
 enum class variant_tag : uint8_t {

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -1,0 +1,111 @@
+#include "broker/builder.hh"
+
+#include "broker/data.hh"
+#include "broker/envelope.hh"
+#include "broker/error.hh"
+#include "broker/topic.hh"
+
+namespace broker {
+
+namespace {
+
+class builder_envelope : public envelope {
+public:
+  builder_envelope(std::vector<std::byte> bytes, size_t offset)
+    : bytes_(std::move(bytes)), offset_(offset) {
+    // nop
+  }
+
+  variant value() const noexcept override {
+    return {root_, shared_from_this()};
+  }
+
+  std::string_view topic() const noexcept override {
+    return {};
+  }
+
+  bool is_root(const variant_data* val) const noexcept override {
+    return val == root_;
+  }
+
+  std::pair<const std::byte*, size_t> raw_bytes() const noexcept override {
+    return {bytes_.data() + offset_, bytes_.size() - offset_};
+  }
+
+  error parse() {
+    error result;
+    root_ = do_parse(buf_, result);
+    return result;
+  }
+
+private:
+  variant_data* root_ = nullptr;
+  std::vector<std::byte> bytes_;
+  detail::monotonic_buffer_resource buf_;
+  size_t offset_;
+};
+
+envelope_ptr make_builder_envelope(std::vector<std::byte> bytes,
+                                   size_t offset) {
+  auto res = std::make_shared<builder_envelope>(std::move(bytes), offset);
+#ifndef NDEBUG
+  if (auto err = res->parse()) {
+    auto errstr = to_string(err);
+    fprintf(stderr, "make_builder_envelope received malformed data: %s\n",
+            errstr.c_str());
+    abort();
+  }
+#else
+  std::ignore = res->parse();
+#endif
+  return res;
+}
+
+} // namespace
+
+set_builder::set_builder() {
+  format::bin::v1::encode_sequence_begin(bytes_);
+}
+
+std::pair<const std::byte*, size_t> set_builder::bytes() {
+  auto offset = format::bin::v1::encode_sequence_end(tag(), size_, bytes_);
+  return {bytes_.data() + offset, bytes_.size() - offset};
+}
+
+variant set_builder::build() && {
+  auto offset = format::bin::v1::encode_sequence_end(tag(), size_, bytes_);
+  auto enevlope = make_builder_envelope(std::move(bytes_), offset);
+  return enevlope->value();
+}
+
+table_builder::table_builder() {
+  format::bin::v1::encode_sequence_begin(bytes_);
+}
+
+std::pair<const std::byte*, size_t> table_builder::bytes() {
+  auto offset = format::bin::v1::encode_sequence_end(tag(), size_, bytes_);
+  return {bytes_.data() + offset, bytes_.size() - offset};
+}
+
+variant table_builder::build() && {
+  auto offset = format::bin::v1::encode_sequence_end(tag(), size_, bytes_);
+  auto enevlope = make_builder_envelope(std::move(bytes_), offset);
+  return enevlope->value();
+}
+
+list_builder::list_builder() {
+  format::bin::v1::encode_sequence_begin(bytes_);
+}
+
+std::pair<const std::byte*, size_t> list_builder::bytes() {
+  auto offset = format::bin::v1::encode_sequence_end(tag(), size_, bytes_);
+  return {bytes_.data() + offset, bytes_.size() - offset};
+}
+
+variant list_builder::build() && {
+  auto offset = format::bin::v1::encode_sequence_end(tag(), size_, bytes_);
+  auto enevlope = make_builder_envelope(std::move(bytes_), offset);
+  return enevlope->value();
+}
+
+} // namespace broker

--- a/src/envelope.cc
+++ b/src/envelope.cc
@@ -1,0 +1,167 @@
+#include "broker/envelope.hh"
+
+#include "broker/detail/monotonic_buffer_resource.hh"
+#include "broker/error.hh"
+#include "broker/internal/type_id.hh"
+#include "broker/topic.hh"
+#include "broker/variant.hh"
+#include "broker/variant_data.hh"
+
+#include <caf/binary_serializer.hpp>
+#include <caf/byte_buffer.hpp>
+#include <caf/detail/ieee_754.hpp>
+#include <caf/detail/network_order.hpp>
+
+namespace broker {
+
+namespace {
+
+template <class T>
+using mbr_allocator = broker::detail::monotonic_buffer_resource::allocator<T>;
+
+using const_byte_pointer = const std::byte*;
+
+} // namespace
+
+envelope::~envelope() {
+  // nop
+}
+
+variant_data* envelope::do_parse(detail::monotonic_buffer_resource& buf,
+                                 error& err) {
+  auto [bytes, size] = raw_bytes();
+  if (bytes == nullptr || size == 0) {
+    err = make_error(ec::deserialization_failed, "cannot parse null data");
+    return nullptr;
+  }
+  // Create the root object.
+  variant_data* root;
+  {
+    mbr_allocator<variant_data> allocator{&buf};
+    root = new (allocator.allocate(1)) variant_data();
+  }
+  // Parse the data. This is a shallow parse, which is why we need to copy the
+  // bytes into the buffer resource first.
+  auto end = bytes + size;
+  auto [ok, pos] = root->parse_shallow(buf, bytes, end);
+  if (ok && pos == end)
+    return root;
+  err = make_error(ec::deserialization_failed, "failed to parse data");
+  return nullptr;
+}
+
+namespace {
+
+/// The default implementation for @ref envelope that wraps a byte buffer
+/// and a topic..
+class default_envelope : public envelope {
+public:
+  default_envelope(std::string topic_str, caf::byte_buffer bytes)
+    : topic_(std::move(topic_str)), bytes_(std::move(bytes)) {
+    // nop
+  }
+
+  variant value() const noexcept override {
+    return {root_, shared_from_this()};
+  }
+
+  std::string_view topic() const noexcept override {
+    return topic_;
+  }
+
+  bool is_root(const variant_data* val) const noexcept override {
+    return val == root_;
+  }
+
+  std::pair<const std::byte*, size_t> raw_bytes() const noexcept override {
+    return {reinterpret_cast<const std::byte*>(bytes_.data()), bytes_.size()};
+  }
+
+  error parse() {
+    error result;
+    root_ = do_parse(buf_, result);
+    return result;
+  }
+
+private:
+  variant_data* root_ = nullptr;
+  std::string topic_;
+  caf::byte_buffer bytes_;
+  detail::monotonic_buffer_resource buf_;
+};
+
+} // namespace
+
+envelope_ptr envelope::make(broker::topic t, const data& d) {
+  caf::byte_buffer buf;
+  caf::binary_serializer sink{nullptr, buf};
+#ifndef NDEBUG
+  if (auto ok = sink.apply(d); !ok) {
+    auto errstr = caf::to_string(sink.get_error());
+    fprintf(stderr,
+            "broker::envelope::make failed to serialize data: %s\n",
+            errstr.c_str());
+    abort();
+  }
+#else
+  std::ignore = sink.apply(d);
+#endif
+  auto res = std::make_shared<default_envelope>(std::move(t).move_string(),
+                                                std::move(buf));
+#ifndef NDEBUG
+  if (auto err = res->parse()) {
+    auto errstr = to_string(err);
+    fprintf(stderr,
+            "broker::envelope::make generated malformed data: %s\n",
+            errstr.c_str());
+    abort();
+  }
+#else
+  std::ignore = res->parse();
+#endif
+  return res;
+}
+
+namespace {
+
+/// Wraps a data view and a topic.
+class envelope_wrapper : public envelope {
+public:
+  envelope_wrapper(std::string topic_str, variant val)
+    : topic_(std::move(topic_str)), val_(std::move(val)) {
+    // nop
+  }
+
+  variant value() const noexcept override {
+    return val_;
+  }
+
+  std::string_view  topic() const noexcept override {
+    return topic_;
+  }
+
+  bool is_root(const variant_data* val) const noexcept override {
+    return val == val_.raw() && val_.is_root();
+  }
+
+
+  std::pair<const std::byte*, size_t> raw_bytes() const noexcept override {
+    if (val_.is_root())
+      val_.shared_envelope()->raw_bytes();
+    return {nullptr, 0};
+  }
+
+private:
+  std::string topic_;
+  variant val_;
+};
+
+} // namespace
+
+envelope_ptr envelope::make(broker::topic t, variant d) {
+  return std::make_shared<envelope_wrapper>(std::move(t).move_string(),
+                                            std::move(d));
+}
+
+
+} // namespace broker

--- a/src/envelope.cc
+++ b/src/envelope.cc
@@ -98,8 +98,7 @@ envelope_ptr envelope::make(broker::topic t, const data& d) {
 #ifndef NDEBUG
   if (auto ok = sink.apply(d); !ok) {
     auto errstr = caf::to_string(sink.get_error());
-    fprintf(stderr,
-            "broker::envelope::make failed to serialize data: %s\n",
+    fprintf(stderr, "broker::envelope::make failed to serialize data: %s\n",
             errstr.c_str());
     abort();
   }
@@ -111,8 +110,7 @@ envelope_ptr envelope::make(broker::topic t, const data& d) {
 #ifndef NDEBUG
   if (auto err = res->parse()) {
     auto errstr = to_string(err);
-    fprintf(stderr,
-            "broker::envelope::make generated malformed data: %s\n",
+    fprintf(stderr, "broker::envelope::make generated malformed data: %s\n",
             errstr.c_str());
     abort();
   }
@@ -136,14 +134,13 @@ public:
     return val_;
   }
 
-  std::string_view  topic() const noexcept override {
+  std::string_view topic() const noexcept override {
     return topic_;
   }
 
   bool is_root(const variant_data* val) const noexcept override {
     return val == val_.raw() && val_.is_root();
   }
-
 
   std::pair<const std::byte*, size_t> raw_bytes() const noexcept override {
     if (val_.is_root())
@@ -162,6 +159,5 @@ envelope_ptr envelope::make(broker::topic t, variant d) {
   return std::make_shared<envelope_wrapper>(std::move(t).move_string(),
                                             std::move(d));
 }
-
 
 } // namespace broker

--- a/src/format/bin.cc
+++ b/src/format/bin.cc
@@ -1,0 +1,24 @@
+#include "broker/format/bin.hh"
+
+#include <caf/detail/ieee_754.hpp>
+#include <caf/detail/network_order.hpp>
+
+namespace broker::format::bin::v1 {
+
+uint16_t to_network_order(uint16_t value) {
+  return caf::detail::to_network_order(value);
+}
+
+uint64_t to_network_order(uint64_t value) {
+  return caf::detail::to_network_order(value);
+}
+
+uint64_t real_to_network_representation(real value) {
+  return caf::detail::pack754(value);
+}
+
+real real_from_network_representation(uint64_t value) {
+  return caf::detail::unpack754(value);
+}
+
+} // namespace broker::format::bin::v1

--- a/src/subnet.cc
+++ b/src/subnet.cc
@@ -11,9 +11,10 @@
 
 namespace broker {
 
-subnet::subnet() : len_(0) {}
+subnet::subnet() noexcept : len_(0) {}
 
-subnet::subnet(const address& addr, uint8_t length) : net_(addr), len_(length) {
+subnet::subnet(const address& addr, uint8_t length) noexcept
+  : net_(addr), len_(length) {
   if (init())
     return;
   net_ = {};

--- a/src/variant.cc
+++ b/src/variant.cc
@@ -75,30 +75,8 @@ void convert(const variant& value, std::string& out) {
   format::txt::v1::encode(value.raw(), std::back_inserter(out));
 }
 
-void convert(const variant_set& value, std::string& out) {
-  format::txt::v1::encode(value.raw(), std::back_inserter(out));
-}
-
-void convert(const variant_table& value, std::string& out) {
-  format::txt::v1::encode(value.raw(), std::back_inserter(out));
-}
-
-void convert(const variant_list& value, std::string& out) {
-  format::txt::v1::encode(value.raw(), std::back_inserter(out));
-}
-
 std::ostream& operator<<(std::ostream& out, const variant& what) {
   format::txt::v1::encode(what, std::ostream_iterator<char>(out));
-  return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const variant_set& what) {
-  format::txt::v1::encode(what.raw(), std::ostream_iterator<char>(out));
-  return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const variant_table& what) {
-  format::txt::v1::encode(what.raw(), std::ostream_iterator<char>(out));
   return out;
 }
 

--- a/src/variant.cc
+++ b/src/variant.cc
@@ -1,0 +1,105 @@
+#include "broker/variant.hh"
+
+#include "broker/detail/assert.hh"
+#include "broker/detail/type_traits.hh"
+#include "broker/error.hh"
+#include "broker/format/txt.hh"
+#include "broker/variant_list.hh"
+#include "broker/variant_set.hh"
+#include "broker/variant_table.hh"
+
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+
+namespace broker::detail {
+
+namespace {
+
+template <class T>
+using mbr_allocator = broker::detail::monotonic_buffer_resource::allocator<T>;
+
+using const_byte_pointer = const std::byte*;
+
+} // namespace
+
+namespace {
+
+const variant_data::set empty_set_instance;
+
+const variant_data::table empty_table_instance;
+
+const variant_data::list empty_vector_instance;
+
+} // namespace
+
+} // namespace broker::detail
+
+namespace broker {
+
+bool variant::is_root() const noexcept {
+  return envelope_ && envelope_->is_root(raw_);
+}
+
+data variant::to_data() const {
+  return raw_->to_data();
+}
+
+variant_set variant::to_set() const noexcept {
+  using detail_t = variant_data::set*;
+  if (auto ptr = std::get_if<detail_t>(&stl_value()))
+    return variant_set{*ptr, envelope_};
+  return variant_set{&detail::empty_set_instance, nullptr};
+}
+
+variant_table variant::to_table() const noexcept {
+  using detail_t = variant_data::table*;
+  if (auto ptr = std::get_if<detail_t>(&stl_value()))
+    return variant_table{*ptr, envelope_};
+  return variant_table{&detail::empty_table_instance, nullptr};
+}
+
+variant_list variant::to_list() const noexcept {
+  using detail_t = variant_data::list*;
+  if (auto ptr = std::get_if<detail_t>(&stl_value()))
+    return variant_list{*ptr, envelope_};
+  return variant_list{&detail::empty_vector_instance, nullptr};
+}
+
+variant_list variant::to_vector() const noexcept {
+  return to_list();
+}
+
+void convert(const variant& value, std::string& out) {
+  format::txt::v1::encode(value.raw(), std::back_inserter(out));
+}
+
+void convert(const variant_set& value, std::string& out) {
+  format::txt::v1::encode(value.raw(), std::back_inserter(out));
+}
+
+void convert(const variant_table& value, std::string& out) {
+  format::txt::v1::encode(value.raw(), std::back_inserter(out));
+}
+
+void convert(const variant_list& value, std::string& out) {
+  format::txt::v1::encode(value.raw(), std::back_inserter(out));
+}
+
+std::ostream& operator<<(std::ostream& out, const variant& what) {
+  format::txt::v1::encode(what, std::ostream_iterator<char>(out));
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const variant_set& what) {
+  format::txt::v1::encode(what.raw(), std::ostream_iterator<char>(out));
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const variant_table& what) {
+  format::txt::v1::encode(what.raw(), std::ostream_iterator<char>(out));
+  return out;
+}
+
+} // namespace broker

--- a/src/variant_data.cc
+++ b/src/variant_data.cc
@@ -1,0 +1,361 @@
+#include "broker/variant_data.hh"
+
+#include "broker/data.hh"
+#include "broker/detail/type_traits.hh"
+
+#include <caf/detail/ieee_754.hpp>
+#include <caf/detail/network_order.hpp>
+
+namespace broker {
+
+namespace {
+
+/// Global instance of `variant_data` that represents a `nil` value.
+const variant_data nil_instance;
+
+template <variant_tag Tag, class Pred, class T1, class T2>
+auto stl_visit(Pred& pred, const T1& lhs, const T2& rhs) {
+  static constexpr auto index = static_cast<size_t>(Tag);
+  return pred(std::get<index>(lhs.stl_value()),
+              std::get<index>(rhs.stl_value()));
+}
+
+/// Visits two `data` and/or `variant` objects by calling `pred(lhs, rhs)` if
+/// the types of `lhs` and `rhs` are the same. Otherwise, returns
+/// `pred(lhs.type(), rhs.type())`.
+template <class Predicate, class T1, class T2>
+auto visit_if_same_type(Predicate&& pred, const T1& lhs, const T2& rhs) {
+  // Note: we could do std::visit here, but that would require the Predicate
+  //       to support all possible combinations of types. Instead, we only
+  //       require the Predicate to support all combinations of types that
+  //       can actually occur.
+  auto lhs_type = lhs.get_tag();
+  auto rhs_type = rhs.get_tag();
+  if (lhs_type != rhs_type)
+    return pred(lhs_type, rhs_type);
+  using type = variant_tag;
+  switch (lhs_type) {
+    default: // type::none:
+      return stl_visit<type::none>(pred, lhs, rhs);
+    case type::boolean:
+      return stl_visit<type::boolean>(pred, lhs, rhs);
+    case type::integer:
+      return stl_visit<type::integer>(pred, lhs, rhs);
+    case type::count:
+      return stl_visit<type::count>(pred, lhs, rhs);
+    case type::real:
+      return stl_visit<type::real>(pred, lhs, rhs);
+    case type::string:
+      return stl_visit<type::string>(pred, lhs, rhs);
+    case type::address:
+      return stl_visit<type::address>(pred, lhs, rhs);
+    case type::subnet:
+      return stl_visit<type::subnet>(pred, lhs, rhs);
+    case type::port:
+      return stl_visit<type::port>(pred, lhs, rhs);
+    case type::timestamp:
+      return stl_visit<type::timestamp>(pred, lhs, rhs);
+    case type::timespan:
+      return stl_visit<type::timespan>(pred, lhs, rhs);
+    case type::enum_value:
+      return stl_visit<type::enum_value>(pred, lhs, rhs);
+    case type::set:
+      return stl_visit<type::set>(pred, lhs, rhs);
+    case type::table:
+      return stl_visit<type::table>(pred, lhs, rhs);
+    case type::vector:
+      return stl_visit<type::vector>(pred, lhs, rhs);
+  }
+}
+
+/// Compares two `data` and/or `variant` objects for equality.
+struct eq_predicate {
+  template <class T1, class T2>
+  bool operator()(const T1& lhs, const T2& rhs) const noexcept {
+    if constexpr (std::is_pointer_v<T1>)
+      return (*this)(*lhs, rhs);
+    else if constexpr (std::is_pointer_v<T2>)
+      return (*this)(lhs, *rhs);
+    else if constexpr (detail::has_begin_v<T1>)
+      return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), *this);
+    else if constexpr (detail::is_pair<T1>)
+      return (*this)(lhs.first, rhs.first) && (*this)(lhs.second, rhs.second);
+    else
+      return lhs == rhs;
+  }
+};
+
+} // namespace
+
+const variant_data* variant_data::nil() noexcept {
+  return &nil_instance;
+}
+
+data variant_data::to_data() const {
+  auto f = [](const auto& val) -> broker::data {
+    using val_type = std::decay_t<decltype(val)>;
+    if constexpr (std::is_same_v<std::string_view, val_type>) {
+      return broker::data{std::string{val}};
+    } else if constexpr (std::is_same_v<enum_value_view, val_type>) {
+      return broker::data{enum_value{std::string{val.name}}};
+    } else if constexpr (std::is_same_v<variant_data::set*, val_type>) {
+      broker::set result;
+      for (const auto& x : *val)
+        result.emplace(x.to_data());
+      return broker::data{std::move(result)};
+    } else if constexpr (std::is_same_v<variant_data::table*, val_type>) {
+      broker::table result;
+      for (const auto& [key, val] : *val)
+        result.emplace(key.to_data(), val.to_data());
+      return broker::data{std::move(result)};
+    } else if constexpr (std::is_same_v<variant_data::list*, val_type>) {
+      broker::vector result;
+      result.reserve(val->size());
+      for (const auto& x : *val)
+        result.emplace_back(x.to_data());
+      return broker::data{std::move(result)};
+    } else {
+      return broker::data{val};
+    }
+  };
+  return std::visit(f, value);
+}
+
+namespace {
+
+template <class T>
+using mbr_allocator = broker::detail::monotonic_buffer_resource::allocator<T>;
+
+using const_byte_pointer = const std::byte*;
+
+/// Reads a 64-bit unsigned integer from a byte sequence.
+uint64_t rd_u64(const_byte_pointer& bytes) {
+  broker::count tmp = 0;
+  memcpy(&tmp, bytes, sizeof(broker::count));
+  bytes += sizeof(broker::count);
+  return caf::detail::from_network_order(tmp);
+}
+
+/// Reads an 8-bit unsigned integer from a byte sequence.
+uint8_t rd_u8(const_byte_pointer& bytes) {
+  auto result = *bytes++;
+  return static_cast<uint8_t>(result);
+}
+
+/// Reads a 16-bit unsigned integer from a byte sequence.
+uint16_t rd_u16(const_byte_pointer& bytes) {
+  uint16_t tmp = 0;
+  memcpy(&tmp, bytes, sizeof(uint16_t));
+  bytes += sizeof(uint16_t);
+  return caf::detail::from_network_order(tmp);
+}
+
+/// Reads a size_t from a byte sequence using varbyte encoding.
+bool rd_varbyte(const_byte_pointer& first, const_byte_pointer last,
+                size_t& result) {
+  // Use varbyte encoding to compress sequence size on the wire.
+  uint32_t x = 0;
+  int n = 0;
+  uint8_t low7 = 0;
+  do {
+    if (first == last)
+      return false;
+    low7 = rd_u8(first);
+    x |= static_cast<uint32_t>((low7 & 0x7F)) << (7 * n);
+    ++n;
+  } while (low7 & 0x80);
+  result = x;
+  return true;
+}
+
+} // namespace
+
+std::pair<bool, const std::byte*>
+variant_data::parse_shallow(detail::monotonic_buffer_resource& buf,
+                            const std::byte* pos, const std::byte* end) {
+  if (pos == end)
+    return {false, end};
+  switch (static_cast<variant_tag>(*pos++)) {
+    case variant_tag::none:
+      value = none{};
+      return {true, pos};
+    case variant_tag::boolean:
+      if (pos == end)
+        return {false, end};
+      value = *pos++ != std::byte{0};
+      return {true, pos};
+    case variant_tag::count:
+      if (end - pos < sizeof(count))
+        return {false, end};
+      value = rd_u64(pos);
+      return {true, pos};
+    case variant_tag::integer:
+      if (end - pos < sizeof(count))
+        return {false, end};
+      value = static_cast<broker::integer>(rd_u64(pos));
+      return {true, pos};
+    case variant_tag::real:
+      if (end - pos < sizeof(real))
+        return {false, end};
+      value = caf::detail::unpack754(rd_u64(pos));
+      return {true, pos};
+    case variant_tag::string: {
+      size_t size = 0;
+      if (!rd_varbyte(pos, end, size))
+        return {false, pos};
+      if (end - pos < static_cast<ptrdiff_t>(size))
+        return {false, pos};
+      auto str = reinterpret_cast<const char*>(pos);
+      pos += size;
+      value = std::string_view{str, size};
+      return {true, pos};
+    }
+    case variant_tag::address: {
+      if (end - pos < address::num_bytes)
+        return {false, end};
+      address tmp;
+      memcpy(tmp.bytes().data(), pos, address::num_bytes);
+      pos += address::num_bytes;
+      value = tmp;
+      return {true, pos};
+    }
+    case variant_tag::subnet: {
+      static constexpr size_t subnet_len = address::num_bytes + 1;
+      if (end - pos < subnet_len)
+        return {false, end};
+      address addr;
+      memcpy(addr.bytes().data(), pos, address::num_bytes);
+      pos += address::num_bytes;
+      auto length = rd_u8(pos);
+      value = subnet{addr, length};
+      return {true, pos};
+    }
+    case variant_tag::port: {
+      if (end - pos < 3)
+        return {false, end};
+      auto num = rd_u16(pos);
+      auto proto = rd_u8(pos);
+      if (proto > 3) // 3 is the highest protocol number we support (ICMP).
+        return {false, end};
+      value = port{num, static_cast<port::protocol>(proto)};
+      return {true, pos};
+    }
+    case variant_tag::timestamp: {
+      if (end - pos < sizeof(timespan))
+        return {false, end};
+      value = timestamp{timespan{rd_u64(pos)}};
+      return {true, pos};
+    }
+    case variant_tag::timespan: {
+      if (end - pos < sizeof(timespan))
+        return {false, end};
+      value = timespan{rd_u64(pos)};
+      return {true, pos};
+    }
+    case variant_tag::enum_value: {
+      size_t size = 0;
+      if (!rd_varbyte(pos, end, size))
+        return {false, pos};
+      if (end - pos < static_cast<ptrdiff_t>(size))
+        return {false, pos};
+      auto str = reinterpret_cast<const char*>(pos);
+      pos += size;
+      value = enum_value_view{std::string_view{str, size}};
+      return {true, pos};
+    }
+    case variant_tag::set: {
+      size_t size = 0;
+      if (!rd_varbyte(pos, end, size))
+        return {false, pos};
+      using set_allocator = mbr_allocator<variant_data>;
+      using set_type = variant_data::set;
+      mbr_allocator<set_type> allocator{&buf};
+      auto res = new (allocator.allocate(1)) set_type(set_allocator{&buf});
+      for (size_t i = 0; i < size; ++i) {
+        auto tmp = variant_data{};
+        auto [ok, next] = tmp.parse_shallow(buf, pos, end);
+        if (!ok)
+          return {false, pos};
+        auto [_, added] = res->emplace(std::move(tmp));
+        if (!added)
+          return {false, pos};
+        pos = next;
+      }
+      value = res;
+      return {true, pos};
+    }
+    case variant_tag::table: {
+      size_t size = 0;
+      if (!rd_varbyte(pos, end, size))
+        return {false, pos};
+      using table_allocator = variant_data::table_allocator;
+      using table_type = variant_data::table;
+      mbr_allocator<table_type> allocator{&buf};
+      auto res = new (allocator.allocate(1)) table_type(table_allocator{&buf});
+      for (size_t i = 0; i < size; ++i) {
+        auto key = variant_data{};
+        if (auto [ok, next] = key.parse_shallow(buf, pos, end); ok)
+          pos = next;
+        else
+          return {false, pos};
+        auto val = variant_data{};
+        if (auto [ok, next] = val.parse_shallow(buf, pos, end); ok)
+          pos = next;
+        else
+          return {false, pos};
+        auto [_, added] = res->emplace(std::move(key), std::move(val));
+        if (!added)
+          return {false, pos};
+      }
+      value = res;
+      return {true, pos};
+    }
+    case variant_tag::list: {
+      size_t size = 0;
+      if (!rd_varbyte(pos, end, size))
+        return {false, pos};
+      using vec_allocator = mbr_allocator<variant_data>;
+      using vec_type = variant_data::list;
+      mbr_allocator<vec_type> allocator{&buf};
+      auto vec = new (allocator.allocate(1)) vec_type(vec_allocator{&buf});
+      for (size_t i = 0; i < size; ++i) {
+        auto [ok, next] = vec->emplace_back().parse_shallow(buf, pos, end);
+        if (!ok)
+          return {false, pos};
+        pos = next;
+      }
+      value = vec;
+      return {true, pos};
+    }
+    default:
+      return {false, pos};
+  }
+}
+
+// -- free functions -----------------------------------------------------------
+
+bool operator==(const data& lhs, const variant_data& rhs) noexcept {
+  return visit_if_same_type(eq_predicate{}, lhs, rhs);
+}
+
+bool operator==(const variant_data& lhs, const data& rhs) noexcept {
+  return visit_if_same_type(eq_predicate{}, lhs, rhs);
+}
+
+bool operator<(const variant_data& lhs,
+               const variant_data& rhs) noexcept {
+  if (lhs.value.index() != rhs.value.index())
+    return lhs.value.index() < rhs.value.index();
+  return std::visit(
+    [&rhs](const auto& x) -> bool {
+      using T = std::decay_t<decltype(x)>;
+      if constexpr (std::is_pointer_v<T>) {
+        return *x < *std::get<T>(rhs.value);
+      } else {
+        return x < std::get<T>(rhs.value);
+      }
+    },
+    lhs.value);
+}
+
+}; // namespace broker

--- a/src/variant_data.cc
+++ b/src/variant_data.cc
@@ -73,7 +73,7 @@ auto visit_if_same_type(Predicate&& pred, const T1& lhs, const T2& rhs) {
 /// Compares two `data` and/or `variant` objects for equality.
 struct eq_predicate {
   template <class T1, class T2>
-  bool operator()(const T1& lhs, const T2& rhs) const noexcept {
+  bool operator()(const T1& lhs, const T2& rhs) const {
     if constexpr (std::is_pointer_v<T1>)
       return (*this)(*lhs, rhs);
     else if constexpr (std::is_pointer_v<T2>)
@@ -342,16 +342,19 @@ variant_data::parse_shallow(detail::monotonic_buffer_resource& buf,
 
 // -- free functions -----------------------------------------------------------
 
-bool operator==(const data& lhs, const variant_data& rhs) noexcept {
+bool operator==(const data& lhs, const variant_data& rhs) {
   return visit_if_same_type(eq_predicate{}, lhs, rhs);
 }
 
-bool operator==(const variant_data& lhs, const data& rhs) noexcept {
+bool operator==(const variant_data& lhs, const data& rhs) {
   return visit_if_same_type(eq_predicate{}, lhs, rhs);
 }
 
-bool operator<(const variant_data& lhs,
-               const variant_data& rhs) noexcept {
+bool operator==(const variant_data& lhs, const variant_data& rhs) {
+  return visit_if_same_type(eq_predicate{}, lhs, rhs);
+}
+
+bool operator<(const variant_data& lhs, const variant_data& rhs) {
   if (lhs.value.index() != rhs.value.index())
     return lhs.value.index() < rhs.value.index();
   return std::visit(

--- a/src/variant_list.cc
+++ b/src/variant_list.cc
@@ -2,6 +2,8 @@
 
 #include "broker/format/txt.hh"
 
+#include <iterator>
+
 namespace broker {
 
 std::ostream& operator<<(std::ostream& out, const variant_list& what) {

--- a/src/variant_list.cc
+++ b/src/variant_list.cc
@@ -6,6 +6,10 @@
 
 namespace broker {
 
+void convert(const variant_list& value, std::string& out) {
+  format::txt::v1::encode(value.raw(), std::back_inserter(out));
+}
+
 std::ostream& operator<<(std::ostream& out, const variant_list& what) {
   format::txt::v1::encode(what.raw(), std::ostream_iterator<char>(out));
   return out;

--- a/src/variant_list.cc
+++ b/src/variant_list.cc
@@ -1,0 +1,12 @@
+#include "broker/variant_list.hh"
+
+#include "broker/format/txt.hh"
+
+namespace broker {
+
+std::ostream& operator<<(std::ostream& out, const variant_list& what) {
+  format::txt::v1::encode(what.raw(), std::ostream_iterator<char>(out));
+  return out;
+}
+
+} // namespace broker

--- a/src/variant_set.cc
+++ b/src/variant_set.cc
@@ -1,0 +1,18 @@
+#include "broker/variant_set.hh"
+
+#include "broker/format/txt.hh"
+
+#include <iterator>
+
+namespace broker {
+
+void convert(const variant_set& value, std::string& out) {
+  format::txt::v1::encode(value.raw(), std::back_inserter(out));
+}
+
+std::ostream& operator<<(std::ostream& out, const variant_set& what) {
+  format::txt::v1::encode(what.raw(), std::ostream_iterator<char>(out));
+  return out;
+}
+
+} // namespace broker

--- a/src/variant_table.cc
+++ b/src/variant_table.cc
@@ -1,0 +1,18 @@
+#include "broker/variant_table.hh"
+
+#include "broker/format/txt.hh"
+
+#include <iterator>
+
+namespace broker {
+
+void convert(const variant_table& value, std::string& out) {
+  format::txt::v1::encode(value.raw(), std::back_inserter(out));
+}
+
+std::ostream& operator<<(std::ostream& out, const variant_table& what) {
+  format::txt::v1::encode(what.raw(), std::ostream_iterator<char>(out));
+  return out;
+}
+
+} // namespace broker

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
   cpp/alm/multipath.cc
   cpp/alm/routing_table.cc
   cpp/backend.cc
+  cpp/builder.cc
   cpp/data.cc
   cpp/detail/peer_status_map.cc
   cpp/domain_options.cc
@@ -39,6 +40,7 @@ set(tests
   cpp/telemetry/histogram.cc
   cpp/test.cc
   cpp/topic.cc
+  cpp/variant.cc
   cpp/zeek.cc
 )
 
@@ -136,8 +138,10 @@ if (BROKER_PYTHON_BINDINGS)
   # set_tests_properties(python-broker-cluster-benchmark PROPERTIES TIMEOUT 120)
 endif ()
 
-# -- Python -------------------------------------------------------------------
+# -- optional micro benchmarks -------------------------------------------------
 
-if (BROKER_ENABLE_MICRO_BENCHMARKS)
+find_package(benchmark QUIET)
+
+if (benchmark_FOUND)
   add_subdirectory(micro-benchmark)
 endif ()

--- a/tests/cpp/builder.cc
+++ b/tests/cpp/builder.cc
@@ -1,0 +1,241 @@
+#define SUITE builder
+
+#include "broker/builder.hh"
+
+#include "test.hh"
+
+#include "broker/variant.hh"
+#include "broker/variant_list.hh"
+#include "broker/variant_set.hh"
+#include "broker/variant_table.hh"
+
+#include <caf/detail/append_hex.hpp>
+
+using namespace broker;
+using namespace std::literals;
+
+namespace {
+
+std::string to_hex(std::pair<const std::byte*, const std::byte*> range) {
+  auto [first, last] = range;
+  std::string result;
+  caf::detail::append_hex(result, first, static_cast<size_t>(last - first));
+  return result;
+}
+
+std::string to_hex(variant val){
+  auto [data, size] = val.shared_envelope()->raw_bytes();
+  std::string result;
+  caf::detail::append_hex(result, data, size);
+  return result;
+}
+
+std::string to_hex(set_builder builder) {
+  return to_hex(std::move(builder).build());
+}
+
+std::string to_hex(table_builder builder) {
+  return to_hex(std::move(builder).build());
+}
+
+std::string to_hex(list_builder builder) {
+  return to_hex(std::move(builder).build());
+}
+
+struct fixture {
+  address localhost;
+  subnet localnet;
+  timestamp tstamp;
+  timespan tspan;
+
+  fixture() {
+    convert("127.0.0.1"s, localhost);
+    convert("2001:db8::/32"s, localnet);
+    tspan = timespan{1'000'000'000};
+    tstamp = timestamp{tspan};
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(builder_tests, fixture)
+
+TEST(serialize empty set) {
+  set_builder builder;
+  CHECK_EQUAL(builder.num_values(), 0u);
+  CHECK_EQUAL(to_hex(std::move(builder)), "0C00");
+}
+
+TEST(serialize set with none) {
+  set_builder builder;
+  builder.add(nil);
+  CHECK_EQUAL(builder.num_values(), 1u);
+  CHECK_EQUAL(to_hex(builder.encoded_values()), "00");
+  CHECK_EQUAL(to_hex(std::move(builder)), "0C0100");
+}
+
+TEST(serialize set with count) {
+  set_builder builder;
+  builder.add(1u);
+  CHECK_EQUAL(builder.num_values(), 1u);
+  CHECK_EQUAL(to_hex(builder.encoded_values()), "020000000000000001");
+  CHECK_EQUAL(to_hex(std::move(builder)), "0C01020000000000000001");
+}
+
+TEST(serialize set with integer) {
+  set_builder builder;
+  builder.add(1);
+  CHECK_EQUAL(builder.num_values(), 1u);
+  CHECK_EQUAL(to_hex(builder.encoded_values()), "030000000000000001");
+  CHECK_EQUAL(to_hex(std::move(builder)), "0C01030000000000000001");
+}
+
+TEST(serialize set with two strings) {
+  set_builder builder;
+  builder.add("hello"sv);
+  builder.add("broker"sv);
+  CHECK_EQUAL(builder.num_values(), 2u);
+  CHECK_EQUAL(to_hex(builder.encoded_values()),
+              "050568656C6C6F"     // "hello"
+              "050662726F6B6572"); // "broker"
+  CHECK_EQUAL(to_hex(std::move(builder)),
+              "0C"                 // set
+              "02"                 // 2 entries
+              "050568656C6C6F"     // "hello"
+              "050662726F6B6572"); // "broker"
+}
+
+TEST(build set with all primitive types) {
+  auto val = set_builder{}
+               .add(nil)
+               .add(true)
+               .add(24u)
+               .add(42u)
+               .add(-24)
+               .add(-42)
+               .add(2.5)
+               .add("hello"sv)
+               .add(localhost)
+               .add(localnet)
+               .add(port{80, port::protocol::tcp})
+               .add(tstamp)
+               .add(tspan)
+               .add(enum_value{"foo"})
+               .build()
+               .to_set();
+  MESSAGE("val: " << val);
+  CHECK(val.contains(nil));
+  CHECK(val.contains(true));
+  CHECK(val.contains(count{24}));
+  CHECK(val.contains(count{42}));
+  CHECK(val.contains(integer{-24}));
+  CHECK(val.contains(integer{-42}));
+  CHECK(val.contains(2.5));
+  CHECK(val.contains("hello"sv));
+  CHECK(val.contains(localhost));
+  CHECK(val.contains(localnet));
+  CHECK(val.contains(port{80, port::protocol::tcp}));
+  CHECK(val.contains(tstamp));
+  CHECK(val.contains(tspan));
+  CHECK(val.contains(enum_value_view{"foo"}));
+  CHECK(!val.contains(false));
+  CHECK(!val.contains(integer{42}));
+}
+
+TEST(serialize empty table) {
+  table_builder builder;
+  CHECK_EQUAL(builder.num_values(), 0u);
+  CHECK_EQUAL(to_hex(std::move(builder)), "0D00");
+}
+
+TEST(serialize table with one entry) {
+  table_builder builder;
+  builder.add("k1"sv, nil);
+  CHECK_EQUAL(builder.num_values(), 1u);
+  CHECK_EQUAL(to_hex(builder.encoded_values()),
+              "05026B31" // "k1"
+              "00");     // nil
+  CHECK_EQUAL(to_hex(std::move(builder)),
+              "0D"       // table
+              "01"       // 1 entry
+              "05026B31" // "k1"
+              "00");     // nil
+}
+
+TEST(serialize table with two strings) {
+  table_builder builder;
+  builder.add("k1"sv, "v1"sv);
+  builder.add("k2"sv, "v2"sv);
+  CHECK_EQUAL(builder.num_values(), 2u);
+  CHECK_EQUAL(to_hex(builder.encoded_values()),
+              "05026B3105027631"   // k1, v1
+              "05026B3205027632"); // k2, v2
+  CHECK_EQUAL(to_hex(std::move(builder)),
+              "0D"                 // table
+              "02"                 // 2 entries
+              "05026B3105027631"   // k1, v1
+              "05026B3205027632"); // k2, v2
+}
+
+TEST(serialize empty vector) {
+  list_builder builder;
+  CHECK_EQUAL(builder.num_values(), 0u);
+  CHECK_EQUAL(to_hex(std::move(builder)), "0E00");
+}
+
+TEST(serialize vector with none) {
+  list_builder builder;
+  builder.add(nil);
+  CHECK_EQUAL(builder.num_values(), 1u);
+  CHECK_EQUAL(to_hex(builder.encoded_values()), "00");
+  CHECK_EQUAL(to_hex(std::move(builder)), "0E0100");
+}
+
+TEST(serialize vector with two strings) {
+  list_builder builder;
+  builder.add("hello"sv);
+  builder.add("broker"sv);
+  CHECK_EQUAL(builder.num_values(), 2u);
+  CHECK_EQUAL(to_hex(builder.encoded_values()),
+              "050568656C6C6F"     // "hello"
+              "050662726F6B6572"); // "broker"
+  CHECK_EQUAL(to_hex(std::move(builder)),
+              "0E"                 // vector
+              "02"                 // 2 entries
+              "050568656C6C6F"     // "hello"
+              "050662726F6B6572"); // "broker"
+}
+
+TEST(build vector with all primitive types) {
+  auto val = list_builder{}
+               .add(nil)
+               .add(true)
+               .add(42u)
+               .add(-42)
+               .add(2.5)
+               .add("hello"sv)
+               .add(localhost)
+               .add(localnet)
+               .add(port{80, port::protocol::tcp})
+               .add(tstamp)
+               .add(tspan)
+               .add(enum_value{"foo"})
+               .build()
+               .to_list();
+  MESSAGE("val: " << val);
+  CHECK_EQUAL(val.size(), 12u);
+  CHECK(val[0].is_none());
+  CHECK_EQUAL(val[1].to_boolean(), true);
+  CHECK_EQUAL(val[2].to_count(), 42u);
+  CHECK_EQUAL(val[3].to_integer(), -42);
+  CHECK_EQUAL(val[4].to_real(), 2.5);
+  CHECK_EQUAL(val[5].to_string(), "hello"sv);
+  CHECK_EQUAL(val[6].to_address(), localhost);
+  CHECK_EQUAL(val[7].to_subnet(), localnet);
+  CHECK_EQUAL(val[8].to_port(), port(80, port::protocol::tcp));
+  CHECK_EQUAL(val[9].to_timestamp(), tstamp);
+  CHECK_EQUAL(val[10].to_timespan(), tspan);
+  CHECK_EQUAL(val[11].to_enum_value(), enum_value_view{"foo"});
+}
+
+CAF_TEST_FIXTURE_SCOPE_END()

--- a/tests/cpp/builder.cc
+++ b/tests/cpp/builder.cc
@@ -23,7 +23,7 @@ std::string to_hex(std::pair<const std::byte*, const std::byte*> range) {
   return result;
 }
 
-std::string to_hex(variant val){
+std::string to_hex(variant val) {
   auto [data, size] = val.shared_envelope()->raw_bytes();
   std::string result;
   caf::detail::append_hex(result, data, size);

--- a/tests/cpp/variant.cc
+++ b/tests/cpp/variant.cc
@@ -91,7 +91,7 @@ private:
   detail::monotonic_buffer_resource buf_;
 };
 
-template<class T, class... Ts>
+template <class T, class... Ts>
 error parse_bytes_result(T arg, Ts... args) {
   if constexpr (sizeof...(Ts) == 0 && std::is_same_v<byte_buffer, T>) {
     auto envelope = std::make_shared<envelope_test_impl>(std::move(arg));
@@ -101,7 +101,7 @@ error parse_bytes_result(T arg, Ts... args) {
   }
 }
 
-template<class T, class... Ts>
+template <class T, class... Ts>
 variant parse_bytes(T arg, Ts... args) {
   if constexpr (sizeof...(Ts) == 0 && std::is_same_v<byte_buffer, T>) {
     auto envelope = std::make_shared<envelope_test_impl>(std::move(arg));
@@ -142,7 +142,7 @@ TEST(parsing a none) {
 }
 
 TEST(parsing a boolean) {
-  CHECK(parse_bytes(type::boolean).is_none()); // not enough bytes
+  CHECK(parse_bytes(type::boolean).is_none());       // not enough bytes
   CHECK(parse_bytes(type::boolean, 1, 1).is_none()); // trailing bytes
   CHECK_EQ(parse_bytes(type::boolean, 1).to_boolean(false), true);
   CHECK_EQ(parse_bytes(type::boolean, 0).to_boolean(true), false);
@@ -190,7 +190,7 @@ TEST(parsing a string) {
   CHECK(parse_bytes(type::string).is_none());
   CHECK(parse_bytes(type::string, 3).is_none());
   CHECK(parse_bytes(type::string, 3, 'a').is_none());
-  CHECK(parse_bytes(type::string, 3, 'a','b').is_none());
+  CHECK(parse_bytes(type::string, 3, 'a', 'b').is_none());
   CHECK(parse_bytes(type::string, 3, 'a', 'b', 'c', 'd').is_none());
   // We not only check that we get "abc", but also that the view has in fact
   // created a shallow copy while parsing.
@@ -216,7 +216,7 @@ TEST(parsing an enum value) {
   CHECK(parse_bytes(type::enum_value).is_none());
   CHECK(parse_bytes(type::enum_value, 3).is_none());
   CHECK(parse_bytes(type::enum_value, 3, 'a').is_none());
-  CHECK(parse_bytes(type::enum_value, 3, 'a','b').is_none());
+  CHECK(parse_bytes(type::enum_value, 3, 'a', 'b').is_none());
   CHECK(parse_bytes(type::enum_value, 3, 'a', 'b', 'c', 'd').is_none());
   // We not only check that we get "abc", but also that the view has in fact
   // created a shallow copy while parsing.

--- a/tests/cpp/variant.cc
+++ b/tests/cpp/variant.cc
@@ -1,0 +1,401 @@
+#define SUITE variant
+
+#include "broker/variant.hh"
+
+#include "test.hh"
+
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "broker/convert.hh"
+#include "broker/data.hh"
+#include "broker/variant_list.hh"
+#include "broker/variant_set.hh"
+#include "broker/variant_table.hh"
+
+#include <caf/detail/append_hex.hpp>
+
+#define SUBTEST(name)                                                          \
+  MESSAGE(name);                                                               \
+  if (true)
+
+using namespace broker;
+using namespace std::literals;
+
+namespace {
+
+using byte_buffer = caf::byte_buffer;
+
+std::string to_hex(const byte_buffer& buf) {
+  std::string result;
+  caf::detail::append_hex(result, buf.data(), buf.size());
+  return result;
+}
+
+template <class... Ts>
+byte_buffer make_bytes(Ts... xs) {
+  return {static_cast<caf::byte>(xs)...};
+}
+
+bool convert(const byte_buffer& bytes, data& value) {
+  caf::binary_deserializer source{nullptr, bytes};
+  return source.apply(value);
+}
+
+bool convert(const data& value, byte_buffer& bytes) {
+  caf::binary_serializer sink{nullptr, bytes};
+  return sink.apply(value);
+}
+
+byte_buffer to_bytes(const data& value) {
+  byte_buffer result;
+  REQUIRE(convert(value, result));
+  return result;
+}
+
+class envelope_test_impl : public envelope {
+public:
+  envelope_test_impl(byte_buffer bytes) : bytes_(std::move(bytes)) {}
+
+  variant value() const noexcept override {
+    return {root_, shared_from_this()};
+  }
+
+  std::string_view topic() const noexcept override {
+    using namespace std::literals;
+    return "test"sv;
+  }
+
+  bool is_root(const variant_data* val) const noexcept override {
+    return val == root_;
+  }
+
+  std::pair<const std::byte*, size_t> raw_bytes() const noexcept override {
+    return {reinterpret_cast<const std::byte*>(bytes_.data()), bytes_.size()};
+  }
+
+  error parse() {
+    error result;
+    root_ = do_parse(buf_, result);
+    return result;
+  }
+
+private:
+  variant_data* root_ = nullptr;
+  caf::byte_buffer bytes_;
+  detail::monotonic_buffer_resource buf_;
+};
+
+template<class T, class... Ts>
+error parse_bytes_result(T arg, Ts... args) {
+  if constexpr (sizeof...(Ts) == 0 && std::is_same_v<byte_buffer, T>) {
+    auto envelope = std::make_shared<envelope_test_impl>(std::move(arg));
+    return envelope->parse();
+  } else {
+    return parse_bytes(make_bytes(arg, args...));
+  }
+}
+
+template<class T, class... Ts>
+variant parse_bytes(T arg, Ts... args) {
+  if constexpr (sizeof...(Ts) == 0 && std::is_same_v<byte_buffer, T>) {
+    auto envelope = std::make_shared<envelope_test_impl>(std::move(arg));
+    if (auto err = envelope->parse(); err)
+      return variant{};
+    return envelope->value();
+  } else {
+    return parse_bytes(make_bytes(arg, args...));
+  }
+}
+
+using type = data::type;
+
+struct fixture {
+  address localhost;
+  subnet localnet;
+
+  fixture() {
+    convert("127.0.0.1"s, localhost);
+    convert("2001:db8::/32"s, localnet);
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(variant_tests, fixture)
+
+TEST(default construction) {
+  CHECK(variant{}.is_none());
+  CHECK_EQ(variant{}, variant{});
+}
+
+TEST(parsing a none) {
+  CHECK_EQ(parse_bytes_result(make_bytes(type::none)), error{});
+  CHECK_EQ(parse_bytes_result(make_bytes(type::none, 1)),
+           ec::deserialization_failed);
+  CHECK(parse_bytes(make_bytes(type::none)).is_none());
+}
+
+TEST(parsing a boolean) {
+  CHECK(parse_bytes(type::boolean).is_none()); // not enough bytes
+  CHECK(parse_bytes(type::boolean, 1, 1).is_none()); // trailing bytes
+  CHECK_EQ(parse_bytes(type::boolean, 1).to_boolean(false), true);
+  CHECK_EQ(parse_bytes(type::boolean, 0).to_boolean(true), false);
+}
+
+TEST(parsing a count) {
+  CHECK(parse_bytes(type::count).is_none());
+  CHECK(parse_bytes(type::count, 1).is_none());
+  CHECK(parse_bytes(type::count, 1, 2).is_none());
+  CHECK(parse_bytes(type::count, 1, 2, 3).is_none());
+  CHECK(parse_bytes(type::count, 1, 2, 3, 4).is_none());
+  CHECK(parse_bytes(type::count, 1, 2, 3, 4, 5).is_none());
+  CHECK(parse_bytes(type::count, 1, 2, 3, 4, 5, 6, 7).is_none());
+  CHECK(parse_bytes(type::count, 1, 2, 3, 4, 5, 6, 7, 8, 9).is_none());
+  CHECK_EQ(parse_bytes(type::count, 1, 2, 3, 4, 5, 6, 7, 8).to_count(),
+           0x0102030405060708);
+}
+
+TEST(parsing an integer) {
+  CHECK(parse_bytes(type::integer).is_none());
+  CHECK(parse_bytes(type::integer, 1).is_none());
+  CHECK(parse_bytes(type::integer, 1, 2).is_none());
+  CHECK(parse_bytes(type::integer, 1, 2, 3).is_none());
+  CHECK(parse_bytes(type::integer, 1, 2, 3, 4).is_none());
+  CHECK(parse_bytes(type::integer, 1, 2, 3, 4, 5).is_none());
+  CHECK(parse_bytes(type::integer, 1, 2, 3, 4, 5, 6, 7).is_none());
+  CHECK(parse_bytes(type::integer, 1, 2, 3, 4, 5, 6, 7, 8, 9).is_none());
+  CHECK_EQ(parse_bytes(type::integer, 1, 2, 3, 4, 5, 6, 7, 8).to_integer(),
+           0x0102030405060708);
+}
+
+TEST(parsing an real) {
+  CHECK(parse_bytes(type::real).is_none());
+  CHECK(parse_bytes(type::real, 1).is_none());
+  CHECK(parse_bytes(type::real, 1, 2).is_none());
+  CHECK(parse_bytes(type::real, 1, 2, 3).is_none());
+  CHECK(parse_bytes(type::real, 1, 2, 3, 4).is_none());
+  CHECK(parse_bytes(type::real, 1, 2, 3, 4, 5).is_none());
+  CHECK(parse_bytes(type::real, 1, 2, 3, 4, 5, 6, 7).is_none());
+  CHECK(parse_bytes(type::real, 1, 2, 3, 4, 5, 6, 7, 8, 9).is_none());
+  CHECK_EQ(parse_bytes(type::real, 64, 04, 0, 0, 0, 0, 0, 0).to_real(), 2.5);
+}
+
+TEST(parsing a string) {
+  CHECK(parse_bytes(type::string).is_none());
+  CHECK(parse_bytes(type::string, 3).is_none());
+  CHECK(parse_bytes(type::string, 3, 'a').is_none());
+  CHECK(parse_bytes(type::string, 3, 'a','b').is_none());
+  CHECK(parse_bytes(type::string, 3, 'a', 'b', 'c', 'd').is_none());
+  // We not only check that we get "abc", but also that the view has in fact
+  // created a shallow copy while parsing.
+  auto bytes = make_bytes(type::string, 3, 'a', 'b', 'c');
+  auto* abc = static_cast<const void*>(bytes.data() + 2);
+  auto val = parse_bytes(std::move(bytes));
+  auto str = val.to_string();
+  CHECK_EQ(str, "abc");
+  CHECK_EQ(static_cast<const void*>(str.data()), abc);
+}
+
+TEST(parsing an address) {
+  byte_buffer bytes;
+  bytes.push_back(static_cast<caf::byte>(type::address));
+  auto* begin = reinterpret_cast<const caf::byte*>(localhost.bytes().data());
+  bytes.insert(bytes.end(), begin, begin + localhost.bytes().size());
+  auto cpy = parse_bytes(bytes);
+  CHECK(cpy.is_address());
+  CHECK_EQ(cpy.to_address(), localhost);
+}
+
+TEST(parsing an enum value) {
+  CHECK(parse_bytes(type::enum_value).is_none());
+  CHECK(parse_bytes(type::enum_value, 3).is_none());
+  CHECK(parse_bytes(type::enum_value, 3, 'a').is_none());
+  CHECK(parse_bytes(type::enum_value, 3, 'a','b').is_none());
+  CHECK(parse_bytes(type::enum_value, 3, 'a', 'b', 'c', 'd').is_none());
+  // We not only check that we get "abc", but also that the view has in fact
+  // created a shallow copy while parsing.
+  auto bytes = make_bytes(type::enum_value, 3, 'a', 'b', 'c');
+  auto* abc = static_cast<const void*>(bytes.data() + 2);
+  auto val = parse_bytes(std::move(bytes));
+  auto str = val.to_enum_value();
+  CHECK_EQ(str.name, "abc");
+  CHECK_EQ(static_cast<const void*>(str.name.data()), abc);
+}
+
+TEST(parsing a vector) {
+  auto val = parse_bytes(type::vector, 3,                // 3-elem vector
+                         type::boolean, 1,               // [0]: true
+                         type::string, 3, 'a', 'b', 'c', // [1]: "abc"
+                         type::vector, 2,                // [2]: 2-elem vector
+                         type::integer, 0, 0, 0, 0, 0, 0, 0, 1,  // [2][0]: 1
+                         type::integer, 0, 0, 0, 0, 0, 0, 0, 2); // [2][0]: 2
+  if (!CHECK(val.is_vector()))
+    return;
+  auto xs = val.to_vector();
+  if (!CHECK_EQ(xs.size(), 3))
+    return;
+  // [0]: true
+  auto i = xs.begin();
+  REQUIRE(i != xs.end());
+  CHECK(i->is_boolean());
+  CHECK_EQ(i->to_boolean(), true);
+  // [1]: "abc"
+  ++i;
+  REQUIRE(i != xs.end());
+  CHECK(i->is_string());
+  CHECK_EQ(i->to_string(), "abc");
+  // [2]: 2-elem vector
+  ++i;
+  REQUIRE(i != xs.end());
+  CHECK(i->is_vector());
+  if (auto sub_vec = i->to_vector(); CHECK_EQ(sub_vec.size(), 2u)) {
+    // [2][0]: 1
+    auto j = sub_vec.begin();
+    REQUIRE(j != sub_vec.end());
+    CHECK(j->is_integer());
+    CHECK_EQ(j->to_integer(), 1);
+    // [2][1]: 2
+    ++j;
+    REQUIRE(j != sub_vec.end());
+    CHECK(j->is_integer());
+    CHECK_EQ(j->to_integer(), 2);
+    // end of sub vector
+    ++j;
+    CHECK(j == sub_vec.end());
+  }
+  // end of vector
+  ++i;
+  CHECK(i == xs.end());
+}
+
+TEST(parsing a set) {
+  auto val = parse_bytes(type::set, 3,                          // 3-elem set
+                         type::integer, 0, 0, 0, 0, 0, 0, 0, 1, // [0]: 1
+                         type::integer, 0, 0, 0, 0, 0, 0, 0, 2, // [1]: 2
+                         type::string, 3, 'a', 'b', 'c');       // [2]: "abc"
+  if (!CHECK(val.is_set()))
+    return;
+  auto xs = val.to_set();
+  if (!CHECK_EQ(xs.size(), 3))
+    return;
+  // [0]: 1
+  auto i = xs.begin();
+  REQUIRE(i != xs.end());
+  CHECK(i->is_integer());
+  CHECK_EQ(i->to_integer(), 1);
+  // [1]: 2
+  ++i;
+  REQUIRE(i != xs.end());
+  CHECK(i->is_integer());
+  CHECK_EQ(i->to_integer(), 2);
+  // [2]: "abc"
+  ++i;
+  REQUIRE(i != xs.end());
+  CHECK(i->is_string());
+  CHECK_EQ(i->to_string(), "abc");
+  // end of set
+  ++i;
+  CHECK(i == xs.end());
+}
+
+TEST(parsing a table) {
+  auto val = parse_bytes(type::table, 3,                         // 3-elem tbl
+                         type::string, 4, 'k', 'e', 'y', '1',    // [0]: "key1"
+                         type::integer, 0, 0, 0, 0, 0, 0, 0, 1,  // [0]: 1
+                         type::string, 4, 'k', 'e', 'y', '2',    // [1]: "key2"
+                         type::integer, 0, 0, 0, 0, 0, 0, 0, 2,  // [1]: 2
+                         type::string, 4, 'k', 'e', 'y', '3',    // [2]: "key3"
+                         type::integer, 0, 0, 0, 0, 0, 0, 0, 3); // [2]: 3
+  if (!CHECK(val.is_table()))
+    return;
+  auto xs = val.to_table();
+  if (!CHECK_EQ(xs.size(), 3))
+    return;
+  // Test the iterator API.
+  // [0]: { "key1": 1}
+  auto i = xs.begin();
+  REQUIRE(i != xs.end());
+  CHECK_EQ(i->first.to_string(), "key1");
+  CHECK_EQ(i->second.to_integer(), 1);
+  // [1]: { "key2": 2}
+  ++i;
+  REQUIRE(i != xs.end());
+  CHECK_EQ(i->first.to_string(), "key2");
+  CHECK_EQ(i->second.to_integer(), 2);
+  // [2]: { "key3": 3}
+  ++i;
+  REQUIRE(i != xs.end());
+  CHECK_EQ(i->first.to_string(), "key3");
+  CHECK_EQ(i->second.to_integer(), 3);
+  // end of table
+  ++i;
+  CHECK(i == xs.end());
+  // Test the lookup API.
+  CHECK_EQ(xs["key1"].to_integer(), 1);
+  CHECK_EQ(xs["key2"].to_integer(), 2);
+  CHECK_EQ(xs["key3"].to_integer(), 3);
+  CHECK(xs["key4"].is_none());
+}
+
+namespace {
+
+auto to_variant(const data& value) {
+  auto buf = to_bytes(value);
+  MESSAGE(value << " -> " << to_hex(buf));
+  return parse_bytes(buf);
+};
+
+  } // namespace
+
+TEST(data serialization roundtrips) {
+  auto ts = timespan{100'000};
+  auto icmp = port::protocol::icmp;
+  CHECK(to_variant(data{}).is_none());
+  CHECK_EQ(to_variant(data{true}).to_boolean(), true);
+  CHECK_EQ(to_variant(data{42u}).to_count(), 42u);
+  CHECK_EQ(to_variant(data{42}).to_integer(), 42);
+  CHECK_EQ(to_variant(data{2.5}).to_real(), 2.5);
+  CHECK_EQ(to_variant(data{"foo"}).to_string(), "foo");
+  CHECK_EQ(to_variant(data{localhost}).to_address(), localhost);
+  CHECK_EQ(to_variant(data{localnet}).to_subnet(), localnet);
+  CHECK_EQ(to_variant(data{port{123, icmp}}).to_port(), port(123, icmp));
+  CHECK_EQ(to_variant(data{timestamp{ts}}).to_timestamp(), timestamp{ts});
+  CHECK_EQ(to_variant(data{ts}).to_timespan(), ts);
+  CHECK_EQ(to_variant(data{vector{1, 2, 3}}), vector({1, 2, 3}));
+  CHECK_EQ(to_variant(data{set{1, 2, 3}}), set({1, 2, 3}));
+  CHECK_EQ(to_variant(data{table{{"a", 1}, {"b", 2}, {"c", 3}}}),
+           table({{"a", 1}, {"b", 2}, {"c", 3}}));
+}
+
+#define CHECK_DEEP_COPY_ROUNDTRIP(data_init)                                   \
+  {                                                                            \
+    auto value = data{data_init};                                              \
+    CHECK_EQ(to_variant(value).to_data(), value);                              \
+  }                                                                            \
+  static_cast<void>(0)
+
+TEST(deep copies) {
+  auto ts = timespan{100'000};
+  CHECK_DEEP_COPY_ROUNDTRIP(true);
+  CHECK_DEEP_COPY_ROUNDTRIP(false);
+  CHECK_DEEP_COPY_ROUNDTRIP(42);
+  CHECK_DEEP_COPY_ROUNDTRIP(42u);
+  CHECK_DEEP_COPY_ROUNDTRIP(2.5);
+  CHECK_DEEP_COPY_ROUNDTRIP("foo"s);
+  CHECK_DEEP_COPY_ROUNDTRIP(localhost);
+  CHECK_DEEP_COPY_ROUNDTRIP(localnet);
+  CHECK_DEEP_COPY_ROUNDTRIP(port(123, port::protocol::icmp));
+  CHECK_DEEP_COPY_ROUNDTRIP(timestamp{ts});
+  CHECK_DEEP_COPY_ROUNDTRIP(ts);
+  CHECK_DEEP_COPY_ROUNDTRIP(vector({1, 2, 3}));
+  CHECK_DEEP_COPY_ROUNDTRIP(set({1, 2, 3}));
+  CHECK_DEEP_COPY_ROUNDTRIP(table({{"a", 1}, {"b", 2}, {"c", 3}}));
+}
+
+CAF_TEST_FIXTURE_SCOPE_END()

--- a/tests/cpp/variant.cc
+++ b/tests/cpp/variant.cc
@@ -158,7 +158,7 @@ TEST(parsing a count) {
   CHECK(parse_bytes(type::count, 1, 2, 3, 4, 5, 6, 7).is_none());
   CHECK(parse_bytes(type::count, 1, 2, 3, 4, 5, 6, 7, 8, 9).is_none());
   CHECK_EQ(parse_bytes(type::count, 1, 2, 3, 4, 5, 6, 7, 8).to_count(),
-           0x0102030405060708);
+           0x0102030405060708u);
 }
 
 TEST(parsing an integer) {
@@ -238,7 +238,7 @@ TEST(parsing a vector) {
   if (!CHECK(val.is_vector()))
     return;
   auto xs = val.to_vector();
-  if (!CHECK_EQ(xs.size(), 3))
+  if (!CHECK_EQ(xs.size(), 3u))
     return;
   // [0]: true
   auto i = xs.begin();
@@ -282,7 +282,7 @@ TEST(parsing a set) {
   if (!CHECK(val.is_set()))
     return;
   auto xs = val.to_set();
-  if (!CHECK_EQ(xs.size(), 3))
+  if (!CHECK_EQ(xs.size(), 3u))
     return;
   // [0]: 1
   auto i = xs.begin();
@@ -315,7 +315,7 @@ TEST(parsing a table) {
   if (!CHECK(val.is_table()))
     return;
   auto xs = val.to_table();
-  if (!CHECK_EQ(xs.size(), 3))
+  if (!CHECK_EQ(xs.size(), 3u))
     return;
   // Test the iterator API.
   // [0]: { "key1": 1}
@@ -349,9 +349,9 @@ auto to_variant(const data& value) {
   auto buf = to_bytes(value);
   MESSAGE(value << " -> " << to_hex(buf));
   return parse_bytes(buf);
-};
+}
 
-  } // namespace
+} // namespace
 
 TEST(data serialization roundtrips) {
   auto ts = timespan{100'000};

--- a/tests/micro-benchmark/CMakeLists.txt
+++ b/tests/micro-benchmark/CMakeLists.txt
@@ -1,18 +1,23 @@
-find_package(benchmark REQUIRED)
+add_library(micro-benchmark-base INTERFACE)
 
-add_executable(micro-benchmark
-  "src/main.cc"
-  "src/routing-table.cc"
-  "src/serialization.cc"
-  "src/streaming.cc"
-)
-
-target_include_directories(micro-benchmark PRIVATE "include")
-
-target_link_libraries(micro-benchmark PRIVATE benchmark::benchmark_main)
+target_link_libraries(micro-benchmark-base INTERFACE benchmark::benchmark_main)
 
 if (ENABLE_STATIC)
-  target_link_libraries(micro-benchmark PRIVATE broker_static)
+  target_link_libraries(micro-benchmark-base INTERFACE broker_static)
 else ()
-  target_link_libraries(micro-benchmark PRIVATE broker)
+  target_link_libraries(micro-benchmark-base INTERFACE broker)
 endif ()
+
+target_include_directories(micro-benchmark-base INTERFACE "include")
+
+add_executable(broker-serialization-benchmark src/serialization.cc)
+target_link_libraries(broker-serialization-benchmark PRIVATE micro-benchmark-base)
+
+# add_executable(micro-benchmark
+#   "src/main.cc"
+#   "src/routing-table.cc"
+#   "src/serialization.cc"
+#   "src/streaming.cc"
+# )
+#
+# target_link_libraries(micro-benchmark PRIVATE benchmark::benchmark_main)

--- a/tests/micro-benchmark/src/routing-table.cc
+++ b/tests/micro-benchmark/src/routing-table.cc
@@ -370,9 +370,7 @@ using default_routing_table = broker::alm::routing_table;
 #define BENCH_SETUP(TableType, Algorithm)                                      \
   using TableType##_impl = routing_table<TableType>;                           \
   BENCHMARK_DEFINE_F(TableType##_impl, Algorithm)                              \
-  (benchmark::State & state) {                                                 \
-    Algorithm##_bench(state);                                                  \
-  }                                                                            \
+  (benchmark::State & state) { Algorithm##_bench(state); }                     \
   BENCHMARK_REGISTER_F(TableType##_impl, Algorithm)->DenseRange(0, 9, 1);
 
 // -- adding entries to a routing table ----------------------------------------


### PR DESCRIPTION
This is a huge "code dump", so let me first explain the big picture here. 🙂

The performance in Broker is held back by `broker::data`. Performance problems related to this type keep coming up. In #318, I've built a barebones alternative to `broker::data` (named `data_view` at the time) that achieved a ~3x speedup over `broker::data` when deserializing a simple (Zeek) event-like structure.

It's not really a "view", though. After a bit of thinking, I've settled on `broker::variant` for "the new thing". The reasoning is simply that `broker::variant` is a tagged union type just like `std::variant`, only that it hard-codes what types are allowed. How can it be so much faster than `broker::data`? Custom allocation strategy. `broker::data` uses "regular" STL types that allocate stuff on the heap. As a result, a Zeek event will allocate multiple memory regions and scatter an object all over the heap.

A `broker::variant` *always* uses a [monotonic buffer resource](https://en.cppreference.com/w/cpp/memory/monotonic_buffer_resource) (albeit a Broker replacement type that we use since the STL type isn't available everywhere yet) to build the nested data structure. The work flow is now *always* that we start from a serialized version of the value, iterate it, and build the nested structure as we go. Once a `variant` is assembled, it is immutable and can be (thread-safe) passed around freely.

The interaction between types is as follows:

- `variant_data` simply wraps the `std::variant` that will hold the actual data. This is very similar to `broker::data` except that we will only store pointers to the container types. This is because we allocate everything in the same allocator, so we can just safely pass around pointers. Further, we don't need to call any destructors. We allocate everything into the same memory region. If that region gets discarded, all of the objects that lived in there just conveniently disappear.
- `envelope` holds a shared pointer to the buffer resource alongside the `variant_data` that lives in the buffer.
- `variant` is a high-level wrapper type that gives us a nice and clean interface without having to care about the `std::variant` and the "trivial" types. It holds a (raw) pointer to the actual `variant_data` plus a (shared) pointer to the `envelope` that owns the memory of the data.
- `variant_list` is a high-level wrapper to replace `broker::vector`.
- `variant_set` is a high-level wrapper to replace `broker::set`.
- `variant_table` is a high-level wrapper to replace `broker::table`.

Because we need to build an envelope now, before we can construct the actual `broker::variant`, we also add a couple of builder types. The builders generate the serialized version of the object. Side note: the `variant` will simply point back to the buffer it was deserialized from for string data. This means ultimately, we can have this workflow in Broker:

1. Copy bytes from the network into a buffer.
2. Hand the buffer to an envelope.
3. Deserialize the `variant` from the buffer "in-place".

Because the envelope holds on to the serialized version of the object, we can trivially serialize it when sending it over to the network: just copy the bytes from the buffer to the network.

This first PR just adds all of the new tools to the code base. Ultimately, we want to get rid of the old types. The `data_message` will be replaced by `envelope` and `data` will be replaced by `variant`. Of course we'll do this in small increments. We will also keep the `data` type around for a bit to not break APIs immediately and for Python bindings.

By the way, the `envelope` also holds the topic. But it's accessible as `string_view` to give us more freedom on how and where to store it. Our `broker::topic` will also get the axe eventually because it forces us to commit to a `std::string`.

The critical part of the equation of all of this is of course performance. I've re-used the `serialization` micro benchmark. Here are the results:

```
$ ./build/broker/release/bin/broker-serialization-benchmark 
2023-06-29T08:14:35+02:00
Running ./build/broker/release/bin/broker-serialization-benchmark
Run on (20 X 3600 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x10)
  L3 Unified 20480 KiB
Load Average: 15.28, 5.60, 2.80
---------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations
---------------------------------------------------------------------------
serialization/event_1_data              327 ns          326 ns      1884933
serialization/table_1_data              226 ns          226 ns      3443956
serialization/event_1_builder           137 ns          137 ns      4898016
serialization/table_1_builder           130 ns          130 ns      5298855
deserialization/event_1_data            561 ns          561 ns      1243052
deserialization/table_1_data            220 ns          220 ns      3162898
deserialization/event_1_variant         116 ns          116 ns      6054054
deserialization/table_1_variant         103 ns          103 ns      6742244
deserialization/event_1_envelope        200 ns          200 ns      3534515
deserialization/table_1_envelope        186 ns          186 ns      3686908
```

The `event_1` is a simple, nested representation that models a simple Zeek event: `(1, 1, ("event_1", (42, "test")))`. This is basically how a `broker::zeek::Event` looks like.

The `table_1` is a simple table with two key/value pairs: `{"first-name": "John", "last-name": "Doe"}`.

Serializing a `broker::data` of this type is ~330ns. Now, serializing a `broker::variant` wouldn't be a good comparison here. In the new design, the builders have the job of producing the binary format. And they do this much faster with a speedup of around ~2x.

The real deal is *deserializing*, though. For real code, we would be interested in how long it takes to deserialize an `envelope` vs. a `data`. The values for deserializing a "naked" `variant` are just available for the sake of completeness. So here, we look at 560ns vs. 200ns for `event_1` (almost 3x speedup) and just a small gain (around 20%) for `table_1`. Of course this would become a much bigger speedup real quick if the table had more keys or more complex key/value entries.

In practice, Broker will mostly operate on Zeek events and Zeek log entries. They come from the nesting implemented in `broker/zeek.hh`, so this will give us a nice boost. A ~3x speedup for the deserialization path just from switching to a different data structure. We will combine this with the additional gains from putting radix trees to work for the filtering.