### PR TITLE
Require C++17 when compiling example

### DIFF
--- a/doc/comm.rst
+++ b/doc/comm.rst
@@ -252,7 +252,7 @@ Zeek:
 
 .. code-block:: bash
 
-    # g++ -std=c++17 -lbroker -lcaf_core -lcaf_io -lcaf_openssl -o ping ping.cc
+    # g++ -std=c++17 -lbroker -o ping ping.cc
     # zeek ping.zeek &
     # ./ping
     received pong[0]

--- a/doc/comm.rst
+++ b/doc/comm.rst
@@ -252,7 +252,7 @@ Zeek:
 
 .. code-block:: bash
 
-    # g++ -std=c++11 -lbroker -lcaf_core -lcaf_io -lcaf_openssl -o ping ping.cc
+    # g++ -std=c++17 -lbroker -lcaf_core -lcaf_io -lcaf_openssl -o ping ping.cc
     # zeek ping.zeek &
     # ./ping
     received pong[0]


### PR DESCRIPTION
We have required C++17 since some time now, and this would have not
compiled since then.