### PR TITLE
Replace CAF deserializers with Broker decoders

### DIFF
--- a/libbroker/broker/alm/multipath.hh
+++ b/libbroker/broker/alm/multipath.hh
@@ -229,8 +229,6 @@ private:
         }
         if (!down_.emplace(child)) {
           child->shallow_delete();
-          f.field_invariant_check_failed(
-            "a multipath may not contain duplicates");
           return false;
         }
       }

--- a/libbroker/broker/alm/multipath.test.cc
+++ b/libbroker/broker/alm/multipath.test.cc
@@ -1,11 +1,9 @@
 #include "broker/alm/multipath.hh"
 
 #include "broker/broker-test.test.hh"
+#include "broker/format/bin.hh"
 
 #include <random>
-
-#include <caf/binary_deserializer.hpp>
-#include <caf/binary_serializer.hpp>
 
 #include "broker/alm/routing_table.hh"
 
@@ -128,16 +126,16 @@ TEST(multipaths are serializable) {
     emplace(ab, 'G');
   }
   auto path = multipath{tptr};
-  caf::binary_serializer::container_type buf;
+  std::vector<std::byte> buf;
   MESSAGE("serializer the path into a buffer");
   {
-    caf::binary_serializer sink{nullptr, buf};
+    format::bin::v1::encoder sink{std::back_inserter(buf)};
     CHECK(sink.apply(path));
   }
   multipath copy;
   MESSAGE("deserializers a copy from the path from the buffer");
   {
-    caf::binary_deserializer source{nullptr, buf};
+    format::bin::v1::decoder source{buf.data(), buf.size()};
     CHECK(source.apply(copy));
   }
   MESSAGE("after a serialization roundtrip, the path is equal to its copy");

--- a/libbroker/broker/command_envelope.cc
+++ b/libbroker/broker/command_envelope.cc
@@ -8,7 +8,6 @@
 #include "broker/internal_command.hh"
 #include "broker/topic.hh"
 
-#include <caf/binary_deserializer.hpp>
 #include <caf/byte_buffer.hpp>
 #include <caf/deep_to_string.hpp>
 
@@ -145,7 +144,7 @@ public:
 
   error parse() {
     auto [data, data_size] = this->raw_bytes();
-    caf::binary_deserializer src{nullptr, data, data_size};
+    format::bin::v1::decoder src{data, data_size};
     if (!src.apply(value_))
       return make_error(ec::invalid_data);
     return error{};

--- a/libbroker/broker/command_envelope.cc
+++ b/libbroker/broker/command_envelope.cc
@@ -3,12 +3,12 @@
 #include "broker/endpoint_id.hh"
 #include "broker/error.hh"
 #include "broker/expected.hh"
+#include "broker/format/bin.hh"
 #include "broker/internal/type_id.hh"
 #include "broker/internal_command.hh"
 #include "broker/topic.hh"
 
 #include <caf/binary_deserializer.hpp>
-#include <caf/binary_serializer.hpp>
 #include <caf/byte_buffer.hpp>
 #include <caf/deep_to_string.hpp>
 
@@ -65,14 +65,16 @@ public:
       receiver_(receiver),
       topic_(std::move(topic_str)),
       value_(std::move(cmd)) {
-    caf::binary_serializer sink{nullptr, buf_};
+    auto out = std::back_inserter(buf_);
+    format::bin::v1::encoder sink{out};
     if (!sink.apply(value_))
       throw std::logic_error("failed to serialize command");
   }
 
   default_command_envelope(std::string&& topic_str, internal_command&& cmd)
     : topic_(topic_str), value_(std::move(cmd)) {
-    caf::binary_serializer sink{nullptr, buf_};
+    auto out = std::back_inserter(buf_);
+    format::bin::v1::encoder sink{out};
     if (!sink.apply(value_))
       throw std::logic_error("failed to serialize command");
   }

--- a/libbroker/broker/data.hh
+++ b/libbroker/broker/data.hh
@@ -325,6 +325,9 @@ public:
     return data_;
   }
 
+  /// Deserializes the data from a binary representation.
+  bool deserialize(const std::byte* payload, size_t payload_size);
+
 private:
   data_variant data_;
 };

--- a/libbroker/broker/detail/sqlite_backend.cc
+++ b/libbroker/broker/detail/sqlite_backend.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include <caf/binary_deserializer.hpp>
 #include <caf/detail/scope_guard.hpp>
 
 #include "broker/config.hh"
