### PR TITLE
Fix MBR allocations for >= 1024 bytes

### DIFF
--- a/include/broker/detail/monotonic_buffer_resource.hh
+++ b/include/broker/detail/monotonic_buffer_resource.hh
@@ -11,7 +11,7 @@ namespace broker::detail {
 class monotonic_buffer_resource {
 public:
   monotonic_buffer_resource() {
-    allocate_block(nullptr);
+    allocate_block(nullptr, 0);
   }
 
   monotonic_buffer_resource(const monotonic_buffer_resource&) = delete;
@@ -38,7 +38,7 @@ private:
     void* bytes;
   };
 
-  void allocate_block(block* prev_block);
+  void allocate_block(block* prev_block, size_t min_size);
 
   void destroy() noexcept;
 


### PR DESCRIPTION
When trying to allocate a single object with size >= 1024, the current implementation crashes with a stack overflow. This patch allows blocks to exceed the hard-coded size limit to accommodate larger objects.

I'll also check whether we can get rid of this class entirely as a followup. It's just a placeholder until we can use [std::pmr::monotonic_buffer_resource](https://en.cppreference.com/w/cpp/memory/monotonic_buffer_resource).