### PR TITLE
Disable tools when building Broker as sub-project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,9 +295,11 @@ endif ()
 
 # -- Tools and benchmarks -----------------------------------------------------
 
-add_subdirectory(broker-node)
-add_subdirectory(broker-pipe)
-add_subdirectory(broker-throughput)
+if (NOT broker_is_subproject)
+  add_subdirectory(broker-node)
+  add_subdirectory(broker-pipe)
+  add_subdirectory(broker-throughput)
+endif ()
 
 # -- Bindings -----------------------------------------------------------------
 


### PR DESCRIPTION
Projects that build Broker only as a dependency (like Zeek) have no use for the benchmark tools. Hence, those targets should be excluded from the build to avoid building superfluous binaries but also since they might cause build issues in some scenarios.

@0xxon with this patch, Zeek builds in an Ubuntu 20.04 container again without issue.