### PR TITLE
Replace usage of deprecated CMake FindPythonInterp and FindPythonDev modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,33 +446,18 @@ endif ()
 
 # -- Bindings -----------------------------------------------------------------
 
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bindings/python/3rdparty/pybind11/CMakeLists.txt")
+  message(WARNING "Skipping Python bindings: pybind11 submodule not available")
+  set(DISABLE_PYTHON_BINDINGS true)
+endif ()
+
 if (NOT DISABLE_PYTHON_BINDINGS)
   set(Python_ADDITIONAL_VERSIONS 3)
-  find_package(PythonInterp)
-  if (NOT PYTHONINTERP_FOUND)
+  find_package(Python 3.7 COMPONENTS Interpreter Development)
+
+  if (NOT Python_FOUND)
     message(STATUS "Skipping Python bindings: Python interpreter not found")
-  endif ()
-
-  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bindings/python/3rdparty/pybind11/CMakeLists.txt")
-    message(WARNING "Skipping Python bindings: pybind11 submodule not available")
-    set(PYTHONINTERP_FOUND false)
-  endif ()
-
-  if (${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} VERSION_LESS 3.5)
-    message(WARNING "Skipping Python bindings: Python 3.5 or greater required")
-    set(PYTHONINTERP_FOUND false)
-  endif ()
-
-  find_package(PythonDev)
-  if (PYTHONDEV_FOUND)
-    # The standard PythonLibs package puts its includes at PYTHON_INCLUDE_DIRS.
-    set(PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIR})
   else ()
-    message(STATUS
-            "Skipping Python bindings: Python includes/libraries not found")
-  endif ()
-
-  if (PYTHONINTERP_FOUND AND PYTHONDEV_FOUND)
     set (BROKER_PYTHON_BINDINGS true)
     set (BROKER_PYTHON_STAGING_DIR ${CMAKE_CURRENT_BINARY_DIR}/python)
     add_subdirectory(bindings/python)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -28,7 +28,7 @@ add_dependencies(_broker python-scripts-stage)
 # Set includes.
 target_include_directories(_broker PUBLIC
                            ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/pybind11/include/
-                           ${PYTHON_INCLUDE_DIRS})
+                           ${Python_INCLUDE_DIRS})
 
 # Set libraries to link against.
 if (NOT WIN32)
@@ -40,7 +40,7 @@ if (ENABLE_SHARED)
 else ()
   set(libbroker broker_static)
 endif ()
-target_link_libraries(_broker PUBLIC ${libbroker} ${PYTHON_LIBRARIES})
+target_link_libraries(_broker PUBLIC ${libbroker} ${Python_LIBRARIES})
 if (APPLE)
   # Support multiple Python installations.
   target_link_libraries(_broker PRIVATE "-undefined dynamic_lookup")
@@ -69,12 +69,12 @@ endif ()
 if ( NOT PY_MOD_INSTALL_DIR )
   # Figure out Python module install directory.
   if (BROKER_PYTHON_PREFIX)
-    set(pyver ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+    set(pyver ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR})
     file(TO_CMAKE_PATH "${BROKER_PYTHON_PREFIX}/lib/python${pyver}/site-packages" PY_MOD_INSTALL_DIR)
   elseif (BROKER_PYTHON_HOME)
     file(TO_CMAKE_PATH "${BROKER_PYTHON_HOME}/lib/python" PY_MOD_INSTALL_DIR)
   else ()
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+    execute_process(COMMAND ${Python_EXECUTABLE} -c
       "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
       OUTPUT_VARIABLE python_site_packages
       OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230612
+ENV DOCKERFILE_VERSION 20230728
 
 RUN apk add --no-cache \
   bash \

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230728
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/ci/ubuntu-22.10/Dockerfile
+++ b/ci/ubuntu-22.10/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230612
+ENV DOCKERFILE_VERSION 20230728
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -16,6 +16,10 @@
 
 FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20230728
+
 SHELL [ "powershell" ]
 
 RUN Set-ExecutionPolicy Unrestricted -Force

--- a/configure
+++ b/configure
@@ -170,7 +170,7 @@ while [ $# -ne 0 ]; do
             append_cache_entry OPENSSL_ROOT_DIR     PATH    $optarg
             ;;
         --with-python=*)
-            append_cache_entry PYTHON_EXECUTABLE    PATH    $optarg
+            append_cache_entry Python_EXECUTABLE    PATH    $optarg
             ;;
         --with-python-config=*)
             append_cache_entry PYTHON_CONFIG        PATH    $optarg

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,7 +109,7 @@ if (BROKER_PYTHON_BINDINGS)
     set(script ${CMAKE_CURRENT_SOURCE_DIR}/python/${name}.py)
     set(test_name python-${name})
     add_test(NAME ${test_name}
-             COMMAND ${PYTHON_EXECUTABLE} ${script} ${ARGN}
+             COMMAND ${Python_EXECUTABLE} ${script} ${ARGN}
              WORKING_DIRECTORY ${BROKER_PYTHON_STAGING_DIR})
     set_tests_properties(${test_name} PROPERTIES TIMEOUT ${BROKER_TEST_TIMEOUT})
     set_tests_properties(${test_name} PROPERTIES ENVIRONMENT


### PR DESCRIPTION
This fixes a CMake warning with newer versions of CMake:

> CMake Warning (dev) at cmake/FindRequiredPackage.cmake:33 (find_package):
>   Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
>   are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
>   the cmake_policy command to set the policy and suppress this warning.
> 
> Call Stack (most recent call first):
>   CMakeLists.txt:737 (FindRequiredPackage)
> This warning is for project developers.  Use -Wno-dev to suppress it.

The last commit forces the rebuild of a few of the docker images used by Cirrus since it seems that some of the cached images expired and they couldn't retrieve them anymore.