### PR TITLE
Restore python-ssl test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ if (BROKER_PYTHON_BINDINGS)
   make_python_test(communication)
   make_python_test(data)
   make_python_test(forwarding)
-  # make_python_test(ssl-tests): re-enable after implementing SSL support
+  make_python_test(ssl-tests)
   make_python_test(store)
   make_python_test(topic)
   make_python_test(zeek-module)


### PR DESCRIPTION
Re-enable the SSL python test that got commented out at some point in development. It still functions as-is, so there's no point in disabling it.