### PR TITLE
Fix Github edit links in top-right of HTML pages

### DIFF
--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -5,7 +5,7 @@
 {% if pagename != "search" %}
   {% if display_github %}
     {% if github_version == "master" %}
-      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
     {% endif %}
   {% elif show_source and has_source and sourcename %}
     <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>


### PR DESCRIPTION
These links 404'd because they omitted the file suffix, and they didn't really link to anything editable, just the raw file.

---

Beadcrumbs were relying on `suffix` which was available through sphinx_rtd_theme, but removed with readthedocs/sphinx_rtd_theme@c984d08dae206ae5f65176378e77efb852a278af.