### PR TITLE
Remove space in UDL definition

### DIFF
--- a/libbroker/broker/topic.cc
+++ b/libbroker/broker/topic.cc
@@ -101,6 +101,6 @@ topic topic::store_events() {
 
 } // namespace broker
 
-broker::topic operator"" _t(const char* str, size_t len) {
+broker::topic operator""_t(const char* str, size_t len) {
   return broker::topic{std::string{str, len}};
 }

--- a/libbroker/broker/topic.hh
+++ b/libbroker/broker/topic.hh
@@ -138,7 +138,7 @@ bool is_internal(const topic& x);
 /// Converts a string to a topic.
 /// @param str The string to convert.
 /// @returns The topic according to *str*.
-broker::topic operator"" _t(const char* str, size_t);
+broker::topic operator""_t(const char* str, size_t);
 
 namespace std {
 


### PR DESCRIPTION
Clang 18 added the -Wdeprecated-literal-operator warning for spaces in user-defined literal function definitions. Clang 20 turns it on by default and it's very noisy about it. We're already doing it the correct way in a couple of places, but this one was missed. There's also a few that could be fixed in CAF.