### PR TITLE
Make some lambda captures more concise in what they're capturing

### DIFF
--- a/broker-pipe/broker-pipe.cc
+++ b/broker-pipe/broker-pipe.cc
@@ -192,7 +192,7 @@ void subscribe_mode_stream(broker::endpoint& ep, const std::string& topic_str,
       if (++msgs >= cap)
         throw std::runtime_error("Reached cap");
     },
-    [=](size_t&, const broker::error&) {
+    [](size_t&, const broker::error&) {
       // nop
     });
   ep.wait_for(worker);
@@ -239,7 +239,7 @@ int main(int argc, char** argv) try {
     [] {
       // Init: nop.
     },
-    [=](const data_message& x) {
+    [](const data_message& x) {
       // OnNext: print the message.
       std::string what = to_string(x);
       what.insert(0, "*** ");
@@ -247,7 +247,7 @@ int main(int argc, char** argv) try {
       guard_type guard{cout_mtx};
       std::cerr << what;
     },
-    [=](const broker::error&) {
+    [](const broker::error&) {
       // Cleanup: nop.
     });
   // Publish endpoint at demanded port.

--- a/doc/comm.rst
+++ b/doc/comm.rst
@@ -157,10 +157,10 @@ TODO: Document.
 ..
 ..   context ctx;
 ..   auto ep = ctx.spawn<nonblocking>();
-..   ep.subscribe("/foo", [=](const topic& t, const data& d) {
+..   ep.subscribe("/foo", [](const topic& t, const data& d) {
 ..     std::cout << t << " -> " << d << std::endl;
 ..   });
-..   ep.subscribe("/bar", [=](const topic& t, const data& d) {
+..   ep.subscribe("/bar", [](const topic& t, const data& d) {
 ..     std::cout << t << " -> " << d << std::endl;
 ..   });
 ..

--- a/libbroker/broker/internal/channel.hh
+++ b/libbroker/broker/internal/channel.hh
@@ -604,7 +604,9 @@ public:
       // Find the first message in the assigned offset and drop any buffered
       // message before that point.
       if (!buf_.empty()) {
-        auto pred = [=](const optional_event& x) { return x.seq > offset; };
+        auto pred = [offset](const optional_event& x) {
+          return x.seq > offset;
+        };
         auto new_begin = std::find_if(buf_.begin(), buf_.end(), pred);
         if (auto n = std::distance(buf_.begin(), new_begin); n > 0) {
           metrics_.dec_out_of_order_updates(n);

--- a/libbroker/broker/internal/connector.cc
+++ b/libbroker/broker/internal/connector.cc
@@ -732,7 +732,7 @@ public:
   }
 
   stream_transport_error get_last_error(stream_socket fd, ptrdiff_t ret) {
-    return std::visit([=](auto& pl) { return pl.last_error(fd, ret); },
+    return std::visit([fd, ret](auto& pl) { return pl.last_error(fd, ret); },
                       sck_policy);
   }
 
@@ -771,11 +771,13 @@ public:
   read_result do_transport_handshake_rd(stream_socket fd);
 
   ptrdiff_t do_write(stream_socket fd, caf::span<const caf::byte> buf) {
-    return std::visit([=](auto& pl) { return pl.write(fd, buf); }, sck_policy);
+    return std::visit([fd, buf](auto& pl) { return pl.write(fd, buf); },
+                      sck_policy);
   }
 
   ptrdiff_t do_read(stream_socket fd, caf::span<caf::byte> buf) {
-    return std::visit([=](auto& pl) { return pl.read(fd, buf); }, sck_policy);
+    return std::visit([fd, buf](auto& pl) { return pl.read(fd, buf); },
+                      sck_policy);
   }
 
   write_result continue_writing(stream_socket fd) {


### PR DESCRIPTION
This fixes some warnings in C++ 20 builds as well. Lambda captures using just `[=]` are deprecated in that version.

This splits a commit out of https://github.com/zeek/broker/pull/465, since the changes here can go in before C++20 is required.