### PR TITLE
variant: Allow reference access to shared_envelope

### DIFF
--- a/libbroker/broker/variant.hh
+++ b/libbroker/broker/variant.hh
@@ -282,7 +282,7 @@ public:
   }
 
   /// Returns a shared pointer to the @ref envelope that owns the stored data.
-  auto shared_envelope() const noexcept {
+  const auto& shared_envelope() const noexcept {
     return envelope_;
   }
 


### PR DESCRIPTION
@bbannier pointed out that `shared_envelope()` always increments the atomic ref count due to auto declaration. Switch the API to const auto& to allow access without incrementing the ref count.