### PR TITLE
Fix some comparison operators for C++20

### DIFF
--- a/libbroker/broker/data.hh
+++ b/libbroker/broker/data.hh
@@ -523,6 +523,36 @@ inline bool operator!=(const data& x, const data& y) {
   return x.get_data() != y.get_data();
 }
 
+inline bool operator<(const std::pair<const data, data>& x,
+                      const std::pair<const data, data>& y) {
+  return x.first < y.first && x.second < y.second;
+}
+
+inline bool operator<=(const std::pair<const data, data>& x,
+                       const std::pair<const data, data>& y) {
+  return x.first <= y.first && x.second <= y.second;
+}
+
+inline bool operator>(const std::pair<const data, data>& x,
+                      const std::pair<const data, data>& y) {
+  return x.first > y.first && x.second > y.second;
+}
+
+inline bool operator>=(const std::pair<const data, data>& x,
+                       const std::pair<const data, data>& y) {
+  return x.first >= y.first && x.second >= y.second;
+}
+
+inline bool operator==(const std::pair<const data, data>& x,
+                       const std::pair<const data, data>& y) {
+  return x.first == y.first && x.second == y.second;
+}
+
+inline bool operator!=(const std::pair<const data, data>& x,
+                       const std::pair<const data, data>& y) {
+  return !(x == y);
+}
+
 // --- compatibility/wrapper functionality (may be removed later) --------------
 
 template <class T>


### PR DESCRIPTION
This splits a few more changes out of https://github.com/zeek/broker/pull/465, this time some fixes for comparison operators that are broken by C++20. These changes can go in prior to requiring C++20.