### PR TITLE
Fix build with Python >= 3.12

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -74,11 +74,7 @@ if ( NOT PY_MOD_INSTALL_DIR )
   elseif (BROKER_PYTHON_HOME)
     file(TO_CMAKE_PATH "${BROKER_PYTHON_HOME}/lib/python" PY_MOD_INSTALL_DIR)
   else ()
-    execute_process(COMMAND ${Python_EXECUTABLE} -c
-      "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
-      OUTPUT_VARIABLE python_site_packages
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    file(TO_CMAKE_PATH ${python_site_packages} PY_MOD_INSTALL_DIR)
+    set(PY_MOD_INSTALL_DIR "${Python_SITEARCH}")
   endif ()
 endif ()
 message(STATUS "Python bindings will be built and installed to:")


### PR DESCRIPTION
The distutils package has been removed in Python 3.12. Hence, we need a different approach for finding the site-packages directory.

Using the `site` module for the job seems to be the simplest choice: https://docs.python.org/3/library/site.html#command-line-interface