### PR TITLE
Make println utility reusable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ set(BROKER_SRC
   src/internal/metric_view.cc
   src/internal/peering.cc
   src/internal/pending_connection.cc
+  src/internal/println.cc
   src/internal/prometheus.cc
   src/internal/store_actor.cc
   src/internal/web_socket.cc

--- a/ci/debian-10/Dockerfile
+++ b/ci/debian-10/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230813
 
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230813
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/ci/fedora-37/Dockerfile
+++ b/ci/fedora-37/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:37
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20221127
+ENV DOCKERFILE_VERSION 20230813
 
 RUN dnf -y install \
     cmake \

--- a/ci/fedora-38/Dockerfile
+++ b/ci/fedora-38/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:38
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230612
+ENV DOCKERFILE_VERSION 20230813
 
 RUN dnf -y install \
     cmake \

--- a/ci/ubuntu-22.04/Dockerfile
+++ b/ci/ubuntu-22.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220615
+ENV DOCKERFILE_VERSION 20230813
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/ci/ubuntu-22.10/Dockerfile
+++ b/ci/ubuntu-22.10/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230612
+ENV DOCKERFILE_VERSION 20230813
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/include/broker/internal/println.hh
+++ b/include/broker/internal/println.hh
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "broker/convert.hh"
+
+#include <caf/deep_to_string.hpp>
+#include <caf/term.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <string_view>
+
+namespace broker::internal {
+
+std::mutex& println_mtx();
+
+inline void do_print(std::ostream& ostr, const char* x) {
+  ostr << x;
+}
+
+inline void do_print(std::ostream& ostr, std::string_view x) {
+  ostr << x;
+}
+
+inline void do_print(std::ostream& ostr, const caf::term& x) {
+  ostr << x;
+}
+
+template <class T>
+void do_print(std::ostream& ostr, const T& x) {
+  if constexpr (detail::has_convert_v<T, std::string>) {
+    std::string tmp;
+    convert(x, tmp);
+    do_print(ostr, tmp);
+  } else {
+    auto tmp = caf::deep_to_string(x);
+    do_print(ostr, tmp);
+  }
+}
+
+template <class... Ts>
+void do_print_all(std::ostream& ostr, const Ts&... xs) {
+  (do_print(ostr, xs), ...);
+}
+
+} // namespace broker::internal
+
+namespace broker::internal::out {
+
+/// Prints a sequence of values to standard output.
+template <class... Ts>
+void println(Ts&&... xs) {
+  std::unique_lock guard{println_mtx()};
+  do_print_all(std::cout, std::forward<Ts>(xs)...);
+  std::cout << caf::term::reset_endl;
+}
+
+} // namespace broker::internal::out
+
+namespace broker::internal::err {
+
+/// Prints a sequence of values to standard error.
+template <class... Ts>
+void println(Ts&&... xs) {
+  std::unique_lock guard{println_mtx()};
+  do_print_all(std::cerr, caf::term::red, std::forward<Ts>(xs)...);
+  std::cerr << caf::term::reset_endl;
+}
+
+} // namespace broker::internal::err
+
+namespace broker::internal::verbose {
+
+bool enabled();
+
+void enabled(bool value);
+
+/// Prints a sequence of values to standard output if verbose logging is
+/// enabled.
+template <class... Ts>
+void println(Ts&&... xs) {
+  if (!enabled())
+    return;
+  std::unique_lock guard{println_mtx()};
+  do_print_all(std::cout, caf::term::blue, std::chrono::system_clock::now(),
+               ": ", std::forward<Ts>(xs)...);
+  std::cout << caf::term::reset_endl;
+}
+
+} // namespace broker::internal::verbose

--- a/include/broker/internal/println.hh
+++ b/include/broker/internal/println.hh
@@ -28,7 +28,8 @@ inline void do_print(std::ostream& ostr, const caf::term& x) {
 }
 
 template <class T>
-void do_print(std::ostream& ostr, const T& x) {
+std::enable_if_t<!std::is_convertible_v<T, std::string_view>>
+do_print(std::ostream& ostr, const T& x) {
   if constexpr (detail::has_convert_v<T, std::string>) {
     std::string tmp;
     convert(x, tmp);

--- a/src/internal/println.cc
+++ b/src/internal/println.cc
@@ -1,0 +1,31 @@
+#include "broker/internal/println.hh"
+
+#include <atomic>
+
+namespace {
+
+std::mutex println_mtx_instance;
+
+std::atomic<bool> verbose_output;
+
+} // namespace
+
+namespace broker::internal {
+
+std::mutex& println_mtx() {
+  return println_mtx_instance;
+}
+
+} // namespace broker::internal
+
+namespace broker::internal::verbose {
+
+bool enabled() {
+  return verbose_output.load();
+}
+
+void enabled(bool value) {
+  verbose_output = value;
+}
+
+} // namespace broker::internal::verbose


### PR DESCRIPTION
Moves the `println` utility from the `broker-node` to the `internal` namespace to allow us to re-use this in other tools and benchmarks.