### PR TITLE
Move to building everything with C++ 20

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,101 @@
+{
+  "parse": {
+    "additional_commands": {
+      "CheckIPProto": {
+        "kwargs": {
+          "_proto": "*"
+        }
+      },
+      "CheckType": {
+        "kwargs": {
+          "_type": "*",
+          "_alt_type": "*",
+          "_var": "*"
+        }
+      },
+      "SetPackageVersion": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageFileName": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageInstallScripts": {
+        "kwargs": {
+          "VERSION": "*"
+        }
+      },
+      "ConfigurePackaging": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageGenerators": {},
+      "SetPackageMetadata": {},
+      "FindRequiredPackage": {
+        "kwargs": {
+          "packageName": "*"
+        }
+      },
+      "InstallClobberImmune": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstfile": "*"
+        }
+      },
+      "InstallPackageConfigFile": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstdir": "*",
+          "_dstfilename": "*"
+        }
+      },
+      "InstallShellScript": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstfile": "*"
+        }
+      },
+      "InstallSymLink": {
+        "kwargs": {
+          "_filepath": "*",
+          "_sympath": "*"
+        }
+      },
+      "spicy_add_analyzer": {
+        "kwargs": {
+          "NAME": "*",
+          "PACKAGE_NAME": "*",
+          "SOURCES": "*",
+          "MODULES": "*"
+        }
+      },
+      "zeek_add_plugin": {
+        "kwargs": {
+          "INCLUDE_DIRS": "*",
+          "DEPENDENCIES": "*",
+          "SOURCES": "*",
+          "BIFS": "*",
+          "PAC": "*"
+        }
+      }
+    }
+  },
+  "format": {
+    "always_wrap": [
+      "spicy_add_analyzer",
+      "zeek_add_plugin"
+    ],
+    "line_width": 100,
+    "tab_size": 4,
+    "separate_ctrl_name_with_space": true,
+    "max_subgroups_hwrap": 3,
+    "line_ending": "unix"
+  },
+  "markup": {
+    "enable_markup": false
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
     - id: ruff-format
     - id: ruff
       args: [--fix]
+
+- repo: https://github.com/cheshirekow/cmake-format-precommit
+  rev: v0.6.13
+  hooks:
+  - id: cmake-format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,67 +11,67 @@ include(cmake/ZeekBundle.cmake)
 set(BROKER_TEST_TIMEOUT 60)
 
 get_directory_property(parent_dir PARENT_DIRECTORY)
-if(parent_dir)
-  set(broker_is_subproject ON)
-else()
-  set(broker_is_subproject OFF)
-endif()
+if (parent_dir)
+    set(broker_is_subproject ON)
+else ()
+    set(broker_is_subproject OFF)
+endif ()
 unset(parent_dir)
 
-if ( MSVC )
-  message(STATUS "Broker currently only supports static bulids on Windows")
-  message(STATUS "Note: continue with ENABLE_STATIC_ONLY")
-  set(ENABLE_STATIC_ONLY ON)
+if (MSVC)
+    message(STATUS "Broker currently only supports static bulids on Windows")
+    message(STATUS "Note: continue with ENABLE_STATIC_ONLY")
+    set(ENABLE_STATIC_ONLY ON)
 endif ()
 
 # Check the thread library info early as setting compiler flags seems to
 # interfere with the detection and causes CMAKE_THREAD_LIBS_INIT to not
 # include -lpthread when it should.
 if (NOT TARGET Threads::Threads)
-  find_package(Threads REQUIRED)
+    find_package(Threads REQUIRED)
 endif ()
 set(LINK_LIBS ${LINK_LIBS} Threads::Threads)
 
 # Leave most compiler flags alone when building as subdirectory.
 if (NOT broker_is_subproject)
 
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
-  if ( ENABLE_CCACHE )
-    find_program(CCACHE_PROGRAM ccache)
+    if (ENABLE_CCACHE)
+        find_program(CCACHE_PROGRAM ccache)
 
-    if ( NOT CCACHE_PROGRAM )
-      message(FATAL_ERROR "ccache not found")
+        if (NOT CCACHE_PROGRAM)
+            message(FATAL_ERROR "ccache not found")
+        endif ()
+
+        message(STATUS "Using ccache: ${CCACHE_PROGRAM}")
+        set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+        set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
     endif ()
 
-    message(STATUS "Using ccache: ${CCACHE_PROGRAM}")
-    set(CMAKE_C_COMPILER_LAUNCHER   ${CCACHE_PROGRAM})
-    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
-  endif ()
+    if (BROKER_SANITIZERS)
+        set(_sanitizer_flags "-fsanitize=${BROKER_SANITIZERS}")
+        set(_sanitizer_flags "${_sanitizer_flags} -fno-omit-frame-pointer")
+        set(_sanitizer_flags "${_sanitizer_flags} -fno-optimize-sibling-calls")
 
-  if ( BROKER_SANITIZERS )
-      set(_sanitizer_flags "-fsanitize=${BROKER_SANITIZERS}")
-      set(_sanitizer_flags "${_sanitizer_flags} -fno-omit-frame-pointer")
-      set(_sanitizer_flags "${_sanitizer_flags} -fno-optimize-sibling-calls")
+        # Technically, then we also need to use the compiler to drive linking and
+        # give the sanitizer flags there, too.  However, CMake, by default, uses
+        # the compiler for linking and so the flags automatically get used.  See
+        # https://cmake.org/pipermail/cmake/2014-August/058268.html
+        set(CAF_EXTRA_FLAGS "${_sanitizer_flags}")
 
-      # Technically, then we also need to use the compiler to drive linking and
-      # give the sanitizer flags there, too.  However, CMake, by default, uses
-      # the compiler for linking and so the flags automatically get used.  See
-      # https://cmake.org/pipermail/cmake/2014-August/058268.html
-      set(CAF_EXTRA_FLAGS "${_sanitizer_flags}")
+        # Set EXTRA_FLAGS if broker isn't being built as part of a Zeek build.
+        # The Zeek build sets it otherwise.
+        if (NOT ZEEK_SANITIZERS)
+            set(EXTRA_FLAGS "${EXTRA_FLAGS} ${_sanitizer_flags}")
+        endif ()
+    endif ()
 
-      # Set EXTRA_FLAGS if broker isn't being built as part of a Zeek build.
-      # The Zeek build sets it otherwise.
-      if ( NOT ZEEK_SANITIZERS )
-        set(EXTRA_FLAGS "${EXTRA_FLAGS} ${_sanitizer_flags}")
-      endif ()
-  endif()
+endif ()
 
-endif()
-
-if ( MSVC )
+if (MSVC)
     # Allow more sections in object files, otherwise Broker fails to compile.
     set(EXTRA_FLAGS "${EXTRA_FLAGS} /bigobj")
     # Similar to -funsigned-char on other platforms.
@@ -100,7 +100,8 @@ include(CheckCXXSourceCompiles)
 # links and runs. Otherwise, we fall back to our pre-std-filesystem
 # implementation - or raise an error when building on Windows (since we don't
 # have a fallback on this platform).
-check_cxx_source_compiles("
+check_cxx_source_compiles(
+    "
   #include <cstdlib>
   #include <filesystem>
   int main(int, char**) {
@@ -109,63 +110,64 @@ check_cxx_source_compiles("
     return str.empty() ? EXIT_FAILURE : EXIT_SUCCESS;
   }
   "
-  BROKER_HAS_STD_FILESYSTEM)
+    BROKER_HAS_STD_FILESYSTEM)
 
 if (MSVC)
 
-  if (NOT BROKER_HAS_STD_FILESYSTEM)
-    message(FATAL_ERROR "No std::filesystem support! Required on MSVC.")
-  endif ()
+    if (NOT BROKER_HAS_STD_FILESYSTEM)
+        message(FATAL_ERROR "No std::filesystem support! Required on MSVC.")
+    endif ()
 
-  set(BROKER_USE_SSE2 OFF)
+    set(BROKER_USE_SSE2 OFF)
 
 elseif (NOT BROKER_DISABLE_SSE2_CHECK)
 
-  include(CheckIncludeFiles)
-  set(CMAKE_REQUIRED_FLAGS -msse2)
-  check_include_files(emmintrin.h BROKER_USE_SSE2)
-  set(CMAKE_REQUIRED_FLAGS)
+    include(CheckIncludeFiles)
+    set(CMAKE_REQUIRED_FLAGS -msse2)
+    check_include_files(emmintrin.h BROKER_USE_SSE2)
+    set(CMAKE_REQUIRED_FLAGS)
 
-  if (BROKER_USE_SSE2)
-    add_definitions(-msse2)
-  endif ()
+    if (BROKER_USE_SSE2)
+        add_definitions(-msse2)
+    endif ()
 
 endif ()
 
 if (NOT BROKER_DISABLE_ATOMICS_CHECK)
 
-  set(atomic_64bit_ops_test "
+    set(atomic_64bit_ops_test
+        "
     #include <atomic>
     struct s64 { char a, b, c, d, e, f, g, h; };
     int main() { std::atomic<s64> x; x.store({}); x.load(); return 0; }
   ")
-  check_cxx_source_compiles("${atomic_64bit_ops_test}" atomic64_builtin)
+    check_cxx_source_compiles("${atomic_64bit_ops_test}" atomic64_builtin)
 
-  if ( NOT atomic64_builtin )
-    set(CMAKE_REQUIRED_LIBRARIES atomic)
-    check_cxx_source_compiles("${atomic_64bit_ops_test}" atomic64_with_lib)
-    set(CMAKE_REQUIRED_LIBRARIES)
+    if (NOT atomic64_builtin)
+        set(CMAKE_REQUIRED_LIBRARIES atomic)
+        check_cxx_source_compiles("${atomic_64bit_ops_test}" atomic64_with_lib)
+        set(CMAKE_REQUIRED_LIBRARIES)
 
-    if ( atomic64_with_lib )
-      set(LINK_LIBS ${LINK_LIBS} atomic)
-    else ()
-      # Guess we'll find out for sure when we compile/link.
-      message(WARNING "build may fail due to missing 64-bit atomic support")
+        if (atomic64_with_lib)
+            set(LINK_LIBS ${LINK_LIBS} atomic)
+        else ()
+            # Guess we'll find out for sure when we compile/link.
+            message(WARNING "build may fail due to missing 64-bit atomic support")
+        endif ()
     endif ()
-  endif ()
 
 endif ()
 
 # -- Platform Setup ----------------------------------------------------------
 
 if (APPLE)
-  set(BROKER_APPLE true)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(BROKER_LINUX true)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  set(BROKER_FREEBSD true)
-elseif(WIN32)
-  set(BROKER_WINDOWS true)
+    set(BROKER_APPLE true)
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(BROKER_LINUX true)
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+    set(BROKER_FREEBSD true)
+elseif (WIN32)
+    set(BROKER_WINDOWS true)
 endif ()
 
 include(TestBigEndian)
@@ -174,44 +176,45 @@ test_big_endian(BROKER_BIG_ENDIAN)
 # -- Dependencies -------------------------------------------------------------
 
 if (WIN32)
-  set(LINK_LIBS ${LINK_LIBS} ws2_32 iphlpapi crypt32)
+    set(LINK_LIBS ${LINK_LIBS} ws2_32 iphlpapi crypt32)
 endif ()
 
 # Search for OpenSSL if not already provided by parent project
 if (NOT OPENSSL_LIBRARIES)
-  find_package(OpenSSL REQUIRED)
-  include_directories(BEFORE ${OPENSSL_INCLUDE_DIR})
-endif()
+    find_package(OpenSSL REQUIRED)
+    include_directories(BEFORE ${OPENSSL_INCLUDE_DIR})
+endif ()
 set(LINK_LIBS ${LINK_LIBS} OpenSSL::SSL OpenSSL::Crypto)
 
-function(add_bundled_caf)
-  # Disable unnecessary features and make sure CAF builds static libraries.
-  set(CAF_ENABLE_EXAMPLES OFF)
-  set(CAF_ENABLE_TESTING OFF)
-  set(CAF_ENABLE_TOOLS OFF)
-  set(BUILD_SHARED_LIBS OFF)
-  if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
-    add_subdirectory(caf EXCLUDE_FROM_ALL SYSTEM)
-  else()
-    add_subdirectory(caf EXCLUDE_FROM_ALL)
-  endif()
-  # Disable a few false positives / irrelevant warnings while building CAF.
-  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    target_compile_options(caf_internal INTERFACE -Wno-invalid-offsetof -Wno-documentation)
-  endif ()
-endfunction()
+function (add_bundled_caf)
+    # Disable unnecessary features and make sure CAF builds static libraries.
+    set(CAF_ENABLE_EXAMPLES OFF)
+    set(CAF_ENABLE_TESTING OFF)
+    set(CAF_ENABLE_TOOLS OFF)
+    set(BUILD_SHARED_LIBS OFF)
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+        add_subdirectory(caf EXCLUDE_FROM_ALL SYSTEM)
+    else ()
+        add_subdirectory(caf EXCLUDE_FROM_ALL)
+    endif ()
+    # Disable a few false positives / irrelevant warnings while building CAF.
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        target_compile_options(caf_internal INTERFACE -Wno-invalid-offsetof -Wno-documentation)
+    endif ()
+endfunction ()
 
 # Bundle prometheus-cpp. This approach is currently experimental.
 if (CMAKE_MSVC_RUNTIME_LIBRARY)
-    set(msvc_zeekbundle_args
-        CMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}
-        CMAKE_MSVC_RUNTIME_LIBRARY_FLAG=${CMAKE_MSVC_RUNTIME_LIBRARY_FLAG})
+    set(msvc_zeekbundle_args CMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}
+                             CMAKE_MSVC_RUNTIME_LIBRARY_FLAG=${CMAKE_MSVC_RUNTIME_LIBRARY_FLAG})
 endif ()
-ZeekBundle_Add(
-  NAME prometheus-cpp
-  FETCH
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/auxil/prometheus-cpp
-  CONFIGURE
+zeekbundle_add(
+    NAME
+    prometheus-cpp
+    FETCH
+    SOURCE_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR}/auxil/prometheus-cpp
+    CONFIGURE
     ${msvc_zeekbundle_args}
     ENABLE_COMPRESSION=OFF
     ENABLE_PUSH=OFF)
@@ -219,38 +222,33 @@ unset(msvc_zeekbundle_args)
 
 # Bundle all prometheus-cpp libraries that we need as single interface library.
 add_library(broker-prometheus-cpp INTERFACE)
-target_link_libraries(
-  broker-prometheus-cpp
-  INTERFACE
-    $<BUILD_INTERFACE:prometheus-cpp::core>
-    $<BUILD_INTERFACE:prometheus-cpp::pull>)
+target_link_libraries(broker-prometheus-cpp INTERFACE $<BUILD_INTERFACE:prometheus-cpp::core>
+                                                      $<BUILD_INTERFACE:prometheus-cpp::pull>)
 # Prometheus-cpp sets C++ 11 via CMake property, but we need C++ 17.
 target_compile_features(broker-prometheus-cpp INTERFACE cxx_std_17)
 # Must be exported to keep CMake happy, even though we only need it internally.
-install(TARGETS broker-prometheus-cpp
-        EXPORT BrokerTargets
-        DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS broker-prometheus-cpp EXPORT BrokerTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # NOTE: building and linking against an external CAF version is NOT supported!
 #       This variable is FOR DEVELOPMENT ONLY. The only officially supported CAF
 #       version is the bundled version!
 if (CAF_ROOT)
-  message(STATUS "Using system CAF version ${CAF_VERSION}")
-  find_package(CAF REQUIRED COMPONENTS test io core net)
-  list(APPEND LINK_LIBS CAF::core CAF::io CAF::net)
-  set(BROKER_USE_EXTERNAL_CAF ON)
+    message(STATUS "Using system CAF version ${CAF_VERSION}")
+    find_package(CAF REQUIRED COMPONENTS test io core net)
+    list(APPEND LINK_LIBS CAF::core CAF::io CAF::net)
+    set(BROKER_USE_EXTERNAL_CAF ON)
 else ()
-  # Note: we use the object libraries here to avoid having dependencies on the
-  # actual CAF targets that would force consumers of Broker to have CMake being
-  # able to find a CAF installation.
-  message(STATUS "Using bundled CAF")
-  add_bundled_caf()
-  set(BROKER_USE_EXTERNAL_CAF OFF)
+    # Note: we use the object libraries here to avoid having dependencies on the
+    # actual CAF targets that would force consumers of Broker to have CMake being
+    # able to find a CAF installation.
+    message(STATUS "Using bundled CAF")
+    add_bundled_caf()
+    set(BROKER_USE_EXTERNAL_CAF OFF)
 endif ()
 
-if ( NOT BROKER_DISABLE_TESTS )
-  enable_testing()
-endif()
+if (NOT BROKER_DISABLE_TESTS)
+    enable_testing()
+endif ()
 
 # -- libroker -----------------------------------------------------------------
 
@@ -265,76 +263,76 @@ set(BROKER_SOVERSION 4)
 set(ENABLE_SHARED true)
 
 if (ENABLE_STATIC_ONLY)
-  set(ENABLE_STATIC true)
-  set(ENABLE_SHARED false)
+    set(ENABLE_STATIC true)
+    set(ENABLE_SHARED false)
 endif ()
 
 # Make sure there are no old header versions on disk.
-install(
-  CODE "MESSAGE(STATUS \"Removing: ${CMAKE_INSTALL_PREFIX}/include/broker\")"
-  CODE "file(REMOVE_RECURSE \"${CMAKE_INSTALL_PREFIX}/include/broker\")")
+install(CODE "MESSAGE(STATUS \"Removing: ${CMAKE_INSTALL_PREFIX}/include/broker\")"
+        CODE "file(REMOVE_RECURSE \"${CMAKE_INSTALL_PREFIX}/include/broker\")")
 
 # Install all headers except the files from broker/internal.
-install(DIRECTORY libbroker/broker
-        DESTINATION include
-        FILES_MATCHING PATTERN "*.hh"
-        PATTERN "libbroker/broker/internal" EXCLUDE
-        PATTERN "*.test.hh" EXCLUDE)
+install(
+    DIRECTORY libbroker/broker
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.hh"
+    PATTERN "libbroker/broker/internal" EXCLUDE
+    PATTERN "*.test.hh" EXCLUDE)
 
 if (NOT BROKER_EXTERNAL_SQLITE_TARGET)
-  include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty)
-  set_source_files_properties(3rdparty/sqlite3.c PROPERTIES COMPILE_FLAGS
-                              -DSQLITE_OMIT_LOAD_EXTENSION)
-  list(APPEND OPTIONAL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/sqlite3.c)
-else()
-  list(APPEND LINK_LIBS ${BROKER_EXTERNAL_SQLITE_TARGET})
-endif()
+    include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty)
+    set_source_files_properties(3rdparty/sqlite3.c PROPERTIES COMPILE_FLAGS
+                                                              -DSQLITE_OMIT_LOAD_EXTENSION)
+    list(APPEND OPTIONAL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/sqlite3.c)
+else ()
+    list(APPEND LINK_LIBS ${BROKER_EXTERNAL_SQLITE_TARGET})
+endif ()
 
 add_subdirectory(libbroker)
 
 set(tidyCfgFile "${CMAKE_SOURCE_DIR}/.clang-tidy")
 if (BROKER_ENABLE_TIDY)
-  # Create a preprocessor definition that depends on .clang-tidy content so
-  # the compile command will change when .clang-tidy changes. This ensures
-  # that a subsequent build re-runs clang-tidy on all sources even if they
-  # do not otherwise need to be recompiled.
-  file(SHA1 ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy clang_tidy_sha1)
-  set(BROKER_CLANG_TIDY_DEF "CLANG_TIDY_SHA1=${clang_tidy_sha1}")
-  unset(clang_tidy_sha1)
-  add_custom_target(clang_tidy_dummy DEPENDS ${tidyCfgFile})
-  set_target_properties(${BROKER_LIBRARY} PROPERTIES
-                        CXX_CLANG_TIDY "clang-tidy;--config-file=${tidyCfgFile}")
-  target_compile_definitions(${BROKER_LIBRARY} PRIVATE ${BROKER_CLANG_TIDY_DEF})
-  configure_file(.clang-tidy .clang-tidy COPYONLY)
+    # Create a preprocessor definition that depends on .clang-tidy content so
+    # the compile command will change when .clang-tidy changes. This ensures
+    # that a subsequent build re-runs clang-tidy on all sources even if they
+    # do not otherwise need to be recompiled.
+    file(SHA1 ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy clang_tidy_sha1)
+    set(BROKER_CLANG_TIDY_DEF "CLANG_TIDY_SHA1=${clang_tidy_sha1}")
+    unset(clang_tidy_sha1)
+    add_custom_target(clang_tidy_dummy DEPENDS ${tidyCfgFile})
+    set_target_properties(${BROKER_LIBRARY} PROPERTIES CXX_CLANG_TIDY
+                                                       "clang-tidy;--config-file=${tidyCfgFile}")
+    target_compile_definitions(${BROKER_LIBRARY} PRIVATE ${BROKER_CLANG_TIDY_DEF})
+    configure_file(.clang-tidy .clang-tidy COPYONLY)
 endif ()
-
 
 # -- Tools and benchmarks -----------------------------------------------------
 
 if (NOT broker_is_subproject)
-  add_subdirectory(broker-node)
-  add_subdirectory(broker-pipe)
-  add_subdirectory(broker-throughput)
+    add_subdirectory(broker-node)
+    add_subdirectory(broker-pipe)
+    add_subdirectory(broker-throughput)
 endif ()
 
 # -- Bindings -----------------------------------------------------------------
 
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bindings/python/3rdparty/pybind11/CMakeLists.txt")
-  message(WARNING "Skipping Python bindings: pybind11 submodule not available")
-  set(DISABLE_PYTHON_BINDINGS true)
+if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bindings/python/3rdparty/pybind11/CMakeLists.txt")
+    message(WARNING "Skipping Python bindings: pybind11 submodule not available")
+    set(DISABLE_PYTHON_BINDINGS true)
 endif ()
 
 if (NOT DISABLE_PYTHON_BINDINGS)
-  set(Python_ADDITIONAL_VERSIONS 3)
-  find_package(Python 3.9 COMPONENTS Interpreter Development)
+    set(Python_ADDITIONAL_VERSIONS 3)
+    find_package(Python 3.9 COMPONENTS Interpreter Development)
 
-  if (NOT Python_FOUND)
-    message(STATUS "Skipping Python bindings: Python interpreter not found")
-  else ()
-    set (BROKER_PYTHON_BINDINGS true)
-    set (BROKER_PYTHON_STAGING_DIR ${CMAKE_CURRENT_BINARY_DIR}/python)
-    add_subdirectory(bindings/python)
-  endif ()
+    if (NOT Python_FOUND)
+        message(STATUS "Skipping Python bindings: Python interpreter not found")
+    else ()
+        set(BROKER_PYTHON_BINDINGS true)
+        set(BROKER_PYTHON_STAGING_DIR ${CMAKE_CURRENT_BINARY_DIR}/python)
+        add_subdirectory(bindings/python)
+    endif ()
 endif ()
 
 # -- Zeek ---------------------------------------------------------------------
@@ -344,49 +342,43 @@ if (NOT "${ZEEK_EXECUTABLE}" STREQUAL "")
     set(ZEEK_FOUND_MSG "${ZEEK_EXECUTABLE}")
 else ()
     set(ZEEK_FOUND false)
-    find_file(ZEEK_PATH_DEV zeek-path-dev.sh PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../../build NO_DEFAULT_PATH)
+    find_file(ZEEK_PATH_DEV zeek-path-dev.sh PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../../build
+              NO_DEFAULT_PATH)
     if (EXISTS ${ZEEK_PATH_DEV})
-      set(ZEEK_FOUND true)
-      set(ZEEK_FOUND_MSG "${ZEEK_PATH_DEV}")
+        set(ZEEK_FOUND true)
+        set(ZEEK_FOUND_MSG "${ZEEK_PATH_DEV}")
     endif ()
 endif ()
 
 # -- Unit Tests ---------------------------------------------------------------
 
-if ( NOT BROKER_DISABLE_TESTS )
-  add_subdirectory(tests)
+if (NOT BROKER_DISABLE_TESTS)
+    add_subdirectory(tests)
 endif ()
 
 # -- Documentation ------------------------------------------------------------
 
 if (NOT WIN32 AND NOT BROKER_DISABLE_DOCS)
-  add_subdirectory(doc)
+    add_subdirectory(doc)
 endif ()
 
 # -- CMake package install ----------------------------------------------------
 
 export(EXPORT BrokerTargets FILE BrokerTargets.cmake)
 
-install(
-  EXPORT BrokerTargets
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Broker")
+install(EXPORT BrokerTargets DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Broker")
 
 configure_package_config_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/libbroker/BrokerConfig.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfig.cmake"
-  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Broker")
-
-write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfigVersion.cmake"
-  VERSION ${BROKER_VERSION}
-  COMPATIBILITY ExactVersion)
-
-install(
-  FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/libbroker/BrokerConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfigVersion.cmake"
-  DESTINATION
-    "${CMAKE_INSTALL_LIBDIR}/cmake/Broker")
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Broker")
+
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/BrokerConfigVersion.cmake"
+                                 VERSION ${BROKER_VERSION} COMPATIBILITY ExactVersion)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfig.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/BrokerConfigVersion.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Broker")
 
 # -- Build Summary ------------------------------------------------------------
 
@@ -394,13 +386,13 @@ if (CMAKE_BUILD_TYPE)
     string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
 endif ()
 
-macro(display test desc summary)
-  if ( ${test} )
-    set(${summary} ${desc})
-  else ()
-    set(${summary} no)
-  endif()
-endmacro()
+macro (display test desc summary)
+    if (${test})
+        set(${summary} ${desc})
+    else ()
+        set(${summary} no)
+    endif ()
+endmacro ()
 
 display(ENABLE_SHARED yes shared_summary)
 display(ENABLE_STATIC yes static_summary)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,8 @@ endif ()
 # Append our extra flags to the existing value of CXXFLAGS.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_FLAGS}")
 
-include(RequireCXX17)
 include(CheckCXXSourceCompiles)
+include(cmake/RequireCXXStd.cmake)
 
 # Unfortunately, std::filesystem is a mess. The feature checks at compile time
 # via __has_include(<filesystem>) or __cpp_lib_filesystem only tell half of the

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -3,84 +3,82 @@ add_library(_broker MODULE _broker.cpp data.cpp enums.cpp store.cpp zeek.cpp)
 
 # Stage the Python wrapper along with the internal module in the public
 # "broker" module.
-set (BROKER_PYTHON_MODULE_DIR ${BROKER_PYTHON_STAGING_DIR}/broker)
-set_target_properties(_broker PROPERTIES
-                      OUTPUT_NAME "_broker"
-                      LIBRARY_OUTPUT_DIRECTORY ${BROKER_PYTHON_MODULE_DIR}
-                      # By setting an empty prefix, we can invoke the Python
-                      # executable in the same path as the module. Then
-                      # 'import _broker' Just Works.
-                      PREFIX "")
+set(BROKER_PYTHON_MODULE_DIR ${BROKER_PYTHON_STAGING_DIR}/broker)
+set_target_properties(
+    _broker
+    PROPERTIES OUTPUT_NAME "_broker"
+               LIBRARY_OUTPUT_DIRECTORY ${BROKER_PYTHON_MODULE_DIR}
+               # By setting an empty prefix, we can invoke the Python
+               # executable in the same path as the module. Then
+               # 'import _broker' Just Works.
+               PREFIX "")
 
 # Stage Python scripts.
-add_custom_target(python-scripts-stage
-                  COMMAND ${CMAKE_COMMAND} -E copy_directory
-                    ${CMAKE_CURRENT_SOURCE_DIR}/broker
-                    ${BROKER_PYTHON_MODULE_DIR}
-                  COMMENT
-                    "Staging Python scripts in ${BROKER_PYTHON_MODULE_DIR}"
-                  VERBATIM)
+add_custom_target(
+    python-scripts-stage
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/broker
+            ${BROKER_PYTHON_MODULE_DIR}
+    COMMENT "Staging Python scripts in ${BROKER_PYTHON_MODULE_DIR}"
+    VERBATIM)
 
 # Whenever we build the bindings, we also ensure that we stage the current
 # scripts along with it.
 add_dependencies(_broker python-scripts-stage)
 
 # Set includes.
-target_include_directories(_broker PUBLIC
-                           ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/pybind11/include/
-                           ${Python_INCLUDE_DIRS})
+target_include_directories(_broker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/pybind11/include/
+                                          ${Python_INCLUDE_DIRS})
 
 # Set libraries to link against.
 if (NOT WIN32)
-  target_compile_options(_broker PRIVATE "-fvisibility=hidden")
+    target_compile_options(_broker PRIVATE "-fvisibility=hidden")
 endif ()
 
 if (ENABLE_SHARED)
-  set(libbroker broker)
+    set(libbroker broker)
 else ()
-  set(libbroker broker_static)
+    set(libbroker broker_static)
 endif ()
 target_link_libraries(_broker PUBLIC ${libbroker} ${Python_LIBRARIES})
 if (APPLE)
-  # Support multiple Python installations.
-  target_link_libraries(_broker PRIVATE "-undefined dynamic_lookup")
+    # Support multiple Python installations.
+    target_link_libraries(_broker PRIVATE "-undefined dynamic_lookup")
 endif ()
 
 # Check for Link Time Optimization support (GCC/Clang)
 include(CheckCXXCompilerFlag)
 if (NOT CMAKE_BUILD_TYPE MATCHES DEBUG)
-  check_cxx_compiler_flag("-flto" HAS_LTO_FLAG)
-  if (HAS_LTO_FLAG)
-    target_compile_options(_broker PRIVATE -flto)
-  endif()
+    check_cxx_compiler_flag("-flto" HAS_LTO_FLAG)
+    if (HAS_LTO_FLAG)
+        target_compile_options(_broker PRIVATE -flto)
+    endif ()
 endif ()
 
 # Strip unnecessary sections of the binary on Linux/Mac OS.
 if (CMAKE_STRIP)
-  if(APPLE)
-    add_custom_command(TARGET _broker POST_BUILD
-                       COMMAND ${CMAKE_STRIP} -u -r $<TARGET_FILE:_broker>)
-  else()
-    add_custom_command(TARGET _broker POST_BUILD
-                       COMMAND ${CMAKE_STRIP} $<TARGET_FILE:_broker>)
-  endif()
+    if (APPLE)
+        add_custom_command(TARGET _broker POST_BUILD COMMAND ${CMAKE_STRIP} -u -r
+                                                             $<TARGET_FILE:_broker>)
+    else ()
+        add_custom_command(TARGET _broker POST_BUILD COMMAND ${CMAKE_STRIP} $<TARGET_FILE:_broker>)
+    endif ()
 endif ()
 
-if ( NOT PY_MOD_INSTALL_DIR )
-  # Figure out Python module install directory.
-  if (BROKER_PYTHON_PREFIX)
-    set(pyver ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR})
-    file(TO_CMAKE_PATH "${BROKER_PYTHON_PREFIX}/lib/python${pyver}/site-packages" PY_MOD_INSTALL_DIR)
-  elseif (BROKER_PYTHON_HOME)
-    file(TO_CMAKE_PATH "${BROKER_PYTHON_HOME}/lib/python" PY_MOD_INSTALL_DIR)
-  else ()
-    set(PY_MOD_INSTALL_DIR "${Python_SITEARCH}")
-  endif ()
+if (NOT PY_MOD_INSTALL_DIR)
+    # Figure out Python module install directory.
+    if (BROKER_PYTHON_PREFIX)
+        set(pyver ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR})
+        file(TO_CMAKE_PATH "${BROKER_PYTHON_PREFIX}/lib/python${pyver}/site-packages"
+             PY_MOD_INSTALL_DIR)
+    elseif (BROKER_PYTHON_HOME)
+        file(TO_CMAKE_PATH "${BROKER_PYTHON_HOME}/lib/python" PY_MOD_INSTALL_DIR)
+    else ()
+        set(PY_MOD_INSTALL_DIR "${Python_SITEARCH}")
+    endif ()
 endif ()
 message(STATUS "Python bindings will be built and installed to:")
 message(STATUS "  ${PY_MOD_INSTALL_DIR}")
 
 install(TARGETS _broker DESTINATION ${PY_MOD_INSTALL_DIR}/broker)
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/broker
-        DESTINATION ${PY_MOD_INSTALL_DIR}
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/broker DESTINATION ${PY_MOD_INSTALL_DIR}
         REGEX "/\\..*" EXCLUDE)

