### PR TITLE
Remove obsolete CMake/configure options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,23 +56,6 @@ if (NOT broker_is_subproject)
       set(_sanitizer_flags "${_sanitizer_flags} -fno-omit-frame-pointer")
       set(_sanitizer_flags "${_sanitizer_flags} -fno-optimize-sibling-calls")
 
-      if ( NOT DEFINED BROKER_SANITIZER_OPTIMIZATIONS )
-        if ( DEFINED ENV{NO_OPTIMIZATIONS} )
-          # Using -O1 is generally the suggestion to get more reasonable
-          # performance.  The one downside is it that the compiler may optimize
-          # out code that otherwise generates an error/leak in a -O0 build, but
-          # that should be rare and users mostly will not be running unoptimized
-          # builds in production anyway.
-          set(BROKER_SANITIZER_OPTIMIZATIONS false CACHE INTERNAL "" FORCE)
-        else ()
-          set(BROKER_SANITIZER_OPTIMIZATIONS true CACHE INTERNAL "" FORCE)
-        endif ()
-      endif ()
-
-      if ( BROKER_SANITIZER_OPTIMIZATIONS )
-        set(_sanitizer_flags "${_sanitizer_flags} -O1")
-      endif ()
-
       # Technically, then we also need to use the compiler to drive linking and
       # give the sanitizer flags there, too.  However, CMake, by default, uses
       # the compiler for linking and so the flags automatically get used.  See

--- a/configure
+++ b/configure
@@ -19,15 +19,12 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
                                    debug symbols on, debug flags off
     --ccache               use ccache to speed up recompilation (requires
                            ccache installation and CMake 3.10+)
-    --enable-debug         compile in debugging mode (like --build-type=Debug)
     --enable-static        build static libraries (in addition to shared)
     --enable-static-only   only build static libraries, not shared
     --with-log-level=LVL   enable debugging output via the CAF logger.
                            Levels: ERROR, WARNING, INFO, DEBUG, TRACE
     --with-clang-tidy      run with clang-tidy (requires CMake >= 3.7.2)
     --sanitizers=LIST      comma-separated list of sanitizer names to enable
-    --disable-sanitizer-optimizations
-                           build without any optimizations when using sanitizers
 
   Installation Directories:
     --prefix=PREFIX        installation directory [/usr/local]
@@ -136,9 +133,6 @@ while [ $# -ne 0 ]; do
         --build-type=*)
             append_cache_entry CMAKE_BUILD_TYPE     STRING $optarg
             ;;
-        --enable-debug)
-            append_cache_entry BROKER_ENABLE_DEBUG  BOOL   true
-            ;;
         --enable-static)
             append_cache_entry ENABLE_STATIC        BOOL   true
             ;;
@@ -148,9 +142,6 @@ while [ $# -ne 0 ]; do
         --sanitizers=*)
             append_cache_entry BROKER_SANITIZERS    STRING    $optarg
             ;;
-        --disable-sanitizer-optimizations)
-            append_cache_entry BROKER_SANITIZER_OPTIMIZATIONS BOOL OFF
-          ;;
         --enable-static-only)
             append_cache_entry ENABLE_STATIC_ONLY   BOOL   true
             ;;


### PR DESCRIPTION
- `BROKER_ENABLE_DEBUG` is stale and does nothing.
- `BROKER_SANITIZER_OPTIMIZATIONS` is just wrong. Selecting optimization levels is what the build type is for.