### PR TITLE
Bump dockerfiles for Fedora 39 and 40

### DIFF
--- a/ci/fedora-39/Dockerfile
+++ b/ci/fedora-39/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:39
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20231213
+ENV DOCKERFILE_VERSION 20241106
 
 RUN dnf -y install \
     cmake \

--- a/ci/fedora-40/Dockerfile
+++ b/ci/fedora-40/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:40
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20240524
+ENV DOCKERFILE_VERSION 20241106
 
 RUN dnf -y install \
     cmake \


### PR DESCRIPTION
Attempt to bring CI coverage back for Fedora 39 and 40.