--- a/broker-node/CMakeLists.txt
+++ b/broker-node/CMakeLists.txt
@@ -1,7 +1,4 @@
-add_executable(broker-node
-  broker-node.cc
-)
+add_executable(broker-node broker-node.cc)
 target_link_libraries(broker-node PRIVATE ${BROKER_LIBRARY} CAF::core)
-target_include_directories(broker-node PRIVATE
-                           "${CMAKE_CURRENT_SOURCE_DIR}"
-                           "${CMAKE_CURRENT_BINARY_DIR}")
+target_include_directories(broker-node PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+                                               "${CMAKE_CURRENT_BINARY_DIR}")

--- a/broker-pipe/CMakeLists.txt
+++ b/broker-pipe/CMakeLists.txt
@@ -1,7 +1,4 @@
-add_executable(broker-pipe
-  broker-pipe.cc
-)
+add_executable(broker-pipe broker-pipe.cc)
 target_link_libraries(broker-pipe PRIVATE ${BROKER_LIBRARY} CAF::core)
-target_include_directories(broker-pipe PRIVATE
-                           "${CMAKE_CURRENT_SOURCE_DIR}"
-                           "${CMAKE_CURRENT_BINARY_DIR}")
+target_include_directories(broker-pipe PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+                                               "${CMAKE_CURRENT_BINARY_DIR}")

