### PR TITLE
CI Updates

### DIFF
--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230823
+ENV DOCKERFILE_VERSION=20230823
 
 RUN apk add --no-cache \
   bash \

--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream9
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION=20220519
 
 RUN dnf -y install \
     cmake \

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230813
+ENV DOCKERFILE_VERSION=20230813
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230612
+ENV DOCKERFILE_VERSION=20230612
 
 RUN apt-get update && apt-get -y install \
     clang \

--- a/ci/fedora-35/Dockerfile
+++ b/ci/fedora-35/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:35
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION=20220519
 
 RUN dnf -y install \
     cmake \

--- a/ci/fedora-40/Dockerfile
+++ b/ci/fedora-40/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:40
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20241106
+ENV DOCKERFILE_VERSION=20241106
 
 RUN dnf -y install \
     cmake \

--- a/ci/fedora-41/Dockerfile
+++ b/ci/fedora-41/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:41
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20241204
+ENV DOCKERFILE_VERSION=20241204
 
 RUN dnf -y install \
     cmake \

--- a/ci/opensuse-leap-15.5/Dockerfile
+++ b/ci/opensuse-leap-15.5/Dockerfile
@@ -2,15 +2,21 @@ FROM opensuse/leap:15.5
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230612
+ENV DOCKERFILE_VERSION=20230612
 
 RUN zypper in -y \
     cmake \
-    gcc \
-    gcc-c++ \
+    gcc12 \
+    gcc12-c++ \
     git \
     libopenssl-devel \
     make \
-    python3 \
-    python3-devel \
+    python311 \
+    python311-devel \
   && rm -rf /var/cache/zypp
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 100
+RUN update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 100
+
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 100

--- a/ci/opensuse-leap-15.6/Dockerfile
+++ b/ci/opensuse-leap-15.6/Dockerfile
@@ -2,15 +2,21 @@ FROM opensuse/leap:15.6
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20240524
+ENV DOCKERFILE_VERSION=20240524
 
 RUN zypper in -y \
     cmake \
-    gcc \
-    gcc-c++ \
+    gcc12 \
+    gcc12-c++ \
     git \
     libopenssl-devel \
     make \
-    python3 \
-    python3-devel \
+    python312 \
+    python312-devel \
   && rm -rf /var/cache/zypp
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 100
+RUN update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.12-config 100
+
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 100

--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230329
+ENV DOCKERFILE_VERSION=20230329
 
 RUN zypper in -y \
     cmake \

--- a/ci/ubuntu-18.04/Dockerfile
+++ b/ci/ubuntu-18.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION=20220519
 
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"

--- a/ci/ubuntu-20.04/Dockerfile
+++ b/ci/ubuntu-20.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION=20220519
 
 RUN apt-get update && apt-get -y install \
     cmake \
@@ -14,5 +14,6 @@ RUN apt-get update && apt-get -y install \
     make \
     python3.9 \
     python3.9-dev \
+    python3-distutils \
   && apt autoclean \
   && rm -rf /var/lib/apt/lists/*

--- a/ci/ubuntu-22.04/Dockerfile
+++ b/ci/ubuntu-22.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230813
+ENV DOCKERFILE_VERSION=20230813
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20240510
+ENV DOCKERFILE_VERSION=20240510
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/ci/ubuntu-24.10/Dockerfile
+++ b/ci/ubuntu-24.10/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20241204
+ENV DOCKERFILE_VERSION=20241204
 
 RUN apt-get update && apt-get -y install \
     cmake \

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -18,7 +18,7 @@ FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230728
+ENV DOCKERFILE_VERSION=20230728
 
 SHELL [ "powershell" ]
 


### PR DESCRIPTION
This fixes some build issues with recent updates:
- opensuse-leap VMs were still using old versions of gcc, so the recent cmake change to enforce newer compiler versions broke the CI builds. This PR aligns it with what we're installing on Zeek's images.
- ubuntu 20 was missing some necessary python3 files for `configure` to be able to find the dist-packages directory.