### PR TITLE
Implement new hub API (new pub/sub primitive)

### DIFF
--- a/libbroker/CMakeLists.txt
+++ b/libbroker/CMakeLists.txt
@@ -48,11 +48,13 @@ set(BROKER_SRC
   broker/filter_type.cc
   broker/format/bin.cc
   broker/format/json.cc
+  broker/hub.cc
   broker/internal/clone_actor.cc
   broker/internal/connector.cc
   broker/internal/connector_adapter.cc
   broker/internal/core_actor.cc
   broker/internal/flare_actor.cc
+  broker/internal/hub_impl.cc
   broker/internal/json.cc
   broker/internal/json_client.cc
   broker/internal/json_type_mapper.cc
@@ -61,7 +63,9 @@ set(BROKER_SRC
   broker/internal/peering.cc
   broker/internal/pending_connection.cc
   broker/internal/println.cc
+  broker/internal/publisher_queue.cc
   broker/internal/store_actor.cc
+  broker/internal/subscriber_queue.cc
   broker/internal/web_socket.cc
   broker/internal/wire_format.cc
   broker/internal_command.cc
@@ -174,6 +178,7 @@ set(BROKER_TEST_SRC
   broker/filter_type.test.cc
   broker/format/bin.test.cc
   broker/format/json.test.cc
+  broker/hub.test.cc
   broker/internal/channel.test.cc
   broker/internal/json.test.cc
   broker/internal/wire_format.test.cc

--- a/libbroker/broker/configuration.cc
+++ b/libbroker/broker/configuration.cc
@@ -23,6 +23,7 @@
 #include "broker/convert.hh"
 #include "broker/data.hh"
 #include "broker/endpoint.hh"
+#include "broker/hub_id.hh"
 #include "broker/internal/configuration_access.hh"
 #include "broker/internal/core_actor.hh"
 #include "broker/internal/native.hh"

--- a/libbroker/broker/endpoint.cc
+++ b/libbroker/broker/endpoint.cc
@@ -4,11 +4,11 @@
 #include "broker/defaults.hh"
 #include "broker/detail/die.hh"
 #include "broker/detail/filesystem.hh"
+#include "broker/hub.hh"
 #include "broker/internal/configuration_access.hh"
 #include "broker/internal/core_actor.hh"
 #include "broker/internal/endpoint_access.hh"
 #include "broker/internal/json_client.hh"
-#include "broker/internal/json_type_mapper.hh"
 #include "broker/internal/type_id.hh"
 #include "broker/internal/web_socket.hh"
 #include "broker/logger.hh"
@@ -852,6 +852,10 @@ endpoint::do_publish_all(const std::shared_ptr<detail::source_driver>& driver) {
   // Store background worker and return.
   workers_.emplace_back(facade(worker));
   return workers_.back();
+}
+
+hub endpoint::make_hub(filter_type filter) {
+  return hub::make(*this, std::move(filter));
 }
 
 broker_options endpoint::options() const {

--- a/libbroker/broker/endpoint.hh
+++ b/libbroker/broker/endpoint.hh
@@ -356,6 +356,12 @@ public:
                      std::move(cleanup));
   }
 
+  // --- subscribing and publishing data ---------------------------------------
+
+  /// Returns a hub connected to this endpoint with the initial topic
+  /// subscriptions from `filter`.
+  hub make_hub(filter_type filter);
+
   // --- data stores -----------------------------------------------------------
 
   /// Attaches and/or creates a *master* data store with a globally unique name.

--- a/libbroker/broker/fwd.hh
+++ b/libbroker/broker/fwd.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -58,6 +59,7 @@ class endpoint_id;
 class enum_value_view;
 class envelope;
 class error;
+class hub;
 class internal_command;
 class list_builder;
 class mailbox;
@@ -97,6 +99,7 @@ class intrusive_ptr;
 
 enum class backend : uint8_t;
 enum class ec : uint8_t;
+enum class hub_id : uint64_t;
 enum class p2p_message_type : uint8_t;
 enum class sc : uint8_t;
 enum class variant_tag : uint8_t;

--- a/libbroker/broker/hub.cc
+++ b/libbroker/broker/hub.cc
@@ -70,9 +70,7 @@ hub hub::make(endpoint& ep, filter_type filter) {
   auto& core = internal::native(ep.core());
   auto& sys = internal::endpoint_access{&ep}.sys();
   caf::scoped_actor self{sys};
-  self
-    ->request(core, 2s, id, std::move(filter), false, std::move(src2),
-              std::move(snk1))
+  self->request(core, 2s, id, filter, false, std::move(src2), std::move(snk1))
     .receive(
       [] {
         // OK, the core has completed the setup.
@@ -82,7 +80,8 @@ hub hub::make(endpoint& ep, filter_type filter) {
         throw std::runtime_error("cannot create hub");
       });
   // Wrap the queues in shared pointers and create the hub.
-  return hub(std::make_shared<internal::hub_impl>(id, core, sub, pub));
+  return hub(std::make_shared<internal::hub_impl>(id, core, sub, pub,
+                                                  std::move(filter)));
 }
 
 // --- accessors ---------------------------------------------------------------

--- a/libbroker/broker/hub.cc
+++ b/libbroker/broker/hub.cc
@@ -139,16 +139,20 @@ void hub::unsubscribe(const topic& x, bool block) {
   impl_->unsubscribe(x, block);
 }
 
+void hub::publish(data_message msg) {
+  impl_->publish(std::move(msg));
+}
+
 void hub::publish(const topic& dest, set_builder&& content) {
-  impl_->publish(dest, std::move(content).build_envelope(dest.string()));
+  impl_->publish(std::move(content).build_envelope(dest.string()));
 }
 
 void hub::publish(const topic& dest, table_builder&& content) {
-  impl_->publish(dest, std::move(content).build_envelope(dest.string()));
+  impl_->publish(std::move(content).build_envelope(dest.string()));
 }
 
 void hub::publish(const topic& dest, list_builder&& content) {
-  impl_->publish(dest, std::move(content).build_envelope(dest.string()));
+  impl_->publish(std::move(content).build_envelope(dest.string()));
 }
 
 } // namespace broker

--- a/libbroker/broker/hub.cc
+++ b/libbroker/broker/hub.cc
@@ -1,0 +1,154 @@
+#include "broker/hub.hh"
+
+#include "broker/builder.hh"
+#include "broker/detail/assert.hh"
+#include "broker/endpoint.hh"
+#include "broker/fwd.hh"
+#include "broker/internal/endpoint_access.hh"
+#include "broker/internal/hub_impl.hh"
+#include "broker/internal/native.hh"
+#include "broker/internal/publisher_queue.hh"
+#include "broker/internal/subscriber_queue.hh"
+#include "broker/internal/type_id.hh"
+#include "broker/logger.hh"
+#include "broker/message.hh"
+
+#include <caf/actor.hpp>
+#include <caf/async/spsc_buffer.hpp>
+#include <caf/scoped_actor.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+
+using namespace std::literals;
+
+namespace broker {
+
+namespace {
+
+/// Stores the last ID that was assigned to a hub. The next ID will be one
+/// greater than this value. Hence, valid hub IDs start at 1.
+std::atomic<uint64_t> last_hub_id = 0;
+
+} // namespace
+
+// --- static utility functions ------------------------------------------------
+
+hub_id hub::next_id() noexcept {
+  return static_cast<hub_id>(++last_hub_id);
+}
+
+// --- constructors, destructors, and assignment operators ---------------------
+
+hub::hub(std::shared_ptr<internal::hub_impl> ptr) : impl_(std::move(ptr)) {
+  // nop
+}
+
+hub::~hub() {
+  // nop; must be out-of-line to avoid header dependencies.
+}
+
+hub hub::make(endpoint& ep, filter_type filter) {
+  using caf::async::make_spsc_buffer_resource;
+  auto id = next_id();
+  // Produce the two queues for the hub.
+  auto [src1, snk1] = make_spsc_buffer_resource<data_message>();
+  auto [src2, snk2] = make_spsc_buffer_resource<data_message>();
+  // Use queue 1 for reading.
+  auto sub_buf = src1.try_open();
+  BROKER_ASSERT(sub_buf != nullptr);
+  auto sub = caf::make_counted<internal::subscriber_queue>(sub_buf);
+  sub_buf->set_consumer(sub);
+  // Use queue 2 for writing.
+  auto pub_buf = snk2.try_open();
+  BROKER_ASSERT(pub_buf != nullptr);
+  auto pub = caf::make_counted<internal::publisher_queue>(pub_buf);
+  pub_buf->set_producer(pub);
+  // Connect the buffers to the core.
+  auto& core = internal::native(ep.core());
+  auto& sys = internal::endpoint_access{&ep}.sys();
+  caf::scoped_actor self{sys};
+  self
+    ->request(core, 2s, id, std::move(filter), false, std::move(src2),
+              std::move(snk1))
+    .receive(
+      [] {
+        // OK, the core has completed the setup.
+      },
+      [](const caf::error& what) {
+        log::core::error("cannot-create-hub", "failed to create hub: {}", what);
+        throw std::runtime_error("cannot create hub");
+      });
+  // Wrap the queues in shared pointers and create the hub.
+  return hub(std::make_shared<internal::hub_impl>(id, core, sub, pub));
+}
+
+// --- accessors ---------------------------------------------------------------
+
+size_t hub::available() const noexcept {
+  return impl_->available();
+}
+
+size_t hub::demand() const {
+  return impl_->demand();
+}
+
+size_t hub::buffered() const {
+  return impl_->buffered();
+}
+
+size_t hub::capacity() const {
+  return impl_->capacity();
+}
+
+detail::native_socket hub::read_fd() const noexcept {
+  return impl_->read_fd();
+}
+
+detail::native_socket hub::write_fd() const noexcept {
+  return impl_->write_fd();
+}
+
+std::vector<data_message> hub::poll() {
+  return impl_->poll();
+}
+
+data_message hub::get() {
+  return impl_->get();
+}
+
+std::vector<data_message> hub::get(size_t num) {
+  return impl_->get(num);
+}
+
+data_message hub::do_get(timespan timeout) {
+  return do_get(timestamp::clock::now() + timeout);
+}
+
+data_message hub::do_get(timestamp timeout) {
+  return impl_->get(timeout);
+}
+
+void hub::subscribe(const topic& x, bool block) {
+  impl_->subscribe(x, block);
+}
+
+void hub::unsubscribe(const topic& x, bool block) {
+  impl_->unsubscribe(x, block);
+}
+
+void hub::publish(const topic& dest, set_builder&& content) {
+  impl_->publish(dest, std::move(content).build_envelope(dest.string()));
+}
+
+void hub::publish(const topic& dest, table_builder&& content) {
+  impl_->publish(dest, std::move(content).build_envelope(dest.string()));
+}
+
+void hub::publish(const topic& dest, list_builder&& content) {
+  impl_->publish(dest, std::move(content).build_envelope(dest.string()));
+}
+
+} // namespace broker

--- a/libbroker/broker/hub.hh
+++ b/libbroker/broker/hub.hh
@@ -40,11 +40,11 @@ public:
 
   // --- accessors -------------------------------------------------------------
 
-  /// Returns the amount of values than can be extracted immediately without
+  /// Returns the number of values than can be extracted immediately without
   /// blocking.
   size_t available() const noexcept;
 
-  /// Returns the current demand on this publisher. The demand is the amount of
+  /// Returns the current demand on this publisher. The demand is the number of
   /// messages that were requested by the Broker core.
   size_t demand() const;
 

--- a/libbroker/broker/hub.hh
+++ b/libbroker/broker/hub.hh
@@ -92,15 +92,16 @@ public:
 
   // --- messaging -------------------------------------------------------------
 
+  /// Sends a message to all subscribers.
   void publish(data_message msg);
 
-  /// Sends `x` to all subscribers.
+  /// Sends a message to all subscribers.
   void publish(const topic& dest, set_builder&& content);
 
-  /// Sends `x` to all subscribers.
+  /// Sends a message to all subscribers.
   void publish(const topic& dest, table_builder&& content);
 
-  /// Sends `x` to all subscribers.
+  /// Sends a message to all subscribers.
   void publish(const topic& dest, list_builder&& content);
 
 private:

--- a/libbroker/broker/hub.hh
+++ b/libbroker/broker/hub.hh
@@ -28,11 +28,11 @@ public:
 
   hub(hub&&) noexcept = default;
 
-  hub(const hub&) noexcept = default;
-
   hub& operator=(hub&&) noexcept = default;
 
-  hub& operator=(const hub&) noexcept = default;
+  hub(const hub&) noexcept = delete;
+
+  hub& operator=(const hub&) noexcept = delete;
 
   ~hub();
 

--- a/libbroker/broker/hub.hh
+++ b/libbroker/broker/hub.hh
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "broker/detail/native_socket.hh"
+#include "broker/fwd.hh"
+#include "broker/message.hh"
+#include "broker/time.hh"
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+namespace broker::internal {
+
+class hub_impl;
+
+} // namespace broker::internal
+
+namespace broker {
+
+/// Hubs act as a subscriber and publisher at the same time.
+class hub {
+public:
+  // --- static utility functions ----------------------------------------------
+
+  static hub_id next_id() noexcept;
+
+  // --- constructors, destructors, and assignment operators -------------------
+
+  hub(hub&&) noexcept = default;
+
+  hub(const hub&) noexcept = default;
+
+  hub& operator=(hub&&) noexcept = default;
+
+  hub& operator=(const hub&) noexcept = default;
+
+  ~hub();
+
+  static hub make(endpoint& ep, filter_type filter);
+
+  // --- accessors -------------------------------------------------------------
+
+  /// Returns the amount of values than can be extracted immediately without
+  /// blocking.
+  size_t available() const noexcept;
+
+  /// Returns the current demand on this publisher. The demand is the amount of
+  /// messages that were requested by the Broker core.
+  size_t demand() const;
+
+  /// Returns the current size of the output queue.
+  size_t buffered() const;
+
+  /// Returns the capacity of the output queue.
+  size_t capacity() const;
+
+  /// Returns a file handle for integrating this publisher into a `select` or
+  /// `poll` loop. The socket descriptor becomes ready if at least one value is
+  /// available to read.
+  detail::native_socket read_fd() const noexcept;
+
+  /// Returns a file handle for integrating this publisher into a `select` or
+  /// `poll` loop. The socket descriptor becomes ready if the hub is ready to
+  /// accept new values.
+  detail::native_socket write_fd() const noexcept;
+
+  // --- access to values ------------------------------------------------------
+
+  /// Returns all currently available values without blocking.
+  std::vector<data_message> poll();
+
+  /// Pulls a single value out of the stream. Blocks the current thread until
+  /// at least one value becomes available.
+  data_message get();
+
+  /// Returns `num` values, blocking the caller if necessary.
+  std::vector<data_message> get(size_t num);
+
+  /// Pulls a single value out of the stream. Blocks the current thread until
+  /// at least one value becomes available or a timeout occurred.
+  /// @return The message on success, `nullptr` on timeout.
+  template <class Rep, class Period>
+  data_message get(std::chrono::duration<Rep, Period> rel_timeout) {
+    return do_get(std::chrono::duration_cast<timespan>(rel_timeout));
+  }
+
+  // --- topic management ------------------------------------------------------
+
+  void subscribe(const topic& x, bool block = false);
+
+  void unsubscribe(const topic& x, bool block = false);
+
+  // --- messaging -------------------------------------------------------------
+
+  /// Sends `x` to all subscribers.
+  void publish(const topic& dest, set_builder&& content);
+
+  /// Sends `x` to all subscribers.
+  void publish(const topic& dest, table_builder&& content);
+
+  /// Sends `x` to all subscribers.
+  void publish(const topic& dest, list_builder&& content);
+
+private:
+  data_message do_get(timespan timeout);
+
+  data_message do_get(timestamp timeout);
+
+  explicit hub(std::shared_ptr<internal::hub_impl> ptr);
+
+  std::shared_ptr<internal::hub_impl> impl_;
+};
+
+} // namespace broker

--- a/libbroker/broker/hub.hh
+++ b/libbroker/broker/hub.hh
@@ -92,6 +92,8 @@ public:
 
   // --- messaging -------------------------------------------------------------
 
+  void publish(data_message msg);
+
   /// Sends `x` to all subscribers.
   void publish(const topic& dest, set_builder&& content);
 

--- a/libbroker/broker/hub.test.cc
+++ b/libbroker/broker/hub.test.cc
@@ -70,16 +70,25 @@ TEST("hubs receive messages from publishers") {
   }
 }
 
-// TEST("hubs receive messages that are published on the endpoint") {
-//   broker::endpoint ep;
-//   auto uut = ep.make_hub({"/foo/bar"});
-//   ep.publish(broker::topic{"/foo/bar"},
-//              broker::list_builder{}.add(1).add(2).add(3).build());
-//   auto msg = uut.get(150ms);
-//   if (CHECK_NE(msg, nullptr)) {
-//     CHECK_EQ(msg->topic(), "/foo/bar");
-//     if (auto val = msg->value(); CHECK(val.is_list())) {
-//       CHECK_EQ(broker::to_string(val), "(1, 2, 3)");
-//     }
-//   }
-// }
+TEST("hubs receive messages that are published on the endpoint") {
+  broker::endpoint ep;
+  auto uut = ep.make_hub({"/foo/bar"});
+  ep.publish(broker::topic{"/foo/bar"},
+             broker::list_builder{}.add(1).add(2).add(3).build());
+  auto msg = uut.get(150ms);
+  if (CHECK_NE(msg, nullptr)) {
+    CHECK_EQ(msg->topic(), "/foo/bar");
+    if (auto val = msg->value(); CHECK(val.is_list())) {
+      CHECK_EQ(broker::to_string(val), "(1, 2, 3)");
+    }
+  }
+}
+
+TEST("subscribers do not receive messages from hubs") {
+  broker::endpoint ep;
+  auto uut = ep.make_hub({"/foo/bar"});
+  auto sub = ep.make_subscriber({"/foo/bar"});
+  uut.publish("/foo/bar", broker::list_builder{}.add(1).add(2).add(3));
+  auto msg = sub.get(150ms);
+  CHECK(!msg.has_value());
+}

--- a/libbroker/broker/hub.test.cc
+++ b/libbroker/broker/hub.test.cc
@@ -1,0 +1,85 @@
+#include "broker/hub.hh"
+
+#include "broker/broker-test.test.hh"
+#include "broker/builder.hh"
+#include "broker/publisher.hh"
+
+#include <chrono>
+
+using namespace std::literals;
+
+TEST("hubs do not receive their own messages") {
+  broker::endpoint ep;
+  auto uut = ep.make_hub({"/foo/bar"});
+  uut.publish("/foo/bar", broker::list_builder{}.add(1).add(2).add(3));
+  auto msg = uut.get(150ms);
+  CHECK_EQ(msg, nullptr);
+}
+
+TEST("hubs receive messages from other hubs") {
+  broker::endpoint ep;
+  auto uut1 = ep.make_hub({"/foo/bar"});
+  auto uut2 = ep.make_hub({"/foo/bar"});
+  uut1.publish("/foo/bar", broker::list_builder{}.add(1).add(2).add(3));
+  auto msg = uut2.get(150ms);
+  if (CHECK_NE(msg, nullptr)) {
+    CHECK_EQ(msg->topic(), "/foo/bar");
+    if (auto val = msg->value(); CHECK(val.is_list())) {
+      CHECK_EQ(broker::to_string(val), "(1, 2, 3)");
+    }
+  }
+}
+
+TEST("hubs can change their subscriptions") {
+  broker::endpoint ep;
+  auto uut1 = ep.make_hub({"/foo/baz"});
+  auto uut2 = ep.make_hub({"/foo/bar"});
+  // Send to /foo/baz: should not be received by uut2.
+  uut1.publish("/foo/baz", broker::list_builder{}.add(1).add(2).add(3));
+  if (auto msg = uut2.get(150ms); !CHECK_EQ(msg, nullptr)) {
+    return;
+  }
+  // Subscribe to /foo/baz on uut2: should receive the message.
+  uut2.subscribe("/foo/baz", true);
+  uut1.publish("/foo/baz", broker::list_builder{}.add(4).add(5).add(6));
+  if (auto msg = uut2.get(150ms); CHECK_NE(msg, nullptr)) {
+    CHECK_EQ(msg->topic(), "/foo/baz");
+    if (auto val = msg->value(); CHECK(val.is_list())) {
+      CHECK_EQ(broker::to_string(val), "(4, 5, 6)");
+    }
+  }
+  // Unsubscribe from /foo/baz on uut2: should not receive the message anymore.
+  uut2.unsubscribe("/foo/baz", true);
+  uut1.publish("/foo/baz", broker::list_builder{}.add(7).add(8).add(9));
+  if (auto msg = uut2.get(150ms); !CHECK_EQ(msg, nullptr)) {
+    return;
+  }
+}
+
+TEST("hubs receive messages from publishers") {
+  broker::endpoint ep;
+  auto uut = ep.make_hub({"/foo/bar"});
+  auto pub = ep.make_publisher(broker::topic{"/foo/bar"});
+  pub.publish(broker::list_builder{}.add(1).add(2).add(3));
+  auto msg = uut.get(150ms);
+  if (CHECK_NE(msg, nullptr)) {
+    CHECK_EQ(msg->topic(), "/foo/bar");
+    if (auto val = msg->value(); CHECK(val.is_list())) {
+      CHECK_EQ(broker::to_string(val), "(1, 2, 3)");
+    }
+  }
+}
+
+// TEST("hubs receive messages that are published on the endpoint") {
+//   broker::endpoint ep;
+//   auto uut = ep.make_hub({"/foo/bar"});
+//   ep.publish(broker::topic{"/foo/bar"},
+//              broker::list_builder{}.add(1).add(2).add(3).build());
+//   auto msg = uut.get(150ms);
+//   if (CHECK_NE(msg, nullptr)) {
+//     CHECK_EQ(msg->topic(), "/foo/bar");
+//     if (auto val = msg->value(); CHECK(val.is_list())) {
+//       CHECK_EQ(broker::to_string(val), "(1, 2, 3)");
+//     }
+//   }
+// }

--- a/libbroker/broker/hub_id.hh
+++ b/libbroker/broker/hub_id.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+namespace broker {
+
+/// Strong type alias for uniquely identifying hubs.
+enum class hub_id : uint64_t {
+  /// Represents an invalid hub ID.
+  invalid = 0,
+};
+
+template <class Inspector>
+bool inspect(Inspector& f, hub_id& x) {
+  if constexpr (Inspector::is_loading) {
+    uint64_t tmp = 0;
+    if (!f.apply(tmp))
+      return false;
+    x = static_cast<hub_id>(tmp);
+    return true;
+  } else {
+    auto tmp = static_cast<uint64_t>(x);
+    return f.apply(tmp);
+  }
+}
+
+} // namespace broker

--- a/libbroker/broker/internal/core_actor.cc
+++ b/libbroker/broker/internal/core_actor.cc
@@ -402,6 +402,10 @@ caf::behavior core_actor_state::make_behavior() {
     },
     [this](hub_id id, filter_type& filter, bool filter_local,
            data_consumer_res& src, data_producer_res& snk) {
+      // Note: setting the filter_local flag to true means that we will not push
+      //       messages from other hubs to this hub. This is used by the class
+      //       `subscriber` to only receive messages from non-local messages,
+      //       i.e., messages from other peers.
       if (id == hub_id::invalid) {
         log::core::error("add-hub", "cannot add hub with invalid ID");
         src.cancel();

--- a/libbroker/broker/internal/core_actor.hh
+++ b/libbroker/broker/internal/core_actor.hh
@@ -111,12 +111,6 @@ public:
   /// Creates a snapshot for the peering statistics.
   table peer_stats_snapshot() const;
 
-  /// Creates a snapshot for the status of local subscribers.
-  vector local_subscriber_stats_snapshot() const;
-
-  /// Creates a snapshot for the status of local publishers.
-  vector local_publisher_stats_snapshot() const;
-
   /// Creates a snapshot that summarizes the current status of the core.
   table status_snapshot() const;
 
@@ -327,41 +321,6 @@ public:
 
   using flow_scope_stats_ptr_set = std::set<flow_scope_stats_ptr>;
 
-  /// Keeps track of statistics for local subscribers. This is a pointer,
-  /// because some scopes may get destroyed after the state object or while
-  /// destroying the state.
-  std::shared_ptr<flow_scope_stats_ptr_set> local_subscriber_stats =
-    std::make_shared<flow_scope_stats_ptr_set>();
-
-  /// Returns a function object for adding instrumentation to flow that belongs
-  /// to a local subscriber.
-  auto local_subscriber_scope_adder() {
-    auto stats_ptr = std::make_shared<flow_scope_stats>();
-    auto stats_set = local_subscriber_stats;
-    stats_set->emplace(stats_ptr);
-    return add_flow_scope_t{stats_ptr,
-                            [stats_set](const flow_scope_stats_ptr& ptr) {
-                              stats_set->erase(ptr);
-                            }};
-  }
-
-  /// Keeps track of statistics for local publishers. This is a pointer, because
-  /// some scopes may get destroyed after the state object or while destroying
-  /// the state.
-  std::shared_ptr<flow_scope_stats_ptr_set> local_publisher_stats =
-    std::make_shared<flow_scope_stats_ptr_set>();
-
-  /// Returns a function object for adding instrumentation to flow that belongs
-  /// to a local publisher.
-  auto local_publisher_scope_adder() {
-    auto stats_ptr = std::make_shared<flow_scope_stats>();
-    auto stats_set = local_publisher_stats;
-    stats_set->emplace(stats_ptr);
-    return add_flow_scope_t{stats_ptr,
-                            [stats_set](const flow_scope_stats_ptr& ptr) {
-                              stats_set->erase(ptr);
-                            }};
-  }
 
   /// Returns whether `shutdown` was called.
   bool shutting_down();

--- a/libbroker/broker/internal/core_actor.hh
+++ b/libbroker/broker/internal/core_actor.hh
@@ -344,6 +344,10 @@ public:
 
   using hub_state_ptr = std::shared_ptr<hub_state>;
 
+  void drop_hub_input(hub_id id);
+
+  void drop_hub_output(hub_id id);
+
   std::unordered_map<hub_id, hub_state_ptr> hubs;
 };
 

--- a/libbroker/broker/internal/core_actor.hh
+++ b/libbroker/broker/internal/core_actor.hh
@@ -319,9 +319,6 @@ public:
   /// after the timeout.
   caf::disposable shutting_down_timeout;
 
-  using flow_scope_stats_ptr_set = std::set<flow_scope_stats_ptr>;
-
-
   /// Returns whether `shutdown` was called.
   bool shutting_down();
 

--- a/libbroker/broker/internal/data_generator.test.cc
+++ b/libbroker/broker/internal/data_generator.test.cc
@@ -18,9 +18,8 @@ namespace {
 struct fixture {
   caf::binary_serializer::container_type buf;
   caf::binary_serializer sink;
-  size_t read_pos;
 
-  fixture() : sink(nullptr, buf), read_pos(0) {
+  fixture() : sink(nullptr, buf) {
     // nop
   }
 

--- a/libbroker/broker/internal/hub_impl.cc
+++ b/libbroker/broker/internal/hub_impl.cc
@@ -2,6 +2,15 @@
 
 namespace broker::internal {
 
+hub_impl::~hub_impl() {
+  if (write_queue_) {
+    write_queue_->close();
+  }
+  if (read_queue_) {
+    read_queue_->cancel();
+  }
+}
+
 std::vector<data_message> hub_impl::poll() {
   // The Queue may return a capacity of 0 if the producer has closed the flow.
   std::vector<data_message> buf;

--- a/libbroker/broker/internal/hub_impl.cc
+++ b/libbroker/broker/internal/hub_impl.cc
@@ -1,0 +1,45 @@
+#include "broker/internal/hub_impl.hh"
+
+namespace broker::internal {
+
+std::vector<data_message> hub_impl::poll() {
+  // The Queue may return a capacity of 0 if the producer has closed the flow.
+  std::vector<data_message> buf;
+  auto max_size = read_queue_->capacity();
+  if (max_size > 0) {
+    buf.reserve(max_size);
+    read_queue_->pull(buf, max_size);
+  }
+  return buf;
+}
+
+data_message hub_impl::get() {
+  data_message msg;
+  if (!read_queue_->pull(msg)) {
+    throw std::runtime_error("subscriber queue closed");
+  }
+  return msg;
+}
+
+std::vector<data_message> hub_impl::get(size_t num) {
+  BROKER_ASSERT(num > 0);
+  std::vector<data_message> buf;
+  buf.reserve(num);
+  read_queue_->pull(buf, num);
+  while (buf.size() < num) {
+    read_queue_->wait();
+    if (!read_queue_->pull(buf, num))
+      return buf;
+  }
+  return buf;
+}
+
+data_message hub_impl::get(timestamp timeout) {
+  data_message msg;
+  if (read_queue_->wait_until(timeout)) {
+    read_queue_->pull(msg);
+  }
+  return msg;
+}
+
+} // namespace broker::internal

--- a/libbroker/broker/internal/hub_impl.hh
+++ b/libbroker/broker/internal/hub_impl.hh
@@ -26,6 +26,8 @@ public:
     // nop
   }
 
+  ~hub_impl();
+
   // -- subscriber interface ---------------------------------------------------
 
   std::vector<data_message> poll();

--- a/libbroker/broker/internal/hub_impl.hh
+++ b/libbroker/broker/internal/hub_impl.hh
@@ -17,11 +17,12 @@ namespace broker::internal {
 class hub_impl {
 public:
   hub_impl(hub_id id, caf::actor core, subscriber_queue_ptr read_queue,
-           publisher_queue_ptr write_queue)
+           publisher_queue_ptr write_queue, filter_type filter = {})
     : id_(id),
       core_(std::move(core)),
       read_queue_(std::move(read_queue)),
-      write_queue_(std::move(write_queue)) {
+      write_queue_(std::move(write_queue)),
+      filter_(std::move(filter)) {
     // nop
   }
 
@@ -32,6 +33,8 @@ public:
   data_message get();
 
   std::vector<data_message> get(size_t num);
+
+  std::vector<data_message> get(size_t num, timestamp timeout);
 
   data_message get(timestamp timeout);
 
@@ -82,6 +85,10 @@ public:
 
   void publish(const topic& dst, data_message&& msg) {
     write_queue_->push(caf::make_span(&msg, 1));
+  }
+
+  auto& read_queue() {
+    return read_queue_;
   }
 
 private:

--- a/libbroker/broker/internal/hub_impl.hh
+++ b/libbroker/broker/internal/hub_impl.hh
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "broker/detail/assert.hh"
+#include "broker/internal/publisher_queue.hh"
+#include "broker/internal/subscriber_queue.hh"
+#include "broker/internal/type_id.hh"
+#include "broker/logger.hh"
+#include "broker/message.hh"
+#include "broker/time.hh"
+
+#include <caf/actor.hpp>
+#include <caf/scoped_actor.hpp>
+#include <caf/type_id.hpp>
+
+namespace broker::internal {
+
+class hub_impl {
+public:
+  hub_impl(hub_id id, caf::actor core, subscriber_queue_ptr read_queue,
+           publisher_queue_ptr write_queue)
+    : id_(id),
+      core_(std::move(core)),
+      read_queue_(std::move(read_queue)),
+      write_queue_(std::move(write_queue)) {
+    // nop
+  }
+
+  // -- subscriber interface ---------------------------------------------------
+
+  std::vector<data_message> poll();
+
+  data_message get();
+
+  std::vector<data_message> get(size_t num);
+
+  data_message get(timestamp timeout);
+
+  size_t available() const noexcept {
+    return read_queue_->available();
+  }
+
+  detail::native_socket read_fd() const noexcept {
+    return read_queue_->fd();
+  }
+
+  void subscribe(const topic& what, bool block) {
+    auto pred = [&what](const topic& x) { return x == what; };
+    if (std::any_of(filter_.begin(), filter_.end(), pred)) {
+      return;
+    }
+    filter_.push_back(what);
+    send_filter(block);
+  }
+
+  void unsubscribe(const topic& what, bool block) {
+    auto pred = [&what](const topic& x) { return x == what; };
+    auto i = std::find_if(filter_.begin(), filter_.end(), pred);
+    if (i == filter_.end()) {
+      return;
+    }
+    filter_.erase(i);
+    send_filter(block);
+  }
+
+  // -- publisher interface ----------------------------------------------------
+
+  size_t demand() const {
+    return write_queue_->demand();
+  }
+
+  size_t buffered() const {
+    return write_queue_->buf().available();
+  }
+
+  size_t capacity() const {
+    return write_queue_->buf().capacity();
+  }
+
+  detail::native_socket write_fd() const noexcept {
+    return write_queue_->fd();
+  }
+
+  void publish(const topic& dst, data_message&& msg) {
+    write_queue_->push(caf::make_span(&msg, 1));
+  }
+
+private:
+  void send_filter(bool block) {
+    if (block) {
+      caf::scoped_actor self{core_.home_system()};
+      self->request(core_, caf::infinite, id_, filter_)
+        .receive([] {},
+                 [](const caf::error& err) {
+                   log::core::debug("update-hub-filter",
+                                    "failed to update hub filter: {}", err);
+                 });
+    } else {
+      caf::anon_send(core_, id_, filter_);
+    }
+  }
+
+  hub_id id_;
+  caf::actor core_;
+  internal::subscriber_queue_ptr read_queue_;
+  internal::publisher_queue_ptr write_queue_;
+  filter_type filter_;
+};
+
+} // namespace broker::internal

--- a/libbroker/broker/internal/hub_impl.hh
+++ b/libbroker/broker/internal/hub_impl.hh
@@ -83,7 +83,7 @@ public:
     return write_queue_->fd();
   }
 
-  void publish(const topic& dst, data_message&& msg) {
+  void publish(data_message&& msg) {
     write_queue_->push(caf::make_span(&msg, 1));
   }
 

--- a/libbroker/broker/internal/publisher_queue.cc
+++ b/libbroker/broker/internal/publisher_queue.cc
@@ -4,6 +4,10 @@
 
 namespace broker::internal {
 
+publisher_queue::~publisher_queue() {
+  close();
+}
+
 void publisher_queue::on_consumer_ready() {
   // nop
 }
@@ -69,6 +73,13 @@ void publisher_queue::push(caf::span<const value_type> items) {
   guard.unlock();
   buf_->push(items.subspan(0, n));
   push(items.subspan(n));
+}
+
+void publisher_queue::close() {
+  if (buf_) {
+    buf_->close();
+    buf_ = nullptr;
+  }
 }
 
 } // namespace broker::internal

--- a/libbroker/broker/internal/publisher_queue.cc
+++ b/libbroker/broker/internal/publisher_queue.cc
@@ -1,0 +1,74 @@
+#include "broker/internal/publisher_queue.hh"
+
+#include "broker/detail/assert.hh"
+
+namespace broker::internal {
+
+void publisher_queue::on_consumer_ready() {
+  // nop
+}
+
+void publisher_queue::on_consumer_cancel() {
+  guard_type guard{mtx_};
+  cancelled_ = true;
+  if (demand_ == 0) {
+    fx_.fire();
+  }
+}
+
+void publisher_queue::on_consumer_demand(size_t demand) {
+  BROKER_ASSERT(demand > 0);
+  guard_type guard{mtx_};
+  if (demand_ == 0) {
+    demand_ = demand;
+    fx_.fire();
+  } else {
+    demand_ += demand;
+  }
+  return;
+}
+
+void publisher_queue::ref_producer() const noexcept {
+  ref();
+}
+
+void publisher_queue::deref_producer() const noexcept {
+  deref();
+}
+
+size_t publisher_queue::demand() const noexcept {
+  guard_type guard{mtx_};
+  return demand_;
+}
+
+void publisher_queue::push(caf::span<const value_type> items) {
+  if (items.empty()) {
+    return;
+  }
+  guard_type guard{mtx_};
+  if (cancelled_) {
+    return;
+  }
+  while (demand_ == 0) {
+    guard.unlock();
+    fx_.await_one();
+    guard.lock();
+    if (cancelled_) {
+      return;
+    }
+  }
+  if (items.size() < demand_) {
+    demand_ -= items.size();
+    guard.unlock();
+    buf_->push(items);
+    return;
+  }
+  auto n = demand_;
+  demand_ = 0;
+  fx_.extinguish();
+  guard.unlock();
+  buf_->push(items.subspan(0, n));
+  push(items.subspan(n));
+}
+
+} // namespace broker::internal

--- a/libbroker/broker/internal/publisher_queue.hh
+++ b/libbroker/broker/internal/publisher_queue.hh
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "broker/detail/flare.hh"
+#include "broker/detail/native_socket.hh"
+#include "broker/message.hh"
+
+#include <caf/async/producer.hpp>
+#include <caf/async/spsc_buffer.hpp>
+#include <caf/intrusive_ptr.hpp>
+#include <caf/ref_counted.hpp>
+
+#include <mutex>
+#include <utility>
+
+namespace broker::internal {
+
+class publisher_queue : public caf::ref_counted, public caf::async::producer {
+public:
+  using value_type = data_message;
+
+  using buffer_type = caf::async::spsc_buffer<value_type>;
+
+  using buffer_ptr = caf::async::spsc_buffer_ptr<value_type>;
+
+  using guard_type = std::unique_lock<std::mutex>;
+
+  explicit publisher_queue(buffer_ptr buf) : buf_(std::move(buf)) {
+    // nop
+  }
+
+  buffer_type& buf() {
+    return *buf_;
+  }
+
+  detail::native_socket fd() const {
+    return fx_.fd();
+  }
+
+  void wait_on_flare() {
+    fx_.await_one();
+  }
+
+  void on_consumer_ready() override;
+
+  void on_consumer_cancel() override;
+
+  void on_consumer_demand(size_t demand) override;
+
+  void ref_producer() const noexcept override;
+
+  void deref_producer() const noexcept override;
+
+  size_t demand() const noexcept;
+
+  void push(caf::span<const value_type> items);
+
+  friend void intrusive_ptr_add_ref(const publisher_queue* ptr) noexcept {
+    ptr->ref();
+  }
+
+  friend void intrusive_ptr_release(const publisher_queue* ptr) noexcept {
+    ptr->deref();
+  };
+
+private:
+  /// Provides access to the shared producer-consumer buffer.
+  buffer_ptr buf_;
+
+  /// Guards access to other member variables.
+  mutable std::mutex mtx_;
+
+  /// Signals to users when data can be read or written.
+  mutable detail::flare fx_;
+
+  /// Stores how many demand we currently have from the consumer.
+  size_t demand_ = 0;
+
+  /// Stores whether the consumer stopped receiving data.
+  bool cancelled_ = false;
+};
+
+using publisher_queue_ptr = caf::intrusive_ptr<publisher_queue>;
+
+} // namespace broker::internal

--- a/libbroker/broker/internal/publisher_queue.hh
+++ b/libbroker/broker/internal/publisher_queue.hh
@@ -28,6 +28,8 @@ public:
     // nop
   }
 
+  ~publisher_queue();
+
   buffer_type& buf() {
     return *buf_;
   }
@@ -53,6 +55,8 @@ public:
   size_t demand() const noexcept;
 
   void push(caf::span<const value_type> items);
+
+  void close();
 
   friend void intrusive_ptr_add_ref(const publisher_queue* ptr) noexcept {
     ptr->ref();

--- a/libbroker/broker/internal/subscriber_queue.cc
+++ b/libbroker/broker/internal/subscriber_queue.cc
@@ -1,0 +1,182 @@
+#include "broker/internal/subscriber_queue.hh"
+
+#include "broker/detail/assert.hh"
+#include "broker/logger.hh"
+
+namespace broker::internal {
+
+subscriber_queue::subscriber_queue(buffer_ptr buf) : buf_(std::move(buf)) {
+  // nop
+}
+
+subscriber_queue::~subscriber_queue() {
+  if (buf_)
+    buf_->cancel();
+}
+
+void subscriber_queue::on_producer_ready() {
+  // nop
+}
+
+void subscriber_queue::on_producer_wakeup() {
+  guard_type guard{mtx_};
+  if (!ready_) {
+    fx_.fire();
+    ready_ = true;
+  }
+}
+
+void subscriber_queue::wait() {
+  guard_type guard{mtx_};
+  while (!ready_) {
+    guard.unlock();
+    fx_.await_one();
+    guard.lock();
+  }
+}
+
+bool subscriber_queue::wait_until(timestamp abs_timeout) {
+  guard_type guard{mtx_};
+  while (!ready_) {
+    guard.unlock();
+    if (!fx_.await_one(abs_timeout)) {
+      guard.lock();
+      return ready_;
+    }
+    guard.lock();
+  }
+  return true;
+}
+
+void subscriber_queue::ref_consumer() const noexcept {
+  ref();
+}
+
+void subscriber_queue::deref_consumer() const noexcept {
+  deref();
+}
+
+detail::native_socket subscriber_queue::fd() const noexcept {
+  return fx_.fd();
+}
+
+void subscriber_queue::cancel() {
+  if (buf_)
+    buf_->cancel();
+}
+
+void subscriber_queue::extinguish() {
+  guard_type guard{mtx_};
+  if (ready_) {
+    ready_ = false;
+    fx_.extinguish();
+  }
+}
+
+bool subscriber_queue::pull(data_message& dst) {
+  struct cb {
+    subscriber_queue* qptr;
+    data_message* dst;
+    void on_next(const data_message& val) {
+      *dst = val;
+    }
+    void on_complete() {
+      qptr->extinguish();
+    }
+    void on_error(const caf::error&) {
+      qptr->extinguish();
+    }
+  };
+  using caf::async::delay_errors;
+  cb consumer{this, &dst};
+  if (buf_) {
+    auto [open, n] = buf_->pull(delay_errors, 1, consumer);
+    log::endpoint::debug("subscriber-pull",
+                         "got {} messages from bounded buffer", n);
+    if (!open) {
+      log::endpoint::debug("subscriber-queue-closed",
+                           "nothing left to pull, queue closed");
+      buf_ = nullptr;
+      return false;
+    }
+    if (buf_->available() == 0) {
+      // Note: We always *must* acquire the lock on the buffer before
+      // acquiring the lock on the subscriber to prevent deadlocks.
+      guard_type buf_guard{buf_->mtx()};
+      guard_type sub_guard{mtx_};
+      if (ready_ && buf_->available_unsafe() == 0) {
+        ready_ = false;
+        fx_.extinguish();
+      }
+      return true;
+    }
+    return true;
+  }
+  log::endpoint::debug("subscriber-queue-closed",
+                       "nothing left to pull, queue closed");
+  return false;
+}
+
+bool subscriber_queue::pull(std::vector<data_message>& dst, size_t num) {
+  BROKER_ASSERT(num > 0);
+  BROKER_ASSERT(dst.size() < num);
+  struct cb {
+    subscriber_queue* qptr;
+    std::vector<data_message>* dst;
+    void on_next(const data_message& val) {
+      dst->push_back(val);
+    }
+    void on_complete() {
+      qptr->extinguish();
+    }
+    void on_error(const caf::error&) {
+      qptr->extinguish();
+    }
+  };
+  using caf::async::delay_errors;
+  cb consumer{this, &dst};
+  if (buf_) {
+    auto [open, n] = buf_->pull(delay_errors, num - dst.size(), consumer);
+    log::endpoint::debug("subscriber-pull",
+                         "got {} messages from bounded buffer", n);
+    if (!open) {
+      log::endpoint::debug("subscriber-queue-closed",
+                           "nothing left to pull, queue closed");
+      buf_ = nullptr;
+      return false;
+    }
+    if (buf_->available() == 0) {
+      // Note: We always *must* acquire the lock on the buffer before
+      // acquiring the lock on the subscriber to prevent deadlocks.
+      guard_type buf_guard{buf_->mtx()};
+      guard_type sub_guard{mtx_};
+      if (ready_ && buf_->available_unsafe() == 0) {
+        ready_ = false;
+        fx_.extinguish();
+      }
+      return true;
+    }
+    return true;
+  }
+  log::endpoint::debug("subscriber-queue-closed",
+                       "nothing left to pull, queue closed");
+  return false;
+}
+
+size_t subscriber_queue::capacity() const noexcept {
+  return buf_ ? buf_->capacity() : size_t{0};
+}
+
+size_t subscriber_queue::available() const noexcept {
+  return buf_ ? buf_->available() : size_t{0};
+}
+
+void intrusive_ptr_add_ref(const subscriber_queue* ptr) noexcept {
+  ptr->ref();
+}
+
+void intrusive_ptr_release(const subscriber_queue* ptr) noexcept {
+  ptr->deref();
+}
+
+} // namespace broker::internal

--- a/libbroker/broker/internal/subscriber_queue.cc
+++ b/libbroker/broker/internal/subscriber_queue.cc
@@ -10,8 +10,7 @@ subscriber_queue::subscriber_queue(buffer_ptr buf) : buf_(std::move(buf)) {
 }
 
 subscriber_queue::~subscriber_queue() {
-  if (buf_)
-    buf_->cancel();
+  cancel();
 }
 
 void subscriber_queue::on_producer_ready() {
@@ -61,8 +60,10 @@ detail::native_socket subscriber_queue::fd() const noexcept {
 }
 
 void subscriber_queue::cancel() {
-  if (buf_)
+  if (buf_) {
     buf_->cancel();
+    buf_ = nullptr;
+  }
 }
 
 void subscriber_queue::extinguish() {

--- a/libbroker/broker/internal/subscriber_queue.hh
+++ b/libbroker/broker/internal/subscriber_queue.hh
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "broker/detail/flare.hh"
+#include "broker/detail/native_socket.hh"
+#include "broker/message.hh"
+
+#include <caf/async/consumer.hpp>
+#include <caf/async/spsc_buffer.hpp>
+#include <caf/ref_counted.hpp>
+
+namespace broker::internal {
+
+struct subscriber_queue : public caf::ref_counted, public caf::async::consumer {
+public:
+  using buffer_type = caf::async::spsc_buffer<data_message>;
+
+  using buffer_ptr = caf::async::spsc_buffer_ptr<data_message>;
+
+  using guard_type = std::unique_lock<std::mutex>;
+
+  explicit subscriber_queue(buffer_ptr buf);
+
+  ~subscriber_queue() override;
+
+  void on_producer_ready() override;
+
+  void on_producer_wakeup() override;
+
+  void wait();
+
+  bool wait_until(timestamp abs_timeout);
+
+  void ref_consumer() const noexcept override;
+
+  void deref_consumer() const noexcept override;
+
+  detail::native_socket fd() const noexcept;
+
+  void cancel();
+
+  void extinguish();
+
+  bool pull(data_message& dst);
+
+  bool pull(std::vector<data_message>& dst, size_t num);
+
+  size_t capacity() const noexcept;
+
+  size_t available() const noexcept;
+
+  friend void intrusive_ptr_add_ref(const subscriber_queue* ptr) noexcept;
+
+  friend void intrusive_ptr_release(const subscriber_queue* ptr) noexcept;
+
+private:
+  /// Provides access to the shared buffer.
+  buffer_ptr buf_;
+
+  /// Guards access to other member variables.
+  mutable std::mutex mtx_;
+
+  /// Signals to users when data can be read or written.
+  mutable detail::flare fx_;
+
+  /// Stores whether we have data available.
+  bool ready_ = false;
+};
+
+using subscriber_queue_ptr = caf::intrusive_ptr<subscriber_queue>;
+
+} // namespace broker::internal

--- a/libbroker/broker/internal/type_id.hh
+++ b/libbroker/broker/internal/type_id.hh
@@ -4,6 +4,7 @@
 #include "broker/detail/store_state.hh"
 #include "broker/error.hh"
 #include "broker/fwd.hh"
+#include "broker/hub_id.hh"
 #include "broker/internal/fwd.hh"
 #include "broker/internal/native.hh"
 #include "broker/time.hh"
@@ -134,6 +135,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(broker_internal, caf::first_custom_type_id)
   BROKER_ADD_TYPE_ID((broker::erase_command))
   BROKER_ADD_TYPE_ID((broker::expire_command))
   BROKER_ADD_TYPE_ID((broker::filter_type))
+  BROKER_ADD_TYPE_ID((broker::hub_id))
   BROKER_ADD_TYPE_ID((broker::internal::command_consumer_res))
   BROKER_ADD_TYPE_ID((broker::internal::command_producer_res))
   BROKER_ADD_TYPE_ID((broker::internal::connector_event_id))

--- a/libbroker/broker/peering.test.cc
+++ b/libbroker/broker/peering.test.cc
@@ -6,7 +6,6 @@
 #include "broker/endpoint.hh"
 
 #include <atomic>
-#include <condition_variable>
 #include <future>
 #include <iostream>
 #include <mutex>

--- a/libbroker/broker/publisher.cc
+++ b/libbroker/broker/publisher.cc
@@ -3,203 +3,69 @@
 #include <future>
 #include <numeric>
 
-#include <caf/flow/observable.hpp>
-#include <caf/scheduled_actor/flow.hpp>
-#include <caf/send.hpp>
-
 #include "broker/builder.hh"
 #include "broker/data.hh"
 #include "broker/detail/assert.hh"
-#include "broker/detail/flare.hh"
 #include "broker/endpoint.hh"
-#include "broker/internal/endpoint_access.hh"
+#include "broker/internal/native.hh"
+#include "broker/internal/publisher_queue.hh"
 #include "broker/internal/type_id.hh"
 #include "broker/logger.hh"
 #include "broker/message.hh"
 #include "broker/topic.hh"
 
-namespace broker::detail {
-
-using broker::internal::facade;
-using broker::internal::native;
+#include <caf/flow/observable.hpp>
+#include <caf/send.hpp>
 
 namespace atom = broker::internal::atom;
 
-struct publisher_queue : public caf::ref_counted, public caf::async::producer {
-public:
-  using value_type = data_message;
-
-  using buffer_type = caf::async::spsc_buffer<value_type>;
-
-  using buffer_ptr = caf::async::spsc_buffer_ptr<value_type>;
-
-  using guard_type = std::unique_lock<std::mutex>;
-
-  explicit publisher_queue(buffer_ptr buf) : buf_(std::move(buf)) {
-    // nop
-  }
-
-  ~publisher_queue() override {
-    if (buf_)
-      buf_->close();
-  }
-
-  buffer_type& buf() {
-    return *buf_;
-  }
-
-  void on_consumer_ready() override {
-    // nop
-  }
-
-  void on_consumer_cancel() override {
-    guard_type guard{mtx_};
-    cancelled_ = true;
-    if (demand_ == 0)
-      fx_.fire();
-  }
-
-  void on_consumer_demand(size_t demand) override {
-    BROKER_ASSERT(demand > 0);
-    guard_type guard{mtx_};
-    if (demand_ == 0) {
-      demand_ = demand;
-      fx_.fire();
-    } else {
-      demand_ += demand;
-    }
-  }
-
-  void ref_producer() const noexcept override {
-    ref();
-  }
-
-  void deref_producer() const noexcept override {
-    deref();
-  }
-
-  size_t demand() const noexcept {
-    guard_type guard{mtx_};
-    return demand_;
-  }
-
-  auto fd() const {
-    return fx_.fd();
-  }
-
-  void wait_on_flare() {
-    fx_.await_one();
-  }
-
-  void push(caf::span<const value_type> items) {
-    if (items.empty())
-      return;
-    guard_type guard{mtx_};
-    if (cancelled_)
-      return;
-    while (demand_ == 0) {
-      guard.unlock();
-      fx_.await_one();
-      guard.lock();
-      if (cancelled_)
-        return;
-    }
-    if (items.size() < demand_) {
-      demand_ -= items.size();
-      guard.unlock();
-      buf_->push(items);
-    } else {
-      auto n = demand_;
-      demand_ = 0;
-      fx_.extinguish();
-      guard.unlock();
-      buf_->push(items.subspan(0, n));
-      push(items.subspan(n));
-    }
-  }
-
-  friend void intrusive_ptr_add_ref(const publisher_queue* ptr) noexcept {
-    ptr->ref();
-  }
-
-  friend void intrusive_ptr_release(const publisher_queue* ptr) noexcept {
-    ptr->deref();
-  }
-
-private:
-  /// Provides access to the shared producer-consumer buffer.
-  buffer_ptr buf_;
-
-  /// Guards access to other member variables.
-  mutable std::mutex mtx_;
-
-  /// Signals to users when data can be read or written.
-  mutable detail::flare fx_;
-
-  /// Stores how many demand we currently have from the consumer.
-  size_t demand_ = 0;
-
-  /// Stores whether the consumer stopped receiving data.
-  bool cancelled_ = false;
-};
-
-namespace {
-
-auto* dptr(opaque_type* ptr) {
-  return reinterpret_cast<publisher_queue*>(ptr);
-}
-
-const auto* dptr(const opaque_type* ptr) {
-  return reinterpret_cast<const publisher_queue*>(ptr);
-}
-
-auto* dptr(const detail::opaque_ptr& ptr) {
-  return dptr(ptr.get());
-}
-
-detail::opaque_ptr make_opaque(caf::intrusive_ptr<publisher_queue> ptr) {
-  caf::ref_counted* raw = ptr.release();
-  return detail::opaque_ptr{reinterpret_cast<detail::opaque_type*>(raw), false};
-}
-
-} // namespace
-
-} // namespace broker::detail
-
-using broker::detail::dptr;
-
 namespace broker {
 
-publisher::publisher(detail::opaque_ptr q, topic t)
-  : queue_(std::move(q)), topic_(std::move(t)) {
+publisher::publisher(internal::publisher_queue* q, topic t)
+  : queue_(q), topic_(std::move(t)) {
   // nop
 }
 
+publisher::publisher(publisher&& other) noexcept
+  : queue_(nullptr), topic_(std::move(other.topic_)) {
+  std::swap(queue_, other.queue_);
+}
+
+publisher& publisher::operator=(publisher&& other) noexcept {
+  if (this != &other) {
+    std::swap(queue_, other.queue_);
+    std::swap(topic_, other.topic_);
+  }
+  return *this;
+}
+
 publisher::~publisher() {
-  reset();
+  if (queue_ != nullptr) {
+    intrusive_ptr_release(queue_);
+  }
 }
 
 publisher publisher::make(endpoint& ep, topic t) {
   using caf::async::make_spsc_buffer_resource;
   auto [cons_res, prod_res] = make_spsc_buffer_resource<value_type>();
-  caf::anon_send(native(ep.core()), std::move(cons_res));
+  caf::anon_send(internal::native(ep.core()), std::move(cons_res));
   auto buf = prod_res.try_open();
   BROKER_ASSERT(buf != nullptr);
-  auto qptr = caf::make_counted<detail::publisher_queue>(buf);
+  auto* qptr = new internal::publisher_queue(buf);
   buf->set_producer(qptr);
-  return publisher{detail::make_opaque(std::move(qptr)), std::move(t)};
+  return publisher{qptr, std::move(t)};
 }
 
 size_t publisher::demand() const {
-  return dptr(queue_)->demand();
+  return queue_->demand();
 }
 
 size_t publisher::buffered() const {
-  return dptr(queue_)->buf().available();
+  return queue_->buf().available();
 }
 
 size_t publisher::capacity() const {
-  return dptr(queue_)->buf().capacity();
+  return queue_->buf().capacity();
 }
 
 size_t publisher::free_capacity() const {
@@ -209,7 +75,7 @@ size_t publisher::free_capacity() const {
 }
 
 detail::native_socket publisher::fd() const {
-  return dptr(queue_)->fd();
+  return queue_->fd();
 }
 
 void publisher::drop_all_on_destruction() {
@@ -219,7 +85,7 @@ void publisher::drop_all_on_destruction() {
 void publisher::publish(const data& x) {
   auto msg = make_data_message(topic_, x);
   log::endpoint::debug("publish", "publishing {}", msg);
-  dptr(queue_)->push(caf::make_span(&msg, 1));
+  queue_->push(caf::make_span(&msg, 1));
 }
 
 void publisher::publish(const std::vector<data>& xs) {
@@ -229,28 +95,29 @@ void publisher::publish(const std::vector<data>& xs) {
     msgs.push_back(make_data_message(topic_, x));
   log::endpoint::debug("publish-batch", "publishing a batch of size {}",
                        xs.size());
-  dptr(queue_)->push(msgs);
+  queue_->push(msgs);
 }
 
 void publisher::publish(set_builder&& x) {
   auto msg = std::move(x).build_envelope(topic_.string());
-  dptr(queue_)->push(caf::make_span(&msg, 1));
+  queue_->push(caf::make_span(&msg, 1));
 }
 
 void publisher::publish(table_builder&& x) {
   auto msg = std::move(x).build_envelope(topic_.string());
-  dptr(queue_)->push(caf::make_span(&msg, 1));
+  queue_->push(caf::make_span(&msg, 1));
 }
 
 void publisher::publish(list_builder&& x) {
   auto msg = std::move(x).build_envelope(topic_.string());
-  dptr(queue_)->push(caf::make_span(&msg, 1));
+  queue_->push(caf::make_span(&msg, 1));
 }
 
 void publisher::reset() {
-  if (queue_) {
-    dptr(queue_)->buf().close();
-    queue_.reset();
+  if (queue_ != nullptr) {
+    queue_->buf().close();
+    intrusive_ptr_release(queue_);
+    queue_ = nullptr;
   }
 }
 

--- a/libbroker/broker/publisher.cc
+++ b/libbroker/broker/publisher.cc
@@ -116,7 +116,7 @@ void publisher::publish(list_builder&& content) {
 }
 
 void publisher::reset() {
-  if (impl_ == nullptr) {
+  if (impl_) {
     impl_ = nullptr;
   }
 }

--- a/libbroker/broker/publisher.cc
+++ b/libbroker/broker/publisher.cc
@@ -94,25 +94,25 @@ void publisher::drop_all_on_destruction() {
 }
 
 void publisher::publish(const data& val) {
-  impl_->publish(dst_, make_data_message(dst_, val));
+  impl_->publish(make_data_message(dst_, val));
 }
 
 void publisher::publish(const std::vector<data>& vals) {
   for (auto& val : vals) {
-    impl_->publish(dst_, make_data_message(dst_, val));
+    impl_->publish(make_data_message(dst_, val));
   }
 }
 
 void publisher::publish(set_builder&& content) {
-  impl_->publish(dst_, std::move(content).build_envelope(dst_.string()));
+  impl_->publish(std::move(content).build_envelope(dst_.string()));
 }
 
 void publisher::publish(table_builder&& content) {
-  impl_->publish(dst_, std::move(content).build_envelope(dst_.string()));
+  impl_->publish(std::move(content).build_envelope(dst_.string()));
 }
 
 void publisher::publish(list_builder&& content) {
-  impl_->publish(dst_, std::move(content).build_envelope(dst_.string()));
+  impl_->publish(std::move(content).build_envelope(dst_.string()));
 }
 
 void publisher::reset() {

--- a/libbroker/broker/publisher.hh
+++ b/libbroker/broker/publisher.hh
@@ -2,13 +2,18 @@
 
 #include "broker/detail/native_socket.hh"
 #include "broker/detail/opaque_type.hh"
-#include "broker/entity_id.hh"
 #include "broker/fwd.hh"
 #include "broker/message.hh"
 
-#include <chrono>
 #include <cstddef>
+#include <mutex>
 #include <vector>
+
+namespace broker::internal {
+
+class publisher_queue;
+
+} // namespace broker::internal
 
 namespace broker {
 
@@ -27,9 +32,9 @@ public:
 
   // --- constructors and destructors ------------------------------------------
 
-  publisher(publisher&&) = default;
+  publisher(publisher&&) noexcept;
 
-  publisher& operator=(publisher&&) = default;
+  publisher& operator=(publisher&&) noexcept;
 
   publisher(const publisher&) = delete;
 
@@ -99,10 +104,12 @@ public:
   void reset();
 
 private:
-  // -- force users to use `endpoint::make_publsiher` -------------------------
-  publisher(detail::opaque_ptr q, topic t);
+  // Private to force users to use `endpoint::make_publsiher`.
+  // Note: takes ownership of `q` (not increasing ref count!).
+  publisher(internal::publisher_queue* q, topic t);
 
-  detail::opaque_ptr queue_;
+
+  internal::publisher_queue* queue_;
   topic topic_;
   bool drop_on_destruction_ = false;
 };

--- a/libbroker/broker/publisher.hh
+++ b/libbroker/broker/publisher.hh
@@ -11,7 +11,7 @@
 
 namespace broker::internal {
 
-class publisher_queue;
+class hub_impl;
 
 } // namespace broker::internal
 
@@ -32,9 +32,9 @@ public:
 
   // --- constructors and destructors ------------------------------------------
 
-  publisher(publisher&&) noexcept;
+  publisher(publisher&&) noexcept = default;
 
-  publisher& operator=(publisher&&) noexcept;
+  publisher& operator=(publisher&&) noexcept = default;
 
   publisher(const publisher&) = delete;
 
@@ -68,26 +68,25 @@ public:
 
   // --- mutators --------------------------------------------------------------
 
-  /// Forces the publisher to drop all remaining items from the queue when the
-  /// destructor gets called.
+  /// @deprecated No longer has any effect.
   void drop_all_on_destruction();
 
   // --- messaging -------------------------------------------------------------
 
   /// Sends `x` to all subscribers.
-  void publish(const data& x);
+  void publish(const data& val);
 
   /// Sends `xs` to all subscribers.
-  void publish(const std::vector<data>& xs);
+  void publish(const std::vector<data>& vals);
 
   /// Sends `x` to all subscribers.
-  void publish(set_builder&& x);
+  void publish(set_builder&& content);
 
   /// Sends `x` to all subscribers.
-  void publish(table_builder&& x);
+  void publish(table_builder&& content);
 
   /// Sends `x` to all subscribers.
-  void publish(list_builder&& x);
+  void publish(list_builder&& content);
 
   // --- miscellaneous ---------------------------------------------------------
 
@@ -106,12 +105,10 @@ public:
 private:
   // Private to force users to use `endpoint::make_publsiher`.
   // Note: takes ownership of `q` (not increasing ref count!).
-  publisher(internal::publisher_queue* q, topic t);
+  publisher(topic dst, std::shared_ptr<internal::hub_impl> impl);
 
-
-  internal::publisher_queue* queue_;
-  topic topic_;
-  bool drop_on_destruction_ = false;
+  topic dst_;
+  std::shared_ptr<internal::hub_impl> impl_;
 };
 
 } // namespace broker

--- a/libbroker/broker/subscriber.cc
+++ b/libbroker/broker/subscriber.cc
@@ -17,161 +17,104 @@
 #include "broker/detail/assert.hh"
 #include "broker/endpoint.hh"
 #include "broker/filter_type.hh"
+#include "broker/hub.hh"
+#include "broker/internal/endpoint_access.hh"
+#include "broker/internal/hub_impl.hh"
 #include "broker/internal/native.hh"
 #include "broker/internal/subscriber_queue.hh"
 #include "broker/internal/type_id.hh"
 #include "broker/logger.hh"
 
-using broker::internal::native;
-
-namespace broker::detail {
-
-namespace {
-
-auto* dptr(detail::opaque_type* ptr) {
-  auto bptr = reinterpret_cast<caf::ref_counted*>(ptr);
-  return static_cast<internal::subscriber_queue*>(bptr);
-}
-
-auto* dptr(const detail::opaque_ptr& ptr) {
-  return dptr(ptr.get());
-}
-
-detail::opaque_ptr
-make_opaque(caf::intrusive_ptr<internal::subscriber_queue> ptr) {
-  caf::ref_counted* raw = ptr.release();
-  return detail::opaque_ptr{reinterpret_cast<detail::opaque_type*>(raw), false};
-}
-
-} // namespace
-
-} // namespace broker::detail
-
-using broker::detail::dptr;
+using namespace std::literals;
 
 namespace broker {
 
-subscriber::subscriber(detail::opaque_ptr queue,
-                       std::shared_ptr<filter_type> filter, worker core)
-  : queue_(std::move(queue)),
-    core_(std::move(core)),
-    core_filter_(std::move(filter)) {
+subscriber::subscriber(std::shared_ptr<internal::hub_impl> ptr)
+  : impl_(std::move(ptr)) {
   // nop
 }
 
 subscriber::~subscriber() {
-  reset();
+  // nop; must be out-of-line to avoid header dependencies.
 }
 
 subscriber subscriber::make(endpoint& ep, filter_type filter, size_t) {
-  log::endpoint::info("creating-subscriber",
-                      "creating subscriber for topic(s): {}", filter);
   using caf::async::make_spsc_buffer_resource;
-  auto fptr = std::make_shared<filter_type>(std::move(filter));
-  auto [con_res, prod_res] = make_spsc_buffer_resource<data_message>();
-  caf::anon_send(native(ep.core()), fptr, std::move(prod_res));
-  auto buf = con_res.try_open();
-  BROKER_ASSERT(buf != nullptr);
-  auto qptr = caf::make_counted<internal::subscriber_queue>(buf);
-  buf->set_consumer(qptr);
-  return subscriber{detail::make_opaque(std::move(qptr)), std::move(fptr),
-                    ep.core()};
+  auto id = hub::next_id();
+  // Produce the queue for the hub.
+  auto [src, snk] = make_spsc_buffer_resource<data_message>();
+  // Use the queue for reading.
+  auto sub_buf = src.try_open();
+  BROKER_ASSERT(sub_buf != nullptr);
+  auto sub = caf::make_counted<internal::subscriber_queue>(sub_buf);
+  sub_buf->set_consumer(sub);
+  // Connect the buffers to the core.
+  auto& core = internal::native(ep.core());
+  auto& sys = internal::endpoint_access{&ep}.sys();
+  caf::scoped_actor self{sys};
+  self
+    ->request(core, 2s, id, std::move(filter), true,
+              internal::data_consumer_res{}, std::move(snk))
+    .receive(
+      [] {
+        // OK, the core has completed the setup.
+      },
+      [](const caf::error& what) {
+        log::core::error("cannot-create-hub", "failed to create hub: {}", what);
+        throw std::runtime_error("cannot create hub");
+      });
+  // Wrap the queues in shared pointers and create the hub.
+  return subscriber{std::make_shared<internal::hub_impl>(id, core, sub, nullptr,
+                                                         std::move(filter))};
 }
 
 data_message subscriber::get() {
-  data_message msg;
-  if (!dptr(queue_)->pull(msg)) {
-    throw std::runtime_error("subscriber queue closed");
-  }
-  return msg;
+  return impl_->get();
 }
 
 std::vector<data_message> subscriber::get(size_t num) {
-  BROKER_ASSERT(num > 0);
-  auto q = dptr(queue_);
-  std::vector<data_message> buf;
-  buf.reserve(num);
-  q->pull(buf, num);
-  while (buf.size() < num) {
-    wait();
-    if (!q->pull(buf, num))
-      return buf;
-  }
-  return buf;
+  return impl_->get(num);
 }
 
 std::vector<data_message> subscriber::do_get(size_t num,
                                              timestamp abs_timeout) {
-  std::vector<data_message> buf;
-  do_get(buf, num, abs_timeout);
-  return buf;
+  return impl_->get(num, abs_timeout);
 }
 
 void subscriber::do_get(std::vector<data_message>& buf, size_t num,
                         timestamp abs_timeout) {
-  auto q = dptr(queue_);
-  buf.clear();
-  buf.reserve(num);
-  q->pull(buf, num);
-  while (buf.size() < num && wait_until(abs_timeout))
-    q->pull(buf, num);
+  buf = impl_->get(num, abs_timeout);
 }
 
 std::vector<data_message> subscriber::poll() {
-  // The Queue may return a capacity of 0 if the producer has closed the flow.
-  std::vector<data_message> buf;
-  auto q = dptr(queue_);
-  auto max_size = q->capacity();
-  if (max_size > 0) {
-    buf.reserve(max_size);
-    q->pull(buf, max_size);
-  }
-  return buf;
+  return impl_->poll();
 }
 
 size_t subscriber::available() const noexcept {
-  return dptr(queue_)->available();
+  return impl_->available();
 }
 
 detail::native_socket subscriber::fd() const noexcept {
-  return dptr(queue_)->fd();
+  return impl_->read_fd();
 }
 
 void subscriber::add_topic(topic x, bool block) {
   log::endpoint::info("subscriber-add-topic", "add topic {} to subscriber", x);
-  update_filter(std::move(x), true, block);
+  impl_->subscribe(x, block);
 }
 
 void subscriber::remove_topic(topic x, bool block) {
   log::endpoint::info("subscriber-remove-topic",
                       "remove topic {} from subscriber", x);
-  update_filter(std::move(x), false, block);
+  impl_->unsubscribe(x, block);
 }
 
 void subscriber::reset() {
-  if (queue_) {
-    dptr(queue_)->cancel();
-    queue_ = nullptr;
-    core_ = nullptr;
-  }
-}
-
-void subscriber::update_filter(topic what, bool add, bool block) {
-  using internal::native;
-  if (!block) {
-    caf::anon_send(native(core_), core_filter_, std::move(what), add,
-                   std::shared_ptr<std::promise<void>>{nullptr});
-  } else {
-    auto sync = std::make_shared<std::promise<void>>();
-    auto vfut = sync->get_future();
-    caf::anon_send(native(core_), core_filter_, std::move(what), add,
-                   std::move(sync));
-    vfut.get();
-  }
+  impl_ = nullptr;
 }
 
 void subscriber::wait() {
-  dptr(queue_)->wait();
+  impl_->read_queue()->wait();
 }
 
 bool subscriber::wait_for(timespan rel_timeout) {
@@ -179,7 +122,7 @@ bool subscriber::wait_for(timespan rel_timeout) {
 }
 
 bool subscriber::wait_until(timestamp abs_timeout) {
-  return dptr(queue_)->wait_until(abs_timeout);
+  return impl_->read_queue()->wait_until(abs_timeout);
 }
 
 } // namespace broker

--- a/libbroker/broker/subscriber.cc
+++ b/libbroker/broker/subscriber.cc
@@ -69,6 +69,7 @@ subscriber subscriber::make(endpoint& ep, filter_type filter, size_t) {
 }
 
 data_message subscriber::get() {
+  impl_->read_queue()->wait();
   return impl_->get();
 }
 

--- a/libbroker/broker/subscriber.cc
+++ b/libbroker/broker/subscriber.cc
@@ -1,9 +1,9 @@
 #include "broker/subscriber.hh"
 
-#include <chrono>
 #include <cstddef>
 #include <future>
 #include <numeric>
+#include <stdexcept>
 #include <utility>
 
 #include <caf/async/consumer.hpp>
@@ -15,11 +15,10 @@
 #include <caf/stateful_actor.hpp>
 
 #include "broker/detail/assert.hh"
-#include "broker/detail/flare.hh"
 #include "broker/endpoint.hh"
 #include "broker/filter_type.hh"
-#include "broker/internal/endpoint_access.hh"
 #include "broker/internal/native.hh"
+#include "broker/internal/subscriber_queue.hh"
 #include "broker/internal/type_id.hh"
 #include "broker/logger.hh"
 
@@ -27,171 +26,19 @@ using broker::internal::native;
 
 namespace broker::detail {
 
-struct subscriber_queue : public caf::ref_counted, public caf::async::consumer {
-public:
-  using buffer_type = caf::async::spsc_buffer<data_message>;
-
-  using buffer_ptr = caf::async::spsc_buffer_ptr<data_message>;
-
-  using guard_type = std::unique_lock<std::mutex>;
-
-  explicit subscriber_queue(buffer_ptr buf) : buf_(std::move(buf)) {
-    // nop
-  }
-
-  ~subscriber_queue() override {
-    if (buf_)
-      buf_->cancel();
-  }
-
-  void on_producer_ready() override {
-    // nop
-  }
-
-  void on_producer_wakeup() override {
-    guard_type guard{mtx_};
-    if (!ready_) {
-      fx_.fire();
-      ready_ = true;
-    }
-  }
-
-  void wait() {
-    guard_type guard{mtx_};
-    while (!ready_) {
-      guard.unlock();
-      fx_.await_one();
-      guard.lock();
-    }
-  }
-
-  bool wait_until(timestamp abs_timeout) {
-    guard_type guard{mtx_};
-    while (!ready_) {
-      guard.unlock();
-      if (!fx_.await_one(abs_timeout)) {
-        guard.lock();
-        return ready_;
-      }
-      guard.lock();
-    }
-    return true;
-  }
-
-  void ref_consumer() const noexcept override {
-    this->ref();
-  }
-
-  void deref_consumer() const noexcept override {
-    this->deref();
-  }
-
-  auto fd() const noexcept {
-    return fx_.fd();
-  }
-
-  void cancel() {
-    if (buf_)
-      buf_->cancel();
-  }
-
-  void extinguish() {
-    guard_type guard{mtx_};
-    if (ready_) {
-      ready_ = false;
-      fx_.extinguish();
-    }
-  }
-
-  bool pull(std::vector<data_message>& dst, size_t num) {
-    BROKER_ASSERT(num > 0);
-    BROKER_ASSERT(dst.size() < num);
-    struct cb {
-      subscriber_queue* qptr;
-      std::vector<data_message>* dst;
-      void on_next(const data_message& val) {
-        dst->push_back(val);
-      }
-      void on_complete() {
-        qptr->extinguish();
-      }
-      void on_error(const caf::error&) {
-        qptr->extinguish();
-      }
-    };
-    using caf::async::delay_errors;
-    cb consumer{this, &dst};
-    if (buf_) {
-      auto [open, n] = buf_->pull(delay_errors, num - dst.size(), consumer);
-      log::endpoint::debug("subscriber-pull",
-                           "got {} messages from bounded buffer", n);
-      if (!open) {
-        log::endpoint::debug("subscriber-queue-closed",
-                             "nothing left to pull, queue closed");
-        buf_ = nullptr;
-        return false;
-      } else if (buf_->available() == 0) {
-        // Note: We always *must* acquire the lock on the buffer before
-        // acquiring the lock on the subscriber to prevent deadlocks.
-        guard_type buf_guard{buf_->mtx()};
-        guard_type sub_guard{mtx_};
-        if (ready_ && buf_->available_unsafe() == 0) {
-          ready_ = false;
-          fx_.extinguish();
-        }
-        return true;
-      } else {
-        return true;
-      }
-    } else {
-      log::endpoint::debug("subscriber-queue-closed",
-                           "nothing left to pull, queue closed");
-      return false;
-    }
-  }
-
-  size_t capacity() const noexcept {
-    return buf_ ? buf_->capacity() : size_t{0};
-  }
-
-  size_t available() const noexcept {
-    return buf_ ? buf_->available() : size_t{0};
-  }
-
-  friend void intrusive_ptr_add_ref(const subscriber_queue* ptr) noexcept {
-    ptr->ref();
-  }
-
-  friend void intrusive_ptr_release(const subscriber_queue* ptr) noexcept {
-    ptr->deref();
-  }
-
-private:
-  /// Provides access to the shared buffer.
-  buffer_ptr buf_;
-
-  /// Guards access to other member variables.
-  mutable std::mutex mtx_;
-
-  /// Signals to users when data can be read or written.
-  mutable detail::flare fx_;
-
-  /// Stores whether we have data available.
-  bool ready_ = false;
-};
-
 namespace {
 
 auto* dptr(detail::opaque_type* ptr) {
   auto bptr = reinterpret_cast<caf::ref_counted*>(ptr);
-  return static_cast<subscriber_queue*>(bptr);
+  return static_cast<internal::subscriber_queue*>(bptr);
 }
 
 auto* dptr(const detail::opaque_ptr& ptr) {
   return dptr(ptr.get());
 }
 
-detail::opaque_ptr make_opaque(caf::intrusive_ptr<subscriber_queue> ptr) {
+detail::opaque_ptr
+make_opaque(caf::intrusive_ptr<internal::subscriber_queue> ptr) {
   caf::ref_counted* raw = ptr.release();
   return detail::opaque_ptr{reinterpret_cast<detail::opaque_type*>(raw), false};
 }
@@ -225,18 +72,18 @@ subscriber subscriber::make(endpoint& ep, filter_type filter, size_t) {
   caf::anon_send(native(ep.core()), fptr, std::move(prod_res));
   auto buf = con_res.try_open();
   BROKER_ASSERT(buf != nullptr);
-  auto qptr = caf::make_counted<detail::subscriber_queue>(buf);
+  auto qptr = caf::make_counted<internal::subscriber_queue>(buf);
   buf->set_consumer(qptr);
   return subscriber{detail::make_opaque(std::move(qptr)), std::move(fptr),
                     ep.core()};
 }
 
 data_message subscriber::get() {
-  auto tmp = get(1);
-  BROKER_ASSERT(tmp.size() == 1);
-  auto x = std::move(tmp.front());
-  log::endpoint::debug("subscriber-get", "subscriber received: {}", x);
-  return x;
+  data_message msg;
+  if (!dptr(queue_)->pull(msg)) {
+    throw std::runtime_error("subscriber queue closed");
+  }
+  return msg;
 }
 
 std::vector<data_message> subscriber::get(size_t num) {

--- a/libbroker/broker/subscriber.cc
+++ b/libbroker/broker/subscriber.cc
@@ -53,8 +53,8 @@ subscriber subscriber::make(endpoint& ep, filter_type filter, size_t) {
   auto& sys = internal::endpoint_access{&ep}.sys();
   caf::scoped_actor self{sys};
   self
-    ->request(core, 2s, id, std::move(filter), true,
-              internal::data_consumer_res{}, std::move(snk))
+    ->request(core, 2s, id, filter, true, internal::data_consumer_res{},
+              std::move(snk))
     .receive(
       [] {
         // OK, the core has completed the setup.

--- a/libbroker/broker/subscriber.hh
+++ b/libbroker/broker/subscriber.hh
@@ -11,6 +11,12 @@
 #include <functional>
 #include <vector>
 
+namespace broker::internal {
+
+class hub_impl;
+
+} // namespace broker::internal
+
 namespace broker {
 
 /// Provides blocking access to a stream of data.
@@ -132,8 +138,7 @@ public:
   void reset();
 
 private:
-  subscriber(detail::opaque_ptr queue, std::shared_ptr<filter_type> core_filter,
-             worker core);
+  explicit subscriber(std::shared_ptr<internal::hub_impl> impl);
 
   void update_filter(topic x, bool add, bool block);
 
@@ -156,7 +161,7 @@ private:
 
   /// Points to the filter held by the core actor. May only be touched in the
   /// context of the core.
-  std::shared_ptr<filter_type> core_filter_;
+  std::shared_ptr<internal::hub_impl> impl_;
 };
 
 } // namespace broker


### PR DESCRIPTION
@awelzel this is ready for some testing now. I've re-implemented the old primitives using the new `hub` so that Broker now only knows hubs internally. Nothing changes for existing code: when using a `subscriber`, it will still filter out locally published messages from other hubs. Messages published locally by other hubs (or publishers or when using `endpoint::publish`) are visible only when using the new `hub` API directly.