### PR TITLE
Fix error::context

### DIFF
--- a/src/error.cc
+++ b/src/error.cc
@@ -144,10 +144,9 @@ const std::string* error::message() const noexcept {
 
 const endpoint_info* error::context() const noexcept {
   auto& msg = native(*this).context();
-  if (auto v = caf::make_const_typed_message_view<endpoint_info>(msg))
-    return std::addressof(get<0>(v));
-  else
-    return nullptr;
+  if (msg.match_element<endpoint_info>(0))
+    return std::addressof(msg.get_as<endpoint_info>(0));
+  return nullptr;
 }
 
 error::impl* error::native_ptr() noexcept {


### PR DESCRIPTION
Found this bug (with a Zeek btest) while working on the variants. An error will usually contain an `endpoint_info` and a `string`, so the `view` conversion will fail in this case. It's also overly restrictive, since we only care whether the endpoint is present but not what else might be in the error.