### PR TITLE
Update cmake submodule to fix Zeek configure failures with FETCHCONTENT_FULLY_DISCONNECTED flag

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -161,18 +161,15 @@ alpine_task:
   << : *CI_TEMPLATE
   << : *UNIX_ENV
 
-# Apple doesn't publish official long-term support timelines.
-# We aim to support both the current and previous macOS release.
+# Cirrus only supports the following macos runner currently, selecting
+# anything else automatically upgrades to this one.
+#
+#    ghcr.io/cirruslabs/macos-runner:sonoma
+#
+# See also: https://cirrus-ci.org/guide/macOS/
 macos_sonoma_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-base:latest
-  prepare_script: ./ci/macos/prepare.sh
-  << : *CI_TEMPLATE
-  << : *MACOS_RESOURCES_TEMPLATE
-
-macos_ventura_task:
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_RESOURCES_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,8 +2,8 @@
 cpus: &CPUS 8
 memory: &MEMORY 24GB
 
-config: &CONFIG --build-type=release --enable-static
-memcheck_config: &MEMCHECK_CONFIG --build-type=debug --sanitizers=address
+config: &CONFIG --build-type=release --enable-static -D FETCHCONTENT_FULLY_DISCONNECTED:BOOL=ON
+memcheck_config: &MEMCHECK_CONFIG --build-type=debug --sanitizers=address -D FETCHCONTENT_FULLY_DISCONNECTED:BOOL=ON
 
 resources_template: &RESOURCES_TEMPLATE
   cpu: *CPUS


### PR DESCRIPTION
This also updates the broker CI setup to use the same flag.