--- a/broker-pipe/broker-pipe.cc
+++ b/broker-pipe/broker-pipe.cc
@@ -192,7 +192,7 @@ void subscribe_mode_stream(broker::endpoint& ep, const std::string& topic_str,
       if (++msgs >= cap)
         throw std::runtime_error("Reached cap");
     },
-    [=](size_t&, const broker::error&) {
+    [](size_t&, const broker::error&) {
       // nop
     });
   ep.wait_for(worker);
@@ -239,7 +239,7 @@ int main(int argc, char** argv) try {
     [] {
       // Init: nop.
     },
-    [=](const data_message& x) {
+    [](const data_message& x) {
       // OnNext: print the message.
       std::string what = to_string(x);
       what.insert(0, "*** ");
@@ -247,7 +247,7 @@ int main(int argc, char** argv) try {
       guard_type guard{cout_mtx};
       std::cerr << what;
     },
-    [=](const broker::error&) {
+    [](const broker::error&) {
       // Cleanup: nop.
     });
   // Publish endpoint at demanded port.

--- a/broker-throughput/CMakeLists.txt
+++ b/broker-throughput/CMakeLists.txt
@@ -1,7 +1,4 @@
-add_executable(broker-throughput
-  broker-throughput.cc
-)
+add_executable(broker-throughput broker-throughput.cc)
 target_link_libraries(broker-throughput PRIVATE ${BROKER_LIBRARY})
-target_include_directories(broker-throughput PRIVATE
-                           "${CMAKE_CURRENT_SOURCE_DIR}"
-                           "${CMAKE_CURRENT_BINARY_DIR}")
+target_include_directories(broker-throughput PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+                                                     "${CMAKE_CURRENT_BINARY_DIR}")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,20 +1,18 @@
 if (NOT TARGET doc)
-  add_custom_target(doc)
+    add_custom_target(doc)
 endif ()
 
 set(html_output_dir ${CMAKE_CURRENT_BINARY_DIR}/html)
 
-add_custom_target(broker-doc-html
-  COMMAND sphinx-build
-          -b html
-          -c ${CMAKE_CURRENT_SOURCE_DIR}
-          ${CMAKE_CURRENT_SOURCE_DIR}
-          ${html_output_dir}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  COMMENT "[Sphinx] Generate Broker HTML documentation in ${html_output_dir}")
+add_custom_target(
+    broker-doc-html
+    COMMAND sphinx-build -b html -c ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
+            ${html_output_dir}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "[Sphinx] Generate Broker HTML documentation in ${html_output_dir}")
 
 add_dependencies(doc broker-doc-html)
 
-if ( NOT BROKER_DISABLE_DOC_EXAMPLES )
-  add_subdirectory(_examples)
+if (NOT BROKER_DISABLE_DOC_EXAMPLES)
+    add_subdirectory(_examples)
 endif ()

--- a/doc/_examples/CMakeLists.txt
+++ b/doc/_examples/CMakeLists.txt
@@ -8,16 +8,16 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 # Setup correct broker library (static/shared).
 if (ENABLE_SHARED)
-  set(libbroker broker)
+    set(libbroker broker)
 else ()
-  set(libbroker broker_static)
+    set(libbroker broker_static)
 endif ()
 
-macro(make_example cc)
+macro (make_example cc)
     add_executable(${cc} ${cc}.cc)
     target_link_libraries(${cc} ${libbroker})
     add_dependencies(doc ${cc})
-endmacro()
+endmacro ()
 
 make_example(synopsis)
 make_example(comm)

--- a/doc/comm.rst
+++ b/doc/comm.rst
@@ -157,10 +157,10 @@ TODO: Document.
 ..
 ..   context ctx;
 ..   auto ep = ctx.spawn<nonblocking>();
-..   ep.subscribe("/foo", [=](const topic& t, const data& d) {
+..   ep.subscribe("/foo", [](const topic& t, const data& d) {
 ..     std::cout << t << " -> " << d << std::endl;
 ..   });
-..   ep.subscribe("/bar", [=](const topic& t, const data& d) {
+..   ep.subscribe("/bar", [](const topic& t, const data& d) {
 ..     std::cout << t << " -> " << d << std::endl;
 ..   });
 ..

--- a/libbroker/CMakeLists.txt
+++ b/libbroker/CMakeLists.txt
@@ -1,197 +1,178 @@
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/broker/config.hh.in
                ${CMAKE_CURRENT_BINARY_DIR}/broker/config.hh)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/broker/config.hh
-        DESTINATION include/broker)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/broker/config.hh DESTINATION include/broker)
 
 set(BROKER_SRC
-  # src/detail/core_recorder.cc
-  # src/detail/generator_file_reader.cc
-  # src/detail/generator_file_writer.cc
-  # src/gateway.cc
-  # src/internal/data_generator.cc
-  # src/internal/generator_file_reader.cc
-  # src/internal/generator_file_writer.cc
-  # src/internal/meta_command_writer.cc
-  # src/internal/meta_data_writer.cc
-  ${OPTIONAL_SRC}
-  broker/address.cc
-  broker/alm/multipath.cc
-  broker/alm/routing_table.cc
-  broker/builder.cc
-  broker/command_envelope.cc
-  broker/configuration.cc
-  broker/convert.cc
-  broker/data.cc
-  broker/data_envelope.cc
-  broker/detail/abstract_backend.cc
-  broker/detail/filesystem.cc
-  broker/detail/flare.cc
-  broker/detail/make_backend.cc
-  broker/detail/memory_backend.cc
-  broker/detail/monotonic_buffer_resource.cc
-  broker/detail/opaque_type.cc
-  broker/detail/peer_status_map.cc
-  broker/detail/prefix_matcher.cc
-  broker/detail/sink_driver.cc
-  broker/detail/source_driver.cc
-  broker/detail/sqlite_backend.cc
-  broker/detail/store_state.cc
-  broker/domain_options.cc
-  broker/endpoint.cc
-  broker/endpoint_id.cc
-  broker/endpoint_info.cc
-  broker/entity_id.cc
-  broker/envelope.cc
-  broker/error.cc
-  broker/event_observer.cc
-  broker/filter_type.cc
-  broker/format/bin.cc
-  broker/format/json.cc
-  broker/hub.cc
-  broker/internal/clone_actor.cc
-  broker/internal/connector.cc
-  broker/internal/connector_adapter.cc
-  broker/internal/core_actor.cc
-  broker/internal/flare_actor.cc
-  broker/internal/hub_impl.cc
-  broker/internal/json.cc
-  broker/internal/json_client.cc
-  broker/internal/json_type_mapper.cc
-  broker/internal/master_actor.cc
-  broker/internal/metric_factory.cc
-  broker/internal/peering.cc
-  broker/internal/pending_connection.cc
-  broker/internal/println.cc
-  broker/internal/publisher_queue.cc
-  broker/internal/store_actor.cc
-  broker/internal/subscriber_queue.cc
-  broker/internal/web_socket.cc
-  broker/internal/wire_format.cc
-  broker/internal_command.cc
-  broker/logger.cc
-  broker/mailbox.cc
-  broker/network_info.cc
-  broker/overflow_policy.cc
-  broker/p2p_message_type.cc
-  broker/peer_status.cc
-  broker/ping_envelope.cc
-  broker/pong_envelope.cc
-  broker/port.cc
-  broker/publisher.cc
-  broker/routing_update_envelope.cc
-  broker/shutdown_options.cc
-  broker/status.cc
-  broker/status_subscriber.cc
-  broker/store.cc
-  broker/store_event.cc
-  broker/subnet.cc
-  broker/subscriber.cc
-  broker/time.cc
-  broker/topic.cc
-  broker/variant.cc
-  broker/variant_data.cc
-  broker/variant_list.cc
-  broker/variant_set.cc
-  broker/variant_table.cc
-  broker/variant_tag.cc
-  broker/version.cc
-  broker/worker.cc
-  broker/zeek.cc
-)
+    # src/detail/core_recorder.cc
+    # src/detail/generator_file_reader.cc
+    # src/detail/generator_file_writer.cc
+    # src/gateway.cc
+    # src/internal/data_generator.cc
+    # src/internal/generator_file_reader.cc
+    # src/internal/generator_file_writer.cc
+    # src/internal/meta_command_writer.cc
+    # src/internal/meta_data_writer.cc
+    ${OPTIONAL_SRC}
+    broker/address.cc
+    broker/alm/multipath.cc
+    broker/alm/routing_table.cc
+    broker/builder.cc
+    broker/command_envelope.cc
+    broker/configuration.cc
+    broker/convert.cc
+    broker/data.cc
+    broker/data_envelope.cc
+    broker/detail/abstract_backend.cc
+    broker/detail/filesystem.cc
+    broker/detail/flare.cc
+    broker/detail/make_backend.cc
+    broker/detail/memory_backend.cc
+    broker/detail/monotonic_buffer_resource.cc
+    broker/detail/opaque_type.cc
+    broker/detail/peer_status_map.cc
+    broker/detail/prefix_matcher.cc
+    broker/detail/sink_driver.cc
+    broker/detail/source_driver.cc
+    broker/detail/sqlite_backend.cc
+    broker/detail/store_state.cc
+    broker/domain_options.cc
+    broker/endpoint.cc
+    broker/endpoint_id.cc
+    broker/endpoint_info.cc
+    broker/entity_id.cc
+    broker/envelope.cc
+    broker/error.cc
+    broker/event_observer.cc
+    broker/filter_type.cc
+    broker/format/bin.cc
+    broker/format/json.cc
+    broker/hub.cc
+    broker/internal/clone_actor.cc
+    broker/internal/connector.cc
+    broker/internal/connector_adapter.cc
+    broker/internal/core_actor.cc
+    broker/internal/flare_actor.cc
+    broker/internal/hub_impl.cc
+    broker/internal/json.cc
+    broker/internal/json_client.cc
+    broker/internal/json_type_mapper.cc
+    broker/internal/master_actor.cc
+    broker/internal/metric_factory.cc
+    broker/internal/peering.cc
+    broker/internal/pending_connection.cc
+    broker/internal/println.cc
+    broker/internal/publisher_queue.cc
+    broker/internal/store_actor.cc
+    broker/internal/subscriber_queue.cc
+    broker/internal/web_socket.cc
+    broker/internal/wire_format.cc
+    broker/internal_command.cc
+    broker/logger.cc
+    broker/mailbox.cc
+    broker/network_info.cc
+    broker/overflow_policy.cc
+    broker/p2p_message_type.cc
+    broker/peer_status.cc
+    broker/ping_envelope.cc
+    broker/pong_envelope.cc
+    broker/port.cc
+    broker/publisher.cc
+    broker/routing_update_envelope.cc
+    broker/shutdown_options.cc
+    broker/status.cc
+    broker/status_subscriber.cc
+    broker/store.cc
+    broker/store_event.cc
+    broker/subnet.cc
+    broker/subscriber.cc
+    broker/time.cc
+    broker/topic.cc
+    broker/variant.cc
+    broker/variant_data.cc
+    broker/variant_list.cc
+    broker/variant_set.cc
+    broker/variant_table.cc
+    broker/variant_tag.cc
+    broker/version.cc
+    broker/worker.cc
+    broker/zeek.cc)
 
 if (ENABLE_SHARED)
-  add_library(broker SHARED ${BROKER_SRC})
-  set_target_properties(broker PROPERTIES
-                        SOVERSION ${BROKER_SOVERSION}
-                        VERSION ${BROKER_VERSION_MAJOR}.${BROKER_VERSION_MINOR}
-                        MACOSX_RPATH true
-                        OUTPUT_NAME broker)
-  target_link_libraries(broker PUBLIC ${LINK_LIBS})
-  target_link_libraries(
-    broker
-    PRIVATE
-      CAF::core
-      CAF::io
-      CAF::net
-      broker-prometheus-cpp)
-  install(TARGETS broker
-          EXPORT BrokerTargets
-          DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  target_include_directories(broker PUBLIC
-                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-                             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                             $<INSTALL_INTERFACE:include>)
+    add_library(broker SHARED ${BROKER_SRC})
+    set_target_properties(
+        broker
+        PROPERTIES SOVERSION ${BROKER_SOVERSION}
+                   VERSION ${BROKER_VERSION_MAJOR}.${BROKER_VERSION_MINOR}
+                   MACOSX_RPATH true
+                   OUTPUT_NAME broker)
+    target_link_libraries(broker PUBLIC ${LINK_LIBS})
+    target_link_libraries(broker PRIVATE CAF::core CAF::io CAF::net broker-prometheus-cpp)
+    install(TARGETS broker EXPORT BrokerTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    target_include_directories(
+        broker PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
 endif ()
 
 if (ENABLE_STATIC)
-  add_library(broker_static STATIC ${BROKER_SRC})
-  set_target_properties(broker_static PROPERTIES OUTPUT_NAME broker)
-  if (NOT DISABLE_PYTHON_BINDINGS)
-    set_target_properties(broker_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
-  endif()
-  target_link_libraries(broker_static PUBLIC ${LINK_LIBS})
-  target_link_libraries(
-    broker_static
-    PRIVATE
-      CAF::core
-      CAF::io
-      CAF::net
-      broker-prometheus-cpp)
-  install(TARGETS broker_static
-          EXPORT BrokerTargets
-          DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  target_include_directories(broker_static PUBLIC
-                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-                             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                             $<INSTALL_INTERFACE:include>)
+    add_library(broker_static STATIC ${BROKER_SRC})
+    set_target_properties(broker_static PROPERTIES OUTPUT_NAME broker)
+    if (NOT DISABLE_PYTHON_BINDINGS)
+        set_target_properties(broker_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    endif ()
+    target_link_libraries(broker_static PUBLIC ${LINK_LIBS})
+    target_link_libraries(broker_static PRIVATE CAF::core CAF::io CAF::net broker-prometheus-cpp)
+    install(TARGETS broker_static EXPORT BrokerTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    target_include_directories(
+        broker_static
+        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+               $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
 endif ()
 
 if (ENABLE_SHARED)
-  set(main_lib_target broker)
-else()
-  set(main_lib_target broker_static)
-endif()
+    set(main_lib_target broker)
+else ()
+    set(main_lib_target broker_static)
+endif ()
 
 set(BROKER_LIBRARY ${main_lib_target} PARENT_SCOPE)
 
-if ( BROKER_DISABLE_TESTS )
-  return()
+if (BROKER_DISABLE_TESTS)
+    return()
 endif ()
 
 set(BROKER_TEST_SRC
-  # broker/internal/data_generator.test.cc
-  # broker/internal/generator_file_writer.test.cc
-  # broker/internal/json_type_mapper.test.cc
-  # broker/internal/meta_command_writer.test.cc
-  # broker/internal/meta_data_writer.test.cc
-  broker/alm/multipath.test.cc
-  broker/alm/routing_table.test.cc
-  broker/backend.test.cc
-  broker/broker-test.test.cc
-  broker/builder.test.cc
-  broker/data.test.cc
-  broker/detail/peer_status_map.test.cc
-  broker/domain_options.test.cc
-  broker/envelope.test.cc
-  broker/error.test.cc
-  broker/filter_type.test.cc
-  broker/format/bin.test.cc
-  broker/format/json.test.cc
-  broker/hub.test.cc
-  broker/internal/channel.test.cc
-  broker/internal/json.test.cc
-  broker/internal/wire_format.test.cc
-  broker/peering.test.cc
-  broker/radix_tree.test.cc
-  broker/shutdown.test.cc
-  broker/status.test.cc
-  broker/store.test.cc
-  broker/store_event.test.cc
-  broker/topic.test.cc
-  broker/variant.test.cc
-  broker/zeek.test.cc
-)
+    # broker/internal/data_generator.test.cc
+    # broker/internal/generator_file_writer.test.cc
+    # broker/internal/json_type_mapper.test.cc
+    # broker/internal/meta_command_writer.test.cc
+    # broker/internal/meta_data_writer.test.cc
+    broker/alm/multipath.test.cc
+    broker/alm/routing_table.test.cc
+    broker/backend.test.cc
+    broker/broker-test.test.cc
+    broker/builder.test.cc
+    broker/data.test.cc
+    broker/detail/peer_status_map.test.cc
+    broker/domain_options.test.cc
+    broker/envelope.test.cc
+    broker/error.test.cc
+    broker/filter_type.test.cc
+    broker/format/bin.test.cc
+    broker/format/json.test.cc
+    broker/hub.test.cc
+    broker/internal/channel.test.cc
+    broker/internal/json.test.cc
+    broker/internal/wire_format.test.cc
+    broker/peering.test.cc
+    broker/radix_tree.test.cc
+    broker/shutdown.test.cc
+    broker/status.test.cc
+    broker/store.test.cc
+    broker/store_event.test.cc
+    broker/topic.test.cc
+    broker/variant.test.cc
+    broker/zeek.test.cc)
 
 # Our sytem testing suites require `socketpair`, but Windows lacks this API.
 # if (NOT MSVC)
@@ -201,27 +182,19 @@ set(BROKER_TEST_SRC
 # endif()
 
 add_executable(broker-test ${BROKER_TEST_SRC})
-target_link_libraries(
-  broker-test
-  PRIVATE
-    ${main_lib_target}
-    CAF::core
-    CAF::io
-    CAF::net
-    CAF::test
-    broker-prometheus-cpp)
+target_link_libraries(broker-test PRIVATE ${main_lib_target} CAF::core CAF::io CAF::net CAF::test
+                                          broker-prometheus-cpp)
 
-foreach(file_path ${BROKER_TEST_SRC})
-  get_filename_component(test_dir ${file_path} DIRECTORY)
-  get_filename_component(test_file ${file_path} NAME_WE)
-  string(REPLACE "/" "." test_name ${test_dir}/${test_file})
-  set_source_files_properties(${file_path} PROPERTIES COMPILE_DEFINITIONS SUITE=${test_name})
-  set(test_verbosity 4)
-  if (${test_name} STREQUAL broker.radix_tree)
-    set(test_verbosity 3)  # otherwise it just produces way too much output
-  endif ()
-  add_test(NAME ${test_name} COMMAND broker-test -v ${test_verbosity} -s "^${test_name}$" ${ARGN})
-  set_tests_properties(${test_name} PROPERTIES TIMEOUT ${BROKER_TEST_TIMEOUT})
-  set_tests_properties(${test_name} PROPERTIES ENVIRONMENT
-                       "BROKER_TEST_DIR=${BROKER_TEST_DIR}")
+foreach (file_path ${BROKER_TEST_SRC})
+    get_filename_component(test_dir ${file_path} DIRECTORY)
+    get_filename_component(test_file ${file_path} NAME_WE)
+    string(REPLACE "/" "." test_name ${test_dir}/${test_file})
+    set_source_files_properties(${file_path} PROPERTIES COMPILE_DEFINITIONS SUITE=${test_name})
+    set(test_verbosity 4)
+    if (${test_name} STREQUAL broker.radix_tree)
+        set(test_verbosity 3) # otherwise it just produces way too much output
+    endif ()
+    add_test(NAME ${test_name} COMMAND broker-test -v ${test_verbosity} -s "^${test_name}$" ${ARGN})
+    set_tests_properties(${test_name} PROPERTIES TIMEOUT ${BROKER_TEST_TIMEOUT})
+    set_tests_properties(${test_name} PROPERTIES ENVIRONMENT "BROKER_TEST_DIR=${BROKER_TEST_DIR}")
 endforeach ()

--- a/libbroker/broker/internal/channel.hh
+++ b/libbroker/broker/internal/channel.hh
@@ -604,7 +604,9 @@ public:
       // Find the first message in the assigned offset and drop any buffered
       // message before that point.
       if (!buf_.empty()) {
-        auto pred = [=](const optional_event& x) { return x.seq > offset; };
+        auto pred = [=, this](const optional_event& x) {
+          return x.seq > offset;
+        };
         auto new_begin = std::find_if(buf_.begin(), buf_.end(), pred);
         if (auto n = std::distance(buf_.begin(), new_begin); n > 0) {
           metrics_.dec_out_of_order_updates(n);

--- a/libbroker/broker/internal/clone_actor.cc
+++ b/libbroker/broker/internal/clone_actor.cc
@@ -535,7 +535,7 @@ caf::behavior clone_state::make_behavior() {
     sync_timeout = caf::make_timestamp() + max_sync_interval;
   return super::make_behavior(
     // --- local communication -------------------------------------------------
-    [=](atom::local, internal_command_variant& content) {
+    [=, this](atom::local, internal_command_variant& content) {
       if (auto inner = get_if<put_unique_command>(&content)) {
         if (inner->who) {
           log::store::debug("received-put-unique",
@@ -555,10 +555,10 @@ caf::behavior clone_state::make_behavior() {
       }
       send_to_master(std::move(content));
     },
-    [=](atom::sync_point, caf::actor& who) {
+    [=, this](atom::sync_point, caf::actor& who) {
       self->send(who, atom::sync_point_v);
     },
-    [=](atom::tick) {
+    [=, this](atom::tick) {
       tick();
       if (sync_timeout) {
         if (has_master()) {
@@ -582,17 +582,17 @@ caf::behavior clone_state::make_behavior() {
         idle_callbacks.clear();
       }
     },
-    [=](atom::get, atom::keys) -> caf::result<data> {
+    [=, this](atom::get, atom::keys) -> caf::result<data> {
       auto rp = self->make_response_promise();
       get_impl(rp, [this, rp]() mutable { rp.deliver(keys()); });
       return rp;
     },
-    [=](atom::get, atom::keys, request_id id) {
+    [=, this](atom::get, atom::keys, request_id id) {
       auto rp = self->make_response_promise();
       get_impl(rp, [this, rp, id]() mutable { rp.deliver(keys(), id); }, id);
       return rp;
     },
-    [=](atom::exists, data& key) -> caf::result<data> {
+    [=, this](atom::exists, data& key) -> caf::result<data> {
       auto rp = self->make_response_promise();
       get_impl(rp, [this, rp, key{std::move(key)}]() mutable {
         auto result = this->store.count(key) != 0;
@@ -600,7 +600,7 @@ caf::behavior clone_state::make_behavior() {
       });
       return rp;
     },
-    [=](atom::exists, data& key, request_id id) {
+    [=, this](atom::exists, data& key, request_id id) {
       auto rp = self->make_response_promise();
       get_impl(
         rp,
@@ -611,7 +611,7 @@ caf::behavior clone_state::make_behavior() {
         id);
       return rp;
     },
-    [=](atom::get, data& key) -> caf::result<data> {
+    [=, this](atom::get, data& key) -> caf::result<data> {
       auto rp = self->make_response_promise();
       get_impl(rp, [this, rp, key{std::move(key)}]() mutable {
         if (rp.pending()) {
@@ -624,7 +624,7 @@ caf::behavior clone_state::make_behavior() {
       });
       return rp;
     },
-    [=](atom::get, data& key, data& aspect) -> caf::result<data> {
+    [=, this](atom::get, data& key, data& aspect) -> caf::result<data> {
       auto rp = self->make_response_promise();
       get_impl(rp, [this, rp, key{std::move(key)},
                     aspect{std::move(aspect)}]() mutable {
@@ -639,7 +639,7 @@ caf::behavior clone_state::make_behavior() {
       });
       return rp;
     },
-    [=](atom::get, data& key, request_id id) {
+    [=, this](atom::get, data& key, request_id id) {
       auto rp = self->make_response_promise();
       get_impl(
         rp,
@@ -653,7 +653,7 @@ caf::behavior clone_state::make_behavior() {
         id);
       return rp;
     },
-    [=](atom::get, data& key, data& aspect, request_id id) {
+    [=, this](atom::get, data& key, data& aspect, request_id id) {
       auto rp = self->make_response_promise();
       get_impl(
         rp,
@@ -671,8 +671,8 @@ caf::behavior clone_state::make_behavior() {
         id);
       return rp;
     },
-    [=](atom::get, atom::name) { return store_name; },
-    [=](atom::await, atom::idle) -> caf::result<atom::ok> {
+    [=, this](atom::get, atom::name) { return store_name; },
+    [=, this](atom::await, atom::idle) -> caf::result<atom::ok> {
       if (idle())
         return atom::ok_v;
       auto rp = self->make_response_promise();

--- a/libbroker/broker/internal/connector.cc
+++ b/libbroker/broker/internal/connector.cc
@@ -707,7 +707,7 @@ public:
   }
 
   stream_transport_error get_last_error(stream_socket fd, ptrdiff_t ret) {
-    return std::visit([=](auto& pl) { return pl.last_error(fd, ret); },
+    return std::visit([=, this](auto& pl) { return pl.last_error(fd, ret); },
                       sck_policy);
   }
 
@@ -746,11 +746,13 @@ public:
   read_result do_transport_handshake_rd(stream_socket fd);
 
   ptrdiff_t do_write(stream_socket fd, caf::span<const caf::byte> buf) {
-    return std::visit([=](auto& pl) { return pl.write(fd, buf); }, sck_policy);
+    return std::visit([=, this](auto& pl) { return pl.write(fd, buf); },
+                      sck_policy);
   }
 
   ptrdiff_t do_read(stream_socket fd, caf::span<caf::byte> buf) {
-    return std::visit([=](auto& pl) { return pl.read(fd, buf); }, sck_policy);
+    return std::visit([=, this](auto& pl) { return pl.read(fd, buf); },
+                      sck_policy);
   }
 
   write_result continue_writing(stream_socket fd) {

--- a/libbroker/broker/variant_data.cc
+++ b/libbroker/broker/variant_data.cc
@@ -8,6 +8,7 @@
 #include <caf/detail/network_order.hpp>
 
 #include <cstring>
+#include <type_traits>
 
 namespace broker {
 
@@ -399,7 +400,14 @@ bool operator<(const variant_data& lhs, const variant_data& rhs) {
   return std::visit(
     [&rhs](const auto& x) -> bool {
       using T = std::decay_t<decltype(x)>;
-      if constexpr (std::is_pointer_v<T>) {
+      // Some compilers don't like the fact that a custom allocator is used
+      // for the variant_data::set type, so the is_pointer block here fails
+      // to build.
+      if constexpr (std::is_same_v<T, variant_data::set*>) {
+        auto rhs_val = std::get<T>(rhs.value);
+        return std::lexicographical_compare(x->begin(), x->end(),
+                                            rhs_val->begin(), rhs_val->end());
+      } else if constexpr (std::is_pointer_v<T>) {
         return *x < *std::get<T>(rhs.value);
       } else {
         return x < std::get<T>(rhs.value);

--- a/libbroker/broker/variant_data.hh
+++ b/libbroker/broker/variant_data.hh
@@ -28,15 +28,6 @@ public:
                         std::string_view, address, subnet, port, timestamp,
                         timespan, enum_value_view>;
 
-  // Note: GCC-8 has a broken std::less<> implementation. Remove this workaround
-  //       once we drop support for GCC-8.
-  struct less {
-    template <class T, class U>
-    bool operator()(const T& x, const U& y) const {
-      return x < y;
-    }
-  };
-
   template <class T>
   using allocator_t = detail::monotonic_buffer_resource::allocator<T>;
 
@@ -44,7 +35,7 @@ public:
 
   using list_iterator = list::const_iterator;
 
-  using set = std::set<variant_data, less, allocator_t<variant_data>>;
+  using set = std::set<variant_data, std::less<>, allocator_t<variant_data>>;
 
   using set_iterator = set::const_iterator;
 
@@ -52,7 +43,8 @@ public:
 
   using table_allocator = allocator_t<key_value_pair>;
 
-  using table = std::map<variant_data, variant_data, less, table_allocator>;
+  using table =
+    std::map<variant_data, variant_data, std::less<>, table_allocator>;
 
   using table_iterator = table::const_iterator;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,36 +7,37 @@ add_subdirectory(benchmarks)
 # -- Python -------------------------------------------------------------------
 
 if (BROKER_PYTHON_BINDINGS)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/python/run-zeek.in
-                 ${CMAKE_CURRENT_BINARY_DIR}/python/run-zeek)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/python/run-zeek.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/python/run-zeek)
 
-  macro(make_python_test name)
-    set(script ${CMAKE_CURRENT_SOURCE_DIR}/python/${name}.py)
-    set(test_name python-${name})
-    add_test(NAME ${test_name}
-             COMMAND ${Python_EXECUTABLE} ${script} ${ARGN}
-             WORKING_DIRECTORY ${BROKER_PYTHON_STAGING_DIR})
-    set_tests_properties(${test_name} PROPERTIES TIMEOUT ${BROKER_TEST_TIMEOUT})
-    set_tests_properties(${test_name} PROPERTIES ENVIRONMENT
-                         "PYTHONPATH=${BROKER_PYTHON_STAGING_DIR};BROKER_TEST_DIR=${BROKER_TEST_DIR}")
-  endmacro()
+    macro (make_python_test name)
+        set(script ${CMAKE_CURRENT_SOURCE_DIR}/python/${name}.py)
+        set(test_name python-${name})
+        add_test(NAME ${test_name} COMMAND ${Python_EXECUTABLE} ${script} ${ARGN}
+                 WORKING_DIRECTORY ${BROKER_PYTHON_STAGING_DIR})
+        set_tests_properties(${test_name} PROPERTIES TIMEOUT ${BROKER_TEST_TIMEOUT})
+        set_tests_properties(
+            ${test_name}
+            PROPERTIES ENVIRONMENT
+                       "PYTHONPATH=${BROKER_PYTHON_STAGING_DIR};BROKER_TEST_DIR=${BROKER_TEST_DIR}")
+    endmacro ()
 
-  if (ZEEK_FOUND)
-    make_python_test(zeek)
-    make_python_test(zeek-unsafe-types)
-  endif ()
+    if (ZEEK_FOUND)
+        make_python_test(zeek)
+        make_python_test(zeek-unsafe-types)
+    endif ()
 
-  make_python_test(communication)
-  make_python_test(data)
-  make_python_test(forwarding)
-  make_python_test(ssl-tests)
-  make_python_test(store)
-  make_python_test(topic)
-  make_python_test(zeek-module)
-  # TODO: re-enable after updating generator files or adding backwards compatiblity
-  # make_python_test(broker-cluster-benchmark
-  #                  $<TARGET_FILE:broker-cluster-benchmark>)
-  #
-  # # allow some extra time for the benchmark integration test
-  # set_tests_properties(python-broker-cluster-benchmark PROPERTIES TIMEOUT 120)
+    make_python_test(communication)
+    make_python_test(data)
+    make_python_test(forwarding)
+    make_python_test(ssl-tests)
+    make_python_test(store)
+    make_python_test(topic)
+    make_python_test(zeek-module)
+    # TODO: re-enable after updating generator files or adding backwards compatiblity
+    # make_python_test(broker-cluster-benchmark
+    #                  $<TARGET_FILE:broker-cluster-benchmark>)
+    #
+    # # allow some extra time for the benchmark integration test
+    # set_tests_properties(python-broker-cluster-benchmark PROPERTIES TIMEOUT 120)
 endif ()

--- a/tests/benchmarks/cluster/cluster.cc
+++ b/tests/benchmarks/cluster/cluster.cc
@@ -382,7 +382,7 @@ void generator(caf::stateful_actor<generator_state>* self, node* this_node,
         st.gptr = std::move(ptr);
         st.remaining = *this_node->num_outputs;
       },
-      [=](state& st, caf::downstream<value_type>& out, size_t hint) {
+      [=, this](state& st, caf::downstream<value_type>& out, size_t hint) {
         if (st.gptr == nullptr)
           return;
         auto n = std::min(hint, st.remaining);
@@ -422,7 +422,7 @@ void generator(caf::stateful_actor<generator_state>* self, node* this_node,
         // Take ownership of `ptr`.
         st.gptr = std::move(ptr);
       },
-      [=](state& st, caf::downstream<value_type>& out, size_t hint) {
+      [=, this](state& st, caf::downstream<value_type>& out, size_t hint) {
         size_t n = 0;
         for (; n < hint; ++n) {
           if (done(st))
@@ -496,8 +496,10 @@ struct consumer_state {
       [](caf::unit_t&) {
         // nop
       },
-      [=](caf::unit_t&, std::vector<T>& xs) { handle_messages(xs.size()); },
-      [=](caf::unit_t&, const caf::error& err) {
+      [=, this](caf::unit_t&, std::vector<T>& xs) {
+        handle_messages(xs.size());
+      },
+      [=, this](caf::unit_t&, const caf::error& err) {
         verbose::println(this_node->name, " stops receiving ",
                          caf::type_name_v<T>);
       });
@@ -521,23 +523,23 @@ caf::behavior consumer(caf::stateful_actor<consumer_state>* self,
   self->send(self * core, atom::join_v, atom::data_store_v, topics(*this_node));
   if (!verbose::enabled())
     return {
-      [=](caf::stream<broker::data_message> in) {
+      [=, this](caf::stream<broker::data_message> in) {
         self->state.attach_sink(in, observer);
       },
-      [=](caf::stream<broker::command_message> in) {
+      [=, this](caf::stream<broker::command_message> in) {
         self->state.attach_sink(in, observer);
       },
     };
   size_t last_printed_count = 0;
   return {
-    [=](caf::stream<broker::data_message> in) {
+    [=, this](caf::stream<broker::data_message> in) {
       self->state.attach_sink(in, observer);
     },
-    [=](caf::stream<broker::command_message> in) {
+    [=, this](caf::stream<broker::command_message> in) {
       self->state.attach_sink(in, observer);
     },
     caf::after(std::chrono::seconds(1)) >>
-      [=]() mutable {
+      [=, this]() mutable {
         if (last_printed_count != self->state.received) {
           verbose::println(this_node->name,
                            " received nothing for 1s, last count: ",
@@ -606,7 +608,7 @@ caf::behavior node_manager(node_manager_actor* self, node* this_node) {
   if (is_receiver(*this_node))
     self->state.ep.forward(topics(*this_node));
   return {
-    [=](atom::init) -> caf::result<atom::ok> {
+    [=, this](atom::init) -> caf::result<atom::ok> {
       // Open up the ports and start peering.
       auto& st = self->state;
       if (this_node->id.scheme() == "tcp") {
@@ -660,9 +662,13 @@ caf::behavior node_manager(node_manager_actor* self, node* this_node) {
       verbose::println(this_node->name, " up and running");
       return atom::ok_v;
     },
-    [=](atom::read, caf::actor observer) { run_receive_mode(self, observer); },
-    [=](atom::write, caf::actor observer) { run_send_mode(self, observer); },
-    [=](atom::shutdown) -> caf::result<atom::ok> {
+    [=, this](atom::read, caf::actor observer) {
+      run_receive_mode(self, observer);
+    },
+    [=, this](atom::write, caf::actor observer) {
+      run_send_mode(self, observer);
+    },
+    [=, this](atom::shutdown) -> caf::result<atom::ok> {
       for (auto& child : self->state.children)
         self->send_exit(child, caf::exit_reason::user_shutdown);
       // Tell broker to shutdown. This is a blocking function call.

--- a/tests/benchmarks/fan-out/CMakeLists.txt
+++ b/tests/benchmarks/fan-out/CMakeLists.txt
@@ -1,7 +1,4 @@
-add_executable(broker-fan-out-benchmark
-  fan-out.cc
-)
+add_executable(broker-fan-out-benchmark fan-out.cc)
 target_link_libraries(broker-fan-out-benchmark PRIVATE ${BROKER_LIBRARY})
-target_include_directories(broker-fan-out-benchmark PRIVATE
-                           "${CMAKE_CURRENT_SOURCE_DIR}"
-                           "${CMAKE_CURRENT_BINARY_DIR}")
+target_include_directories(broker-fan-out-benchmark PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+                                                            "${CMAKE_CURRENT_BINARY_DIR}")

--- a/tests/benchmarks/routing-table/CMakeLists.txt
+++ b/tests/benchmarks/routing-table/CMakeLists.txt
@@ -1,15 +1,10 @@
 if (NOT benchmark_FOUND)
-  return()
+    return()
 endif ()
 
-add_executable(broker-routing-table-benchmark
-  routing-table.cc
-)
+add_executable(broker-routing-table-benchmark routing-table.cc)
 
-target_include_directories(broker-routing-table-benchmark PRIVATE
-                           "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(broker-routing-table-benchmark PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(broker-routing-table-benchmark
-  PRIVATE
-    benchmark::benchmark_main
-    ${BROKER_LIBRARY})
+target_link_libraries(broker-routing-table-benchmark PRIVATE benchmark::benchmark_main
+                                                             ${BROKER_LIBRARY})

--- a/tests/benchmarks/serialization/CMakeLists.txt
+++ b/tests/benchmarks/serialization/CMakeLists.txt
@@ -1,17 +1,10 @@
 if (NOT benchmark_FOUND)
-  return()
+    return()
 endif ()
 
-add_executable(broker-serialization-benchmark
-  serialization.cc
-  generator.cc
-)
+add_executable(broker-serialization-benchmark serialization.cc generator.cc)
 
-target_include_directories(broker-serialization-benchmark PRIVATE
-                           "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(broker-serialization-benchmark PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(broker-serialization-benchmark
-  PRIVATE
-    benchmark::benchmark_main
-    ${BROKER_LIBRARY}
-    CAF::core)
+target_link_libraries(broker-serialization-benchmark PRIVATE benchmark::benchmark_main
+                                                             ${BROKER_LIBRARY} CAF::core)

--- a/tests/btest/CMakeLists.txt
+++ b/tests/btest/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Define a function to create an executable and link the required libraries
-function(add_btest_executable target source)
+function (add_btest_executable target source)
     add_executable(btest-${target} ${source})
     target_link_libraries(btest-${target} PRIVATE ${BROKER_LIBRARY} ${ARGN})
-endfunction()
+endfunction ()
 
 add_btest_executable(disconnect-on-overload peering/disconnect-on-overload.cc)
 add_btest_executable(put-unique store/put-unique.cc CAF::core CAF::net)


### PR DESCRIPTION
As part of https://github.com/zeek/zeek/issues/4465, we realized that building with Node v23 also requires building with C++20. This is a good opportunity to upgrade to this version of C++ across the board. This is the broker part of things. This will eventually require a PR in the zeek/cmake repo to be merged too, but that will come later.