### PR TITLE
doc/conf: Fix html_theme not defined

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,14 +110,7 @@ todo_emit_warnings = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:
-    # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Zeek side reference: zeek/zeek-docs#206

RTD build: https://readthedocs.org/projects/bro-broker/builds/21739679/