@@ -41,7 +40,7 @@ auto to_blob(const data& x) {
 }
 
 expected<data> from_blob(const void* buf, size_t size) {
-  caf::binary_deserializer sink{nullptr, buf, size};
+  format::bin::v1::decoder sink{buf, size};
   data result;
   if (sink.apply(result))
     return {std::move(result)};

--- a/libbroker/broker/detail/type_traits.hh
+++ b/libbroker/broker/detail/type_traits.hh
@@ -24,6 +24,16 @@ class topic;
 namespace broker::detail {
 
 template <class>
+struct is_duration_oracle : std::false_type {};
+
+template <class Rep, class Period>
+struct is_duration_oracle<std::chrono::duration<Rep, Period>> : std::true_type {
+};
+
+template <class T>
+inline constexpr bool is_duration = is_duration_oracle<T>::value;
+
+template <class>
 struct is_variant_oracle : std::false_type {};
 
 template <class... Ts>

--- a/libbroker/broker/detail/type_traits.hh
+++ b/libbroker/broker/detail/type_traits.hh
@@ -6,8 +6,10 @@
 #include <list>
 #include <map>
 #include <optional>
+#include <set>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -62,6 +64,18 @@ struct is_map_oracle<std::unordered_map<Key, Val>> : std::true_type {};
 
 template <class T>
 inline constexpr bool is_map = is_map_oracle<T>::value;
+
+template <class>
+struct is_set_oracle : std::false_type {};
+
+template <class Key, class Val>
+struct is_set_oracle<std::set<Key, Val>> : std::true_type {};
+
+template <class Key, class Val>
+struct is_set_oracle<std::unordered_set<Key, Val>> : std::true_type {};
+
+template <class T>
+inline constexpr bool is_set = is_set_oracle<T>::value;
 
 template <class>
 struct is_list_oracle : std::false_type {};

--- a/libbroker/broker/detail/type_traits.hh
+++ b/libbroker/broker/detail/type_traits.hh
@@ -252,3 +252,21 @@ inline constexpr bool is_tuple = is_tuple_oracle<T>::value;
   template <class T, class OutIter>                                            \
   inline constexpr bool has_encode_overload_v =                                \
     has_encode_overload<T, OutIter>::value
+
+#define BROKER_DEF_HAS_DECODE_IN_NS(ns_name)                                   \
+  template <class T, class OutIter>                                            \
+  class has_decode_overload {                                                  \
+  private:                                                                     \
+    template <class U>                                                         \
+    static auto                                                                \
+    sfinae(U& y) -> decltype(::ns_name::decode(y, std::declval<OutIter&>()),   \
+                             std::true_type{});                                \
+    static std::false_type sfinae(...);                                        \
+    using result_type = decltype(sfinae(std::declval<T&>()));                  \
+                                                                               \
+  public:                                                                      \
+    static constexpr bool value = result_type::value;                          \
+  };                                                                           \
+  template <class T, class OutIter>                                            \
+  inline constexpr bool has_decode_overload_v =                                \
+    has_decode_overload<T, OutIter>::value

--- a/libbroker/broker/format/bin.cc
+++ b/libbroker/broker/format/bin.cc
@@ -51,12 +51,53 @@ bool read(const_byte_pointer& first, const_byte_pointer last,
 }
 
 bool read(const_byte_pointer& first, const_byte_pointer last,
+          uint32_t& result) {
+  if (first + sizeof(uint32_t) > last)
+    return false;
+  memcpy(&result, first, sizeof(uint32_t));
+  first += sizeof(uint32_t);
+  result = caf::detail::from_network_order(result);
+  return true;
+}
+
+bool read(const_byte_pointer& first, const_byte_pointer last,
           uint64_t& result) {
   if (first + sizeof(uint64_t) > last)
     return false;
   memcpy(&result, first, sizeof(uint64_t));
   first += sizeof(uint64_t);
   result = caf::detail::from_network_order(result);
+  return true;
+}
+
+bool read(const_byte_pointer& first, const_byte_pointer last, int8_t& result) {
+  if (first == last)
+    return false;
+  result = static_cast<int8_t>(*first++);
+  return true;
+}
+
+bool read(const_byte_pointer& first, const_byte_pointer last, int16_t& result) {
+  uint16_t tmp = 0;
+  if (!read(first, last, tmp))
+    return false;
+  result = static_cast<int16_t>(tmp);
+  return true;
+}
+
+bool read(const_byte_pointer& first, const_byte_pointer last, int32_t& result) {
+  uint32_t tmp = 0;
+  if (!read(first, last, tmp))
+    return false;
+  result = static_cast<int32_t>(tmp);
+  return true;
+}
+
+bool read(const_byte_pointer& first, const_byte_pointer last, int64_t& result) {
+  uint64_t tmp = 0;
+  if (!read(first, last, tmp))
+    return false;
+  result = static_cast<int64_t>(tmp);
   return true;
 }
 

--- a/libbroker/broker/format/bin.cc
+++ b/libbroker/broker/format/bin.cc
@@ -33,6 +33,41 @@ double float64_from_network_representation(uint64_t value) {
   return caf::detail::unpack754(value);
 }
 
+bool read(const_byte_pointer& first, const_byte_pointer last, uint8_t& result) {
+  if (first == last)
+    return false;
+  result = static_cast<uint8_t>(*first++);
+  return true;
+}
+
+bool read(const_byte_pointer& first, const_byte_pointer last,
+          uint16_t& result) {
+  if (first + sizeof(uint16_t) > last)
+    return false;
+  memcpy(&result, first, sizeof(uint16_t));
+  first += sizeof(uint16_t);
+  result = caf::detail::from_network_order(result);
+  return true;
+}
+
+bool read(const_byte_pointer& first, const_byte_pointer last,
+          uint64_t& result) {
+  if (first + sizeof(uint64_t) > last)
+    return false;
+  memcpy(&result, first, sizeof(uint64_t));
+  first += sizeof(uint64_t);
+  result = caf::detail::from_network_order(result);
+  return true;
+}
+
+bool read(const_byte_pointer& first, const_byte_pointer last, double& result) {
+  uint64_t tmp = 0;
+  if (!read(first, last, tmp))
+    return false;
+  result = float64_from_network_representation(tmp);
+  return true;
+}
+
 bool read_varbyte(const_byte_pointer& first, const_byte_pointer last,
                   size_t& result) {
   // Use varbyte encoding to compress sequence size on the wire.

--- a/libbroker/broker/format/bin.hh
+++ b/libbroker/broker/format/bin.hh
@@ -582,50 +582,50 @@ decode(const std::byte* pos, const std::byte* end, Handler& handler) {
       size_t size = 0;
       if (!format::bin::v1::read_varbyte(pos, end, size))
         return {false, pos};
-      handler.begin_set();
+      auto&& nested = handler.begin_set();
       for (size_t i = 0; i < size; ++i) {
-        auto [ok, next] = decode(pos, end, handler);
+        auto [ok, next] = decode(pos, end, nested);
         if (!ok)
           return {false, pos};
         pos = next;
       }
-      handler.end_set();
+      handler.end_set(nested);
       return {true, pos};
     }
     case variant_tag::table: {
       size_t size = 0;
       if (!format::bin::v1::read_varbyte(pos, end, size))
         return {false, pos};
-      handler.begin_table();
+      auto&& nested = handler.begin_table();
       for (size_t i = 0; i < size; ++i) {
-        handler.begin_key_value_pair();
-        if (auto [ok, next] = decode(pos, end, handler); ok) {
+        nested.begin_key_value_pair();
+        if (auto [ok, next] = decode(pos, end, nested); ok) {
           pos = next;
         } else {
           return {false, next};
         }
-        if (auto [ok, next] = decode(pos, end, handler); ok) {
+        if (auto [ok, next] = decode(pos, end, nested); ok) {
           pos = next;
         } else {
           return {false, next};
         }
-        handler.end_key_value_pair();
+        nested.end_key_value_pair();
       }
-      handler.end_table();
+      handler.end_table(nested);
       return {true, pos};
     }
     case variant_tag::list: {
       size_t size = 0;
       if (!format::bin::v1::read_varbyte(pos, end, size))
         return {false, pos};
-      handler.begin_list();
+      auto&& nested = handler.begin_list();
       for (size_t i = 0; i < size; ++i) {
-        auto [ok, next] = decode(pos, end, handler);
+        auto [ok, next] = decode(pos, end, nested);
         if (!ok)
           return {false, next};
         pos = next;
       }
-      handler.end_list();
+      handler.end_list(nested);
       return {true, pos};
     }
     default:

--- a/libbroker/broker/format/bin.hh
+++ b/libbroker/broker/format/bin.hh
@@ -584,7 +584,8 @@ decode(const std::byte* pos, const std::byte* end, Handler& handler) {
       auto proto = uint8_t{0};
       if (!read(pos, end, proto))
         return {false, pos};
-      if (proto > 3) // 3 is the highest protocol number we support (ICMP).
+      // ICMP has the highest protocol number we support
+      if (proto > static_cast<uint8_t>(port::protocol::icmp))
         return {false, end};
       return {handler.value(port{num, static_cast<port::protocol>(proto)}),
               pos};

--- a/libbroker/broker/format/bin.test.cc
+++ b/libbroker/broker/format/bin.test.cc
@@ -147,37 +147,33 @@ struct dummy_decoder_handler {
   int indent = 0;
   std::string log;
 
-  bool value(none) {
+  void value(none) {
     log.insert(log.end(), indent, ' ');
     log += "value: none\n";
-    return true;
   }
 
-  bool value(bool arg) {
+  void value(bool arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += arg ? "true" : "false";
     log += "\n";
-    return true;
   }
 
-  bool value(broker::count arg) {
+  void value(broker::count arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg);
     log += " [count]\n";
-    return true;
   }
 
-  bool value(broker::integer arg) {
+  void value(broker::integer arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg);
     log += " [integer]\n";
-    return true;
   }
 
-  bool value(broker::real arg) {
+  void value(broker::real arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg);
@@ -187,119 +183,106 @@ struct dummy_decoder_handler {
     if (log.back() == '.')
       log.pop_back();
     log += " [real]\n";
-    return true;
   }
 
-  bool value(std::string_view arg) {
+  void value(std::string_view arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += arg;
     log += "\n";
-    return true;
   }
 
-  bool value(enum_value_view arg) {
+  void value(enum_value_view arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += arg.name;
     log += " [enum]\n";
-    return true;
   }
 
-  bool value(address arg) {
+  void value(address arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += broker::to_string(arg);
     log += "\n";
-    return true;
   }
 
-  bool value(subnet arg) {
+  void value(subnet arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += broker::to_string(arg);
     log += "\n";
-    return true;
   }
 
-  bool value(port arg) {
+  void value(port arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += broker::to_string(arg);
     log += "\n";
-    return true;
   }
 
-  bool value(timespan arg) {
+  void value(timespan arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg.count());
     log += " [timespan]\n";
-    return true;
   }
 
-  bool value(timestamp arg) {
+  void value(timestamp arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg.time_since_epoch().count());
     log += " [timestamp]\n";
-    return true;
   }
 
-  bool begin_list() {
+  dummy_decoder_handler& begin_list() {
     log.insert(log.end(), indent, ' ');
     log += "begin list\n";
     indent += 2;
-    return true;
+    return *this;
   }
 
-  bool end_list() {
+  void end_list(dummy_decoder_handler&) {
     indent -= 2;
     log.insert(log.end(), indent, ' ');
     log += "end list\n";
-    return true;
   }
 
-  bool begin_set() {
+  dummy_decoder_handler& begin_set() {
     log.insert(log.end(), indent, ' ');
     log += "begin set\n";
     indent += 2;
-    return true;
+    return *this;
   }
 
-  bool end_set() {
+  void end_set(dummy_decoder_handler&) {
     indent -= 2;
     log.insert(log.end(), indent, ' ');
     log += "end set\n";
-    return true;
   }
 
-  bool begin_table() {
+  dummy_decoder_handler& begin_table() {
     log.insert(log.end(), indent, ' ');
     log += "begin table\n";
     indent += 2;
-    return true;
+    return *this;
   }
 
-  bool end_table() {
+  void end_table(dummy_decoder_handler&) {
     indent -= 2;
     log.insert(log.end(), indent, ' ');
     log += "end table\n";
-    return true;
   }
 
-  bool begin_key_value_pair() {
+  void begin_key_value_pair() {
     log.insert(log.end(), indent, ' ');
     log += "begin key-value-pair\n";
     indent += 2;
-    return true;
   }
 
-  bool end_key_value_pair() {
+  void end_key_value_pair() {
     indent -= 2;
     log.insert(log.end(), indent, ' ');
     log += "end key-value-pair\n";
-    return true;
   }
 };
 
@@ -317,17 +300,6 @@ std::string do_decode(T&& arg) {
     FAIL("decoding did not consume the entire input");
   }
   return std::move(handler.log);
-}
-
-template <class T>
-data do_deserialize(T&& arg) {
-  auto input = data{std::forward<T>(arg)};
-  auto buf = apply_encoder<std::byte>(input);
-  data result;
-  if (!result.deserialize(buf.data(), buf.size())) {
-    FAIL("deserialization failed");
-  }
-  return result;
 }
 
 } // namespace

--- a/libbroker/broker/format/bin.test.cc
+++ b/libbroker/broker/format/bin.test.cc
@@ -147,33 +147,37 @@ struct dummy_decoder_handler {
   int indent = 0;
   std::string log;
 
-  void value(none) {
+  bool value(none) {
     log.insert(log.end(), indent, ' ');
     log += "value: none\n";
+    return true;
   }
 
-  void value(bool arg) {
+  bool value(bool arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += arg ? "true" : "false";
     log += "\n";
+    return true;
   }
 
-  void value(broker::count arg) {
+  bool value(broker::count arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg);
     log += " [count]\n";
+    return true;
   }
 
-  void value(broker::integer arg) {
+  bool value(broker::integer arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg);
     log += " [integer]\n";
+    return true;
   }
 
-  void value(broker::real arg) {
+  bool value(broker::real arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg);
@@ -183,55 +187,63 @@ struct dummy_decoder_handler {
     if (log.back() == '.')
       log.pop_back();
     log += " [real]\n";
+    return true;
   }
 
-  void value(std::string_view arg) {
+  bool value(std::string_view arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += arg;
     log += "\n";
+    return true;
   }
 
-  void value(enum_value_view arg) {
+  bool value(enum_value_view arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += arg.name;
     log += " [enum]\n";
+    return true;
   }
 
-  void value(address arg) {
+  bool value(address arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += broker::to_string(arg);
     log += "\n";
+    return true;
   }
 
-  void value(subnet arg) {
+  bool value(subnet arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += broker::to_string(arg);
     log += "\n";
+    return true;
   }
 
-  void value(port arg) {
+  bool value(port arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += broker::to_string(arg);
     log += "\n";
+    return true;
   }
 
-  void value(timespan arg) {
+  bool value(timespan arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg.count());
     log += " [timespan]\n";
+    return true;
   }
 
-  void value(timestamp arg) {
+  bool value(timestamp arg) {
     log.insert(log.end(), indent, ' ');
     log += "value: ";
     log += std::to_string(arg.time_since_epoch().count());
     log += " [timestamp]\n";
+    return true;
   }
 
   dummy_decoder_handler& begin_list() {
@@ -241,10 +253,11 @@ struct dummy_decoder_handler {
     return *this;
   }
 
-  void end_list(dummy_decoder_handler&) {
+  bool end_list(dummy_decoder_handler&) {
     indent -= 2;
     log.insert(log.end(), indent, ' ');
     log += "end list\n";
+    return true;
   }
 
   dummy_decoder_handler& begin_set() {
@@ -254,10 +267,11 @@ struct dummy_decoder_handler {
     return *this;
   }
 
-  void end_set(dummy_decoder_handler&) {
+  bool end_set(dummy_decoder_handler&) {
     indent -= 2;
     log.insert(log.end(), indent, ' ');
     log += "end set\n";
+    return true;
   }
 
   dummy_decoder_handler& begin_table() {
@@ -267,10 +281,11 @@ struct dummy_decoder_handler {
     return *this;
   }
 
-  void end_table(dummy_decoder_handler&) {
+  bool end_table(dummy_decoder_handler&) {
     indent -= 2;
     log.insert(log.end(), indent, ' ');
     log += "end table\n";
+    return true;
   }
 
   void begin_key_value_pair() {

--- a/libbroker/broker/format/bin.test.cc
+++ b/libbroker/broker/format/bin.test.cc
@@ -446,6 +446,6 @@ TEST(the decoder can deserialize the output of the encoder) {
   CHECK_EQ(cpy.sender, cmd.sender);
   CHECK_EQ(cpy.receiver, cmd.receiver);
   if (CHECK(std::holds_alternative<cumulative_ack_command>(cpy.content))) {
-    CHECK_EQ(std::get<cumulative_ack_command>(cpy.content).seq, 42);
+    CHECK_EQ(std::get<cumulative_ack_command>(cpy.content).seq, 42u);
   }
 }

--- a/libbroker/broker/format/bin.test.cc
+++ b/libbroker/broker/format/bin.test.cc
@@ -18,9 +18,9 @@ auto apply_serialize(const T& value) {
   return buf;
 }
 
-template <class T>
+template <class Out = caf::byte, class T>
 auto apply_encoder(const T& value) {
-  std::vector<caf::byte> buf;
+  std::vector<Out> buf;
   format::bin::v1::encoder sink{std::back_inserter(buf)};
   if (!sink.apply(value))
     FAIL("serialization failed");
@@ -139,4 +139,243 @@ TEST(the encoder emits the same output for data as a binary serializer) {
   CHECK_EQ_ENCODE_OBJ((internal_command{
     123, {eid, 1}, {eid, 2}, {retransmit_failed_command{42}}}));
   CHECK_EQ_ENCODE_OBJ(network_info("192.168.9.2", 8080, timeout::seconds{1}));
+}
+
+namespace {
+
+struct dummy_decoder_handler {
+  int indent = 0;
+  std::string log;
+
+  bool value(none) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: none\n";
+    return true;
+  }
+
+  bool value(bool arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += arg ? "true" : "false";
+    log += "\n";
+    return true;
+  }
+
+  bool value(broker::count arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += std::to_string(arg);
+    log += " [count]\n";
+    return true;
+  }
+
+  bool value(broker::integer arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += std::to_string(arg);
+    log += " [integer]\n";
+    return true;
+  }
+
+  bool value(broker::real arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += std::to_string(arg);
+    // Drop trailing zeros.
+    log.erase(log.find_last_not_of('0') + 1);
+    // Drop trailing dot.
+    if (log.back() == '.')
+      log.pop_back();
+    log += " [real]\n";
+    return true;
+  }
+
+  bool value(std::string_view arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += arg;
+    log += "\n";
+    return true;
+  }
+
+  bool value(enum_value_view arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += arg.name;
+    log += " [enum]\n";
+    return true;
+  }
+
+  bool value(address arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += broker::to_string(arg);
+    log += "\n";
+    return true;
+  }
+
+  bool value(subnet arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += broker::to_string(arg);
+    log += "\n";
+    return true;
+  }
+
+  bool value(port arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += broker::to_string(arg);
+    log += "\n";
+    return true;
+  }
+
+  bool value(timespan arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += std::to_string(arg.count());
+    log += " [timespan]\n";
+    return true;
+  }
+
+  bool value(timestamp arg) {
+    log.insert(log.end(), indent, ' ');
+    log += "value: ";
+    log += std::to_string(arg.time_since_epoch().count());
+    log += " [timestamp]\n";
+    return true;
+  }
+
+  bool begin_list() {
+    log.insert(log.end(), indent, ' ');
+    log += "begin list\n";
+    indent += 2;
+    return true;
+  }
+
+  bool end_list() {
+    indent -= 2;
+    log.insert(log.end(), indent, ' ');
+    log += "end list\n";
+    return true;
+  }
+
+  bool begin_set() {
+    log.insert(log.end(), indent, ' ');
+    log += "begin set\n";
+    indent += 2;
+    return true;
+  }
+
+  bool end_set() {
+    indent -= 2;
+    log.insert(log.end(), indent, ' ');
+    log += "end set\n";
+    return true;
+  }
+
+  bool begin_table() {
+    log.insert(log.end(), indent, ' ');
+    log += "begin table\n";
+    indent += 2;
+    return true;
+  }
+
+  bool end_table() {
+    indent -= 2;
+    log.insert(log.end(), indent, ' ');
+    log += "end table\n";
+    return true;
+  }
+
+  bool begin_key_value_pair() {
+    log.insert(log.end(), indent, ' ');
+    log += "begin key-value-pair\n";
+    indent += 2;
+    return true;
+  }
+
+  bool end_key_value_pair() {
+    indent -= 2;
+    log.insert(log.end(), indent, ' ');
+    log += "end key-value-pair\n";
+    return true;
+  }
+};
+
+template <class T>
+std::string do_decode(T&& arg) {
+  auto input = data{std::forward<T>(arg)};
+  auto buf = apply_encoder<std::byte>(input);
+  dummy_decoder_handler handler;
+  auto [ok, pos] = format::bin::v1::decode(buf.data(), buf.data() + buf.size(),
+                                           handler);
+  if (!ok) {
+    FAIL("decoding failed at position "s + std::to_string(pos - buf.data()));
+  }
+  if (pos != buf.data() + buf.size()) {
+    FAIL("decoding did not consume the entire input");
+  }
+  return std::move(handler.log);
+}
+
+template <class T>
+data do_deserialize(T&& arg) {
+  auto input = data{std::forward<T>(arg)};
+  auto buf = apply_encoder<std::byte>(input);
+  data result;
+  if (!result.deserialize(buf.data(), buf.size())) {
+    FAIL("deserialization failed");
+  }
+  return result;
+}
+
+} // namespace
+
+TEST(the decoder produces a series of events) {
+  CHECK_EQ(do_decode(data{}), "value: none\n");
+  CHECK_EQ(do_decode(true), "value: true\n");
+  CHECK_EQ(do_decode(count{42}), "value: 42 [count]\n");
+  CHECK_EQ(do_decode(integer{42}), "value: 42 [integer]\n");
+  CHECK_EQ(do_decode(real{1.2}), "value: 1.2 [real]\n");
+  CHECK_EQ(do_decode("FooBar"s), "value: FooBar\n");
+  CHECK_EQ(do_decode(addr("192.168.9.8")), "value: 192.168.9.8\n");
+  CHECK_EQ(do_decode(snet("192.168.9.0/24")), "value: 192.168.9.0/24\n");
+  CHECK_EQ(do_decode(port(8080, port::protocol::tcp)), "value: 8080/tcp\n");
+  CHECK_EQ(do_decode(timestamp{timespan{12345}}), "value: 12345 [timestamp]\n");
+  CHECK_EQ(do_decode(timespan{12345}), "value: 12345 [timespan]\n");
+  CHECK_EQ(do_decode(enum_value{"FooBar"}), "value: FooBar [enum]\n");
+  CHECK_EQ(do_decode(set{}), // empty set
+           "begin set\n"
+           "end set\n");
+  CHECK_EQ(do_decode(set{data{count{1}}, data{count{2}}}),
+           "begin set\n"
+           "  value: 1 [count]\n"
+           "  value: 2 [count]\n"
+           "end set\n");
+  CHECK_EQ(do_decode(vector{}), // empty list
+           "begin list\n"
+           "end list\n");
+  CHECK_EQ(do_decode(vector{data{count{1}}, data{count{2}}}),
+           "begin list\n"
+           "  value: 1 [count]\n"
+           "  value: 2 [count]\n"
+           "end list\n");
+  CHECK_EQ(do_decode(table{}), // empty table
+           "begin table\n"
+           "end table\n");
+  CHECK_EQ(do_decode(table{
+             {data{"a"}, data{count{1}}},
+             {data{"b"}, data{count{2}}},
+           }),
+           "begin table\n"
+           "  begin key-value-pair\n"
+           "    value: a\n"
+           "    value: 1 [count]\n"
+           "  end key-value-pair\n"
+           "  begin key-value-pair\n"
+           "    value: b\n"
+           "    value: 2 [count]\n"
+           "  end key-value-pair\n"
+           "end table\n");
 }

--- a/libbroker/broker/internal/wire_format.cc
+++ b/libbroker/broker/internal/wire_format.cc
@@ -6,7 +6,6 @@
 #include "broker/internal/logger.hh"
 #include "broker/internal/native.hh"
 
-#include <caf/binary_deserializer.hpp>
 #include <caf/byte_buffer.hpp>
 #include <caf/byte_span.hpp>
 #include <caf/detail/append_hex.hpp>
@@ -157,11 +156,9 @@ std::string stringify(const var_msg& msg) {
   case type::tag: {                                                            \
     type tmp;                                                                  \
     if (!src.apply(tmp)) {                                                     \
-      BROKER_ERROR("decode: failed to read a" << #type << ":"                  \
-                                              << src.get_error());             \
+      BROKER_ERROR("decode: failed to read a" << #type);                       \
       return make_var_msg_error(ec::invalid_message,                           \
-                                "failed to parse " #type ":"                   \
-                                  + to_string(src.get_error()));               \
+                                "failed to parse " #type);                     \
     }                                                                          \
     if (auto [code, descr] = check(tmp); code != ec::none) {                   \
       return make_var_msg_error(code, std::string{descr});                     \
@@ -170,10 +167,10 @@ std::string stringify(const var_msg& msg) {
   }
 
 var_msg decode(caf::const_byte_span bytes) {
-  caf::binary_deserializer src{nullptr, bytes};
+  format::bin::v1::decoder src{bytes.data(), bytes.size()};
   auto msg_type = p2p_message_type{0};
   if (!src.apply(msg_type)) {
-    BROKER_ERROR("decode: failed to read the type tag:" << src.get_error());
+    BROKER_ERROR("decode: failed to read the type tag");
     return make_var_msg_error(ec::invalid_message, "invalid message type tag"s);
   }
   switch (msg_type) {

--- a/libbroker/broker/timeout.hh
+++ b/libbroker/broker/timeout.hh
@@ -1,19 +1,26 @@
 #pragma once
 
-#include "broker/time.hh"
+#include <chrono>
+#include <cstdint>
+#include <ratio>
 
 namespace broker::timeout {
 
-using std::chrono::milliseconds;
-using std::chrono::seconds;
+/// Represents a timeout in milliseconds with a fixed integer type (unlike
+/// std::chrono::milliseconds).
+using milliseconds = std::chrono::duration<int64_t, std::milli>;
+
+/// Represents a timeout in seconds with a fixed integer type (unlike
+/// std::chrono::seconds).
+using seconds = std::chrono::duration<int64_t>;
 
 /// Timeout when peering between two brokers.
-constexpr auto peer = seconds(10);
+constexpr auto peer = seconds{10};
 
 /// Timeout when subscribing to a topic.
-constexpr auto subscribe = seconds(5);
+constexpr auto subscribe = seconds{5};
 
 /// Timeout for interacting with a data store frontend
-constexpr auto frontend = seconds(10);
+constexpr auto frontend = seconds{10};
 
 } // namespace broker::timeout

--- a/libbroker/broker/variant.test.cc
+++ b/libbroker/broker/variant.test.cc
@@ -12,6 +12,7 @@
 
 #include "broker/convert.hh"
 #include "broker/data.hh"
+#include "broker/format/bin.hh"
 #include "broker/variant_list.hh"
 #include "broker/variant_set.hh"
 #include "broker/variant_table.hh"
@@ -29,6 +30,8 @@ namespace {
 
 using byte_buffer = caf::byte_buffer;
 
+using bin_decoder = format::bin::v1::decoder;
+
 std::string to_hex(const byte_buffer& buf) {
   std::string result;
   caf::detail::append_hex(result, buf.data(), buf.size());
@@ -41,12 +44,13 @@ byte_buffer make_bytes(Ts... xs) {
 }
 
 bool convert(const byte_buffer& bytes, data& value) {
-  caf::binary_deserializer source{nullptr, bytes};
+  bin_decoder source{reinterpret_cast<const std::byte*>(bytes.data()),
+                     bytes.size()};
   return source.apply(value);
 }
 
 bool convert(const data& value, byte_buffer& bytes) {
-  caf::binary_serializer sink{nullptr, bytes};
+  format::bin::v1::encoder sink{std::back_inserter(bytes)};
   return sink.apply(value);
 }
 


### PR DESCRIPTION
When implementing the new networking layer and `broker::variant`, we have implemented encoders for the binary serialization format. However, the decoding has only been implemented for `broker::variant`.

This set of changes implements the decoding as well, meaning that Broker is now fully "self-hosted" and no longer relies on the binary serialization primitives in CAF which make no guarantees on the stability of the format.

There are two "flavors" for the decoding:
- A free `decode` function with a SAX-like interface. This function is tailored towards Broker's type system and can be used for decoding `broker::variant` and `broker::data`.
- A `decoder` class that is designed to work with the `inspect` API. We use this as a drop-in replacement for `caf::deserializer`, e.g., when decoding store commands.

Closes #161.