### PR TITLE
Switch to clang-format 18 in CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,5 +37,7 @@ SpaceBeforeParens: ControlStatements
 SpacesBeforeTrailingComments: '1'
 Standard: Cpp11
 UseTab: Never
-
+---
+Language: Json
+DisableFormat: true
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@
 #
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v13.0.0'
+  rev: 'v18.1.8'
   hooks:
   - id: clang-format
-    exclude: ^tests/benchmark/readerwriterqueue/

--- a/bindings/python/_broker.cpp
+++ b/bindings/python/_broker.cpp
@@ -333,7 +333,7 @@ PYBIND11_MODULE(_broker, m) {
   // the standard class right at that point, one cannot pass an already
   // created one in, which is unfortunate.
   struct Configuration {
-    Configuration(){};
+    Configuration() {}
     Configuration(broker::broker_options opts) : options(std::move(opts)) {}
     broker::broker_options options = {};
     std::string openssl_cafile;

--- a/bindings/python/set_bind.h
+++ b/bindings/python/set_bind.h
@@ -64,8 +64,7 @@ void set_modifiers(
     "remove", [](Set& s, const T& x) { s.erase(x); }, arg("x"),
     "Removes an item from this set.");
 
-  cl.def(
-    "clear", [](Set& s) { s.clear(); }, "Empties this set.");
+  cl.def("clear", [](Set& s) { s.clear(); }, "Empties this set.");
 }
 
 // To iterate by copying objects, as std::set iterators are const.

--- a/libbroker/broker/alm/multipath.hh
+++ b/libbroker/broker/alm/multipath.hh
@@ -68,14 +68,14 @@ private:
 };
 
 template <class T, class U>
-auto operator==(node_iterator<T> x, node_iterator<U> y)
-  -> decltype(x.get() == y.get()) {
+auto operator==(node_iterator<T> x,
+                node_iterator<U> y) -> decltype(x.get() == y.get()) {
   return x.get() == y.get();
 }
 
 template <class T, class U>
-auto operator!=(node_iterator<T> x, node_iterator<U> y)
-  -> decltype(x.get() != y.get()) {
+auto operator!=(node_iterator<T> x,
+                node_iterator<U> y) -> decltype(x.get() != y.get()) {
   return x.get() != y.get();
 }
 

--- a/libbroker/broker/builder.hh
+++ b/libbroker/broker/builder.hh
@@ -54,8 +54,8 @@ struct builder_access {
   static Builder& add(Builder& builder, T&& value) {
     namespace bin_v1 = format::bin::v1;
     using value_type = std::decay_t<T>;
-    static_assert(variant_data::is_primitive<
-                    value_type> || detail::has_builder_access<value_type>,
+    static_assert(variant_data::is_primitive<value_type>
+                    || detail::has_builder_access<value_type>,
                   "T is neither a builder nor a recognized data type");
     using value_type = std::decay_t<T>;
     if constexpr (is_builder<value_type>) {
@@ -65,9 +65,8 @@ struct builder_access {
     } else {
       // Omit the tag for `variant` and `data`, because they will write it
       // themselves.
-      if constexpr (!std::is_same_v<
-                      value_type,
-                      variant> && !std::is_same_v<value_type, data>) {
+      if constexpr (!std::is_same_v<value_type, variant>
+                    && !std::is_same_v<value_type, data>) {
         bin_v1::write_unsigned(data_tag_v<value_type>, builder.adder());
       }
       bin_v1::encode(std::forward<T>(value), builder.adder());

--- a/libbroker/broker/data.hh
+++ b/libbroker/broker/data.hh
@@ -64,11 +64,10 @@ public:
       return detail::tag<count>{};
     } else if constexpr (std::is_signed_v<T>) {
       return detail::tag<integer>{};
-    } else if constexpr (
-      std::is_same_v<
-        T,
-        std::
-          string> || std::is_same_v<T, std::string_view> || std::is_same_v<T, char*> || std::is_same_v<T, const char*>) {
+    } else if constexpr (std::is_same_v<T, std::string>
+                         || std::is_same_v<T, std::string_view>
+                         || std::is_same_v<T, char*>
+                         || std::is_same_v<T, const char*>) {
       return detail::tag<std::string>{};
     } else if constexpr (std::is_same_v<T, timestamp>      //
                          || std::is_same_v<T, timespan>    //

--- a/libbroker/broker/detail/type_traits.hh
+++ b/libbroker/broker/detail/type_traits.hh
@@ -115,8 +115,8 @@ inline constexpr bool are_same_v = are_same<Ts...>::value;
 template <class From, class To>
 struct has_convert {
   template <class T>
-  static auto test(const T* x)
-    -> decltype(convert(*x, std::declval<To&>()), std::true_type());
+  static auto test(const T* x) -> decltype(convert(*x, std::declval<To&>()),
+                                           std::true_type());
 
   template <class T>
   static auto test(...) -> std::false_type;
@@ -240,9 +240,9 @@ inline constexpr bool is_tuple = is_tuple_oracle<T>::value;
   class has_encode_overload {                                                  \
   private:                                                                     \
     template <class U>                                                         \
-    static auto sfinae(U& y)                                                   \
-      -> decltype(::ns_name::encode(y, std::declval<OutIter&>()),              \
-                  std::true_type{});                                           \
+    static auto                                                                \
+    sfinae(U& y) -> decltype(::ns_name::encode(y, std::declval<OutIter&>()),   \
+                             std::true_type{});                                \
     static std::false_type sfinae(...);                                        \
     using result_type = decltype(sfinae(std::declval<T&>()));                  \
                                                                                \

--- a/libbroker/broker/expected.hh
+++ b/libbroker/broker/expected.hh
@@ -246,8 +246,8 @@ private:
 
 /// @relates expected
 template <class T>
-auto operator==(const expected<T>& x, const expected<T>& y)
-  -> decltype(*x == *y) {
+auto operator==(const expected<T>& x,
+                const expected<T>& y) -> decltype(*x == *y) {
   return x && y ? *x == *y : (!x && !y ? x.error() == y.error() : false);
 }
 
@@ -290,8 +290,8 @@ bool operator==(ec x, const expected<T>& y) {
 
 /// @relates expected
 template <class T>
-auto operator!=(const expected<T>& x, const expected<T>& y)
-  -> decltype(*x == *y) {
+auto operator!=(const expected<T>& x,
+                const expected<T>& y) -> decltype(*x == *y) {
   return !(x == y);
 }
 

--- a/libbroker/broker/internal/clone_actor.cc
+++ b/libbroker/broker/internal/clone_actor.cc
@@ -559,8 +559,7 @@ caf::behavior clone_state::make_behavior() {
         rp,
         [this, rp, id]() mutable {
           auto x = keys();
-          BROKER_INFO("KEYS"
-                      << "with id" << id << "->" << x);
+          BROKER_INFO("KEYS" << "with id" << id << "->" << x);
           rp.deliver(std::move(x), id);
         },
         id);

--- a/libbroker/broker/internal/master_actor.cc
+++ b/libbroker/broker/internal/master_actor.cc
@@ -553,8 +553,7 @@ caf::behavior master_state::make_behavior() {
     },
     [this](atom::get, atom::keys, request_id id) {
       auto x = backend->keys();
-      BROKER_INFO("KEYS"
-                  << "with id:" << id << "->" << x);
+      BROKER_INFO("KEYS" << "with id:" << id << "->" << x);
       if (x)
         return caf::make_message(std::move(*x), id);
       else

--- a/libbroker/broker/internal_command.cc
+++ b/libbroker/broker/internal_command.cc
@@ -2,17 +2,17 @@
 
 namespace broker {
 
-#define TO_STRING_CASE(name)                                                   \
-  name:                                                                        \
-  return #name;
-
 std::string to_string(command_tag x) {
   switch (x) {
-    TO_STRING_CASE(action)
-    TO_STRING_CASE(producer_control)
-    TO_STRING_CASE(consumer_control)
+    case command_tag::action:
+      return "action";
+    case command_tag::producer_control:
+      return "producer_control";
+    case command_tag::consumer_control:
+      return "consumer_control";
     default:
       return "???";
   }
 }
+
 } // namespace broker

--- a/libbroker/broker/intrusive_ptr.hh
+++ b/libbroker/broker/intrusive_ptr.hh
@@ -224,15 +224,15 @@ bool operator!=(const T* x, const intrusive_ptr<T>& y) {
 
 /// @relates intrusive_ptr
 template <class T, class U>
-auto operator==(const intrusive_ptr<T>& x, const intrusive_ptr<U>& y)
-  -> decltype(x.get() == y.get()) {
+auto operator==(const intrusive_ptr<T>& x,
+                const intrusive_ptr<U>& y) -> decltype(x.get() == y.get()) {
   return x.get() == y.get();
 }
 
 /// @relates intrusive_ptr
 template <class T, class U>
-auto operator!=(const intrusive_ptr<T>& x, const intrusive_ptr<U>& y)
-  -> decltype(x.get() != y.get()) {
+auto operator!=(const intrusive_ptr<T>& x,
+                const intrusive_ptr<U>& y) -> decltype(x.get() != y.get()) {
   return x.get() != y.get();
 }
 


### PR DESCRIPTION
Our CI still uses `clang-format` 13, which is ancient at this point. This PR updates CI to use the most recent version.