### PR TITLE
Add missing dependency to serialization benchmark

### DIFF
--- a/tests/benchmarks/serialization/CMakeLists.txt
+++ b/tests/benchmarks/serialization/CMakeLists.txt
@@ -13,4 +13,5 @@ target_include_directories(broker-serialization-benchmark PRIVATE
 target_link_libraries(broker-serialization-benchmark
   PRIVATE
     benchmark::benchmark_main
-    ${BROKER_LIBRARY})
+    ${BROKER_LIBRARY}
+    CAF::core)


### PR DESCRIPTION
The `broker-serialization-benchmark` includes CAF headers, so it should also have that dependency in CMake.