### PR TITLE
Build broker bindings for older versions of Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,7 +453,7 @@ endif ()
 
 if (NOT DISABLE_PYTHON_BINDINGS)
   set(Python_ADDITIONAL_VERSIONS 3)
-  find_package(Python 3.7 COMPONENTS Interpreter Development)
+  find_package(Python 3.5 COMPONENTS Interpreter Development)
 
   if (NOT Python_FOUND)
     message(STATUS "Skipping Python bindings: Python interpreter not found")


### PR DESCRIPTION
Recently (GH-370), the version of Python required to build the bindings was upped to 3.7. This is problematic, as we have older versions of Python in distributions that we still support; this lowers this version again.