### PR TITLE
ci: Make ubuntu22 produce build.tgz and execute ci/benchmark.sh

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -156,8 +156,13 @@ ubuntu22_task:
     # Ubuntu 22.04 EOL: April 2027
     dockerfile: ci/ubuntu-22.04/Dockerfile
     << : *RESOURCES_TEMPLATE
+  env:
+    BROKER_CI_CREATE_ARTIFACT: 1
   << : *CI_TEMPLATE
   << : *UNIX_ENV
+  upload_binary_artifacts:
+    path: build.tgz
+  benchmark_script: ./ci/benchmark.sh
 
 ubuntu20_task:
   container:

--- a/ci/ubuntu-22.04/Dockerfile
+++ b/ci/ubuntu-22.04/Dockerfile
@@ -8,6 +8,7 @@ ENV DOCKERFILE_VERSION 20230813
 
 RUN apt-get update && apt-get -y install \
     cmake \
+    curl \
     g++ \
     git \
     libssl-dev \


### PR DESCRIPTION
Seems removal happened with fd0dd674e3c514546483108c660be3e69370a6fb.