### PR TITLE
Avoid implicit conversions in Zeek utility classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,7 @@ set(BROKER_SRC
   src/topic.cc
   src/version.cc
   src/worker.cc
+  src/zeek.cc
 )
 
 if (ENABLE_SHARED)

--- a/doc/_examples/ping.cc
+++ b/doc/_examples/ping.cc
@@ -25,12 +25,15 @@ int main() {
   // Do five ping / pong.
   for (int n = 0; n < 5; n++) {
     // Send event "ping(n)".
-    zeek::Event ping("ping", {n});
-    ep.publish("/topic/test", ping);
+    ep.publish("/topic/test", zeek::Event{"ping", {n}});
 
     // Wait for "pong" reply event.
     auto msg = sub.get();
-    zeek::Event pong(move_data(msg));
-    std::cout << "received " << pong.name() << pong.args() << std::endl;
+    auto pong = zeek::Event{std::move(msg)};
+    if (pong.valid())
+      std::cout << "received " << pong.name() << pong.args() << std::endl;
+    else
+      std::cout << "received invalid pong message: " << to_string(pong)
+                << std::endl;
   }
 }

--- a/doc/_examples/pong.cc
+++ b/doc/_examples/pong.cc
@@ -26,11 +26,14 @@ int main() {
   for (int n = 0; n < 5; n++) {
     // Wait for a "ping" event.
     auto msg = sub.get();
-    zeek::Event ping(move_data(msg));
-    std::cout << "received " << ping.name() << ping.args() << std::endl;
+    auto ping = zeek::Event{std::move(msg)};
+    if (ping.valid())
+      std::cout << "received " << ping.name() << ping.args() << std::endl;
+    else
+      std::cout << "received invalid ping message: " << to_string(ping)
+                << std::endl;
 
     // Send event "pong" response.
-    zeek::Event pong("pong", {n});
-    ep.publish("/topic/test", pong);
+    ep.publish("/topic/test", zeek::Event{"pong", {n}});
   }
 }

--- a/include/broker/data.hh
+++ b/include/broker/data.hh
@@ -138,6 +138,8 @@ public:
     return *this;
   }
 
+  // -- properties -------------------------------------------------------------
+
   /// Returns a string representation of the stored type.
   const char* get_type_name() const;
 
@@ -155,6 +157,171 @@ public:
   [[nodiscard]] const data_variant& get_data() const noexcept {
     return data_;
   }
+
+  /// Checks whether this view contains the `nil` value.
+  bool is_none() const noexcept {
+    return get_type() == type::none;
+  }
+
+  /// Checks whether this view contains a boolean.
+  bool is_boolean() const noexcept {
+    return get_type() == type::boolean;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_count() const noexcept {
+    return get_type() == type::count;
+  }
+
+  /// Checks whether this view contains a integer.
+  bool is_integer() const noexcept {
+    return get_type() == type::integer;
+  }
+
+  /// Checks whether this view contains a real.
+  bool is_real() const noexcept {
+    return get_type() == type::real;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_string() const noexcept {
+    return get_type() == type::string;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_address() const noexcept {
+    return get_type() == type::address;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_subnet() const noexcept {
+    return get_type() == type::subnet;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_port() const noexcept {
+    return get_type() == type::port;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_timestamp() const noexcept {
+    return get_type() == type::timestamp;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_timespan() const noexcept {
+    return get_type() == type::timespan;
+  }
+
+  /// Checks whether this view contains a count.
+  bool is_enum_value() const noexcept {
+    return get_type() == type::enum_value;
+  }
+
+  /// Checks whether this view contains a set.
+  bool is_set() const noexcept {
+    return get_type() == type::set;
+  }
+
+  /// Checks whether this view contains a table.
+  bool is_table() const noexcept {
+    return get_type() == type::table;
+  }
+
+  /// Checks whether this view contains a list.
+  bool is_list() const noexcept {
+    return get_type() == type::vector;
+  }
+
+  // -- conversions ------------------------------------------------------------
+
+  /// Retrieves the @c boolean value or returns @p fallback if this object does
+  /// not contain a @c boolean.
+  bool to_boolean(bool fallback = false) const noexcept {
+    if (auto* val = std::get_if<boolean>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c count value or returns @p fallback if this object does
+  /// not contain a @c count.
+  count to_count(count fallback = 0) const noexcept {
+    if (auto* val = std::get_if<count>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c integer value or returns @p fallback if this object does
+  /// not contain a @c integer.
+  integer to_integer(integer fallback = 0) const noexcept {
+    if (auto* val = std::get_if<integer>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c real value or returns @p fallback if this object does
+  /// not contain a @c real.
+  real to_real(real fallback = 0) const noexcept {
+    if (auto* val = std::get_if<real>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the string value or returns an empty string if this object does
+  /// not contain a string.
+  std::string_view to_string() const noexcept {
+    if (auto* val = std::get_if<std::string>(&data_))
+      return *val;
+    return std::string_view{};
+  }
+
+  /// Retrieves the @c address value or returns @p fallback if this object does
+  /// not contain a @c address.
+  address to_address(const address& fallback = {}) const noexcept {
+    if (auto* val = std::get_if<address>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c subnet value or returns @p fallback if this object does
+  /// not contain a @c subnet.
+  subnet to_subnet(const subnet& fallback = {}) const noexcept {
+    if (auto* val = std::get_if<subnet>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c port value or returns @p fallback if this object does
+  /// not contain a @c port.
+  port to_port(port fallback = {}) const noexcept {
+    if (auto* val = std::get_if<port>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c timestamp value or returns @p fallback if this object
+  /// does not contain a @c timestamp.
+  timestamp to_timestamp(timestamp fallback = {}) const noexcept {
+    if (auto* val = std::get_if<timestamp>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the @c timespan value or returns @p fallback if this object does
+  /// not contain a @c timespan.
+  timespan to_timespan(timespan fallback = {}) const noexcept {
+    if (auto* val = std::get_if<timespan>(&data_))
+      return *val;
+    return fallback;
+  }
+
+  /// Retrieves the enum_value value or returns @p fallback if this object does
+  /// not contain a enum_value.
+  const enum_value& to_enum_value() const noexcept;
+
+  /// Converts the stored data as a list (`vector`). If the stored data is
+  /// not a list, the result is an empty list.
+  [[nodiscard]] const vector& to_list() const;
 
 private:
   data_variant data_;

--- a/include/broker/endpoint.hh
+++ b/include/broker/endpoint.hh
@@ -39,6 +39,12 @@ struct endpoint_context;
 
 } // namespace broker::internal
 
+namespace broker::zeek {
+
+class Message;
+
+} // namespace broker::zeek
+
 namespace broker {
 
 /// The main publish/subscribe abstraction. Endpoints can *peer* with each
@@ -257,6 +263,17 @@ public:
   /// @param t The topic of the message.
   /// @param d The message data.
   void publish(const endpoint_info& dst, topic t, data d);
+
+  /// Publishes a message.
+  /// @param t The topic of the message.
+  /// @param d The message data.
+  void publish(std::string_view t, zeek::Message&& d);
+
+  /// Publishes a message to a specific peer endpoint only.
+  /// @param dst The destination endpoint.
+  /// @param t The topic of the message.
+  /// @param d The message data.
+  void publish(const endpoint_info& dst, std::string_view t, zeek::Message&& d);
 
   /// Publishes a message as vector.
   /// @param t The topic of the messages.

--- a/include/broker/message.hh
+++ b/include/broker/message.hh
@@ -212,6 +212,12 @@ inline const topic& get_topic(const data_message& x) {
   return get<0>(x);
 }
 
+/// Retrieves the topic from a ::command_message as a string.
+/// @relates data_message
+inline std::string get_topic_str(const data_message& x) {
+  return get_topic(x).string();
+}
+
 /// Retrieves the topic from a ::command_message.
 /// @relates data_message
 inline const topic& get_topic(const command_message& x) {

--- a/src/data.cc
+++ b/src/data.cc
@@ -93,6 +93,26 @@ const char* data::get_type_name() const {
 
 namespace {
 
+vector empty_vector;
+
+enum_value empty_enum_value;
+
+} // namespace
+
+const enum_value& data::to_enum_value() const noexcept {
+  if (auto* val = std::get_if<enum_value>(&data_))
+    return *val;
+  return empty_enum_value;
+}
+
+const vector& data::to_list() const {
+  if (auto ptr = std::get_if<vector>(&data_))
+    return *ptr;
+  return empty_vector;
+}
+
+namespace {
+
 template <class Container>
 void container_convert(Container& c, std::string& str, char left, char right) {
   constexpr auto* delim = ", ";

--- a/src/endpoint.cc
+++ b/src/endpoint.cc
@@ -19,6 +19,7 @@
 #include "broker/status_subscriber.hh"
 #include "broker/subscriber.hh"
 #include "broker/timeout.hh"
+#include "broker/zeek.hh"
 
 #include <caf/actor.hpp>
 #include <caf/actor_system.hpp>
@@ -819,6 +820,15 @@ void endpoint::publish(const endpoint_info& dst, topic t, data d) {
   BROKER_INFO("publishing" << std::make_pair(t, d) << "to" << dst.node);
   caf::anon_send(native(core_), atom::publish_v,
                  make_data_message(std::move(t), std::move(d)), dst);
+}
+
+void endpoint::publish(std::string_view t, zeek::Message&& d) {
+  publish(topic{std::string{t}}, d.move_data());
+}
+
+void endpoint::publish(const endpoint_info& dst, std::string_view t,
+                       zeek::Message&& d) {
+  publish(dst, topic{std::string{t}}, d.move_data());
 }
 
 void endpoint::publish(data_message x) {

--- a/src/zeek.cc
+++ b/src/zeek.cc
@@ -1,0 +1,64 @@
+#include "broker/zeek.hh"
+
+namespace broker::zeek {
+
+Message::~Message() {}
+
+Batch::Batch(data elements) : Message(std::move(elements)) {
+  if (!holds_alternative<vector>(data_))
+    return;
+  auto& outer = as_vector();
+  if (!holds_alternative<vector>(outer[2]))
+    return;
+  auto& items = get<vector>(outer[2]);
+  auto tmp = std::make_shared<Content>();
+  tmp->reserve(items.size());
+  auto append = [&tmp](auto&& msg) {
+    if (!msg.valid())
+      return false;
+    tmp->emplace_back(std::forward<decltype(msg)>(msg));
+    return true;
+  };
+  for (auto&& item : items) {
+    switch (Message::type(item)) {
+      case Message::Type::Event:
+        if (!append(zeek::Event{item}))
+          return;
+        break;
+      case Message::Type::LogCreate:
+        if (!append(zeek::LogCreate{item}))
+          return;
+        break;
+      case Message::Type::LogWrite:
+        if (!append(zeek::LogWrite{item}))
+          return;
+        break;
+      case Message::Type::IdentifierUpdate:
+        if (!append(zeek::IdentifierUpdate{item}))
+          return;
+        break;
+      case Message::Type::Batch:
+        if (!append(zeek::Batch{item}))
+          return;
+        break;
+      default:
+        return;
+    }
+  }
+  impl_ = std::move(tmp);
+}
+
+Batch BatchBuilder::build() {
+  vector tmp;
+  tmp.swap(inner_);
+  inner_.reserve(tmp.size());
+  vector outer;
+  outer.reserve(3);
+  outer.emplace_back(ProtocolVersion);
+  outer.emplace_back(static_cast<count>(Message::Type::Batch));
+  outer.emplace_back(std::move(tmp));
+  auto result = Batch{data{std::move(outer)}};
+  return result;
+}
+
+} // namespace broker::zeek


### PR DESCRIPTION
This PR mainly refactors the API in `zeek.hh` as preparation for the upcoming `variant` switch. However, the changes also address some rather nasty API details like implicit conversions all over the place and very verbose code in our `valid()` implementations that make it often hard to follow what's actually being checked.

- to make transition to `variant` easier, the Zeek-compatibility classes provide an interface from `data_message` now
- the new `BatchBuilder` gives an interface for assembling batches without manually pulling out the `data` member from Zeek message types