### PR TITLE
Provide reason string in forced disconnects to allow Zeek to identify backpressure overflow, plus two fixes

### DIFF
--- a/libbroker/broker/expected.hh
+++ b/libbroker/broker/expected.hh
@@ -40,6 +40,12 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
+  template <class U>
+  expected(U x, std::enable_if_t<std::is_convertible_v<U, T>>* = nullptr)
+    : engaged_(true) {
+    new (std::addressof(value_)) T(std::move(x));
+  }
+
   expected(T&& x) noexcept(nothrow_move) : engaged_(true) {
     new (std::addressof(value_)) T(std::move(x));
   }

--- a/libbroker/broker/internal/connector.cc
+++ b/libbroker/broker/internal/connector.cc
@@ -1944,7 +1944,8 @@ void connector::run_impl(listener* sub, shared_filter_type* filter) {
           } else {
             mgr.abort(*i);
           }
-          while ((i->revents & read_mask) && mgr.must_read_more(*i))
+          while ((i->revents & read_mask) && (i->events & read_mask)
+                 && mgr.must_read_more(*i))
             mgr.continue_reading(*i);
         }
       } while (--presult > 0 && advance());

--- a/libbroker/broker/internal/core_actor.cc
+++ b/libbroker/broker/internal/core_actor.cc
@@ -564,7 +564,7 @@ void core_actor_state::shutdown(shutdown_options options) {
 void core_actor_state::finalize_shutdown() {
   // Drop any remaining state of peers.
   for (auto& kvp : peers)
-    kvp.second->force_disconnect();
+    kvp.second->force_disconnect("shutting down");
   peers.clear();
   // Close the shared state for all peers.
   peer_statuses->close();
@@ -873,7 +873,7 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer_id,
       .on_backpressure_buffer(peer_buffer_size(), peer_overflow_policy())
       .do_on_error([this, ptr, peer_id](const caf::error& what) {
         BROKER_INFO("remove peer" << peer_id << "due to:" << what);
-        ptr->force_disconnect();
+        ptr->force_disconnect(to_string(what));
       })
       .as_observable());
   // Push messages received from the peer into the central merge point.

--- a/libbroker/broker/internal/peering.hh
+++ b/libbroker/broker/internal/peering.hh
@@ -38,7 +38,7 @@ public:
 
   /// Forces the peering to shut down its connection without performing the BYE
   /// handshake.
-  void force_disconnect();
+  void force_disconnect(std::string reason);
 
   void schedule_bye_timeout(caf::scheduled_actor* self);
 
@@ -61,6 +61,11 @@ public:
   /// Queries whether `remove` was called.
   bool removed() const noexcept {
     return removed_;
+  }
+
+  /// Returns the removal reason, which may be empty.
+  const std::string& removed_reason() const noexcept {
+    return removed_reason_;
   }
 
   /// Tag this peering as removed and send a BYE message on the `snk` for a
@@ -116,6 +121,8 @@ private:
   /// Indicates whether we have explicitly removed this connection by sending a
   /// BYE message to the peer.
   bool removed_ = false;
+
+  std::string removed_reason_;
 
   /// Network address as reported from the transport (usually TCP).
   network_info addr_;


### PR DESCRIPTION
@Neverlord could you let me know if this looks okay to you? The reason-string support should hopefully be straightforward.

More interesting is ecb9aeaa, which I encountered while testing cluster recovery after forced disconnects: around half of the time the while-loop in `connector::run_impl()` ended up in a situation where it kept trying to read but failed, without realizing it had encountered an error. I'm simply adding a check of the requested-event poll mask, which seems to be resolving it.

I also noticed that Broker's master currently doesn't build with Zeek. I narrowed this down to a part of 4d9aa3bd, which I'm simply reverting here. It doesn't seem to have any impact on clang-tidy, but let me know if I'm missing anything.

Thanks!