### PR TITLE
Use std::format in Broker

### DIFF
--- a/doc/formatting.rst
+++ b/doc/formatting.rst
@@ -1,0 +1,71 @@
+Formatting
+==========
+
+Broker uses C++20's ``std::format`` library for string formatting throughout the
+codebase and provides formatters for its own types.
+
+String Conversion
+~~~~~~~~~~~~~~~~~
+
+All types in Broker support formatting through the `convert` function pattern:
+
+.. code-block:: cpp
+
+   void convert(const T& value, std::string& output);
+   std::string to_string(const T& value);
+
+The `convert` function is the primary formatting function that writes to an
+output string. The `to_string` function is a convenience wrapper that calls
+`convert`.
+
+Any type in Broker that provides a ``convert`` function can be formatted with
+``std::format``. The formatter implementations are defined in
+``broker/format.hh``. Only after including this header, Broker types can be
+formatted with ``std::format``.
+
+Basic Formatting
+~~~~~~~~~~~~~~~
+
+.. code-block:: cpp
+
+   #include "broker/data.hh"
+   #include "broker/format.hh"
+
+   auto value = broker::data{42};
+   auto result = std::format("Value: {}", value);
+
+Logging
+~~~~~~~
+
+The logging system uses ``std::format`` internally. In addition to the format
+string and the arguments, all logging functions take an event name as first
+argument. This name is used to identify the event in the logging system and can
+be used to filter events.
+
+For example, the following code logs a message with severity ``info`` and the
+event name ``my-event-name`` for the ``core`` component:
+
+.. code-block:: cpp
+
+   broker::log::core::info("my-event-name", "Processing message: {}", message);
+
+Available severity levels are:
+
+- ``critical``: fatal errors that prevent the application from continuing
+- ``error``: severe events that most likely result in a loss of functionality
+- ``warning``: events that indicate a potential problem
+- ``info``: informational messages that provide context to the user
+- ``verbose``: detailed messages that provide additional context
+- ``debug``: messages that provide detailed information for debugging
+
+Available components are:
+
+- ``core``: logging for core Broker components
+- ``endpoint``: logging related to the local endpoint
+- ``store``: logging related to data stores
+- ``network``: logging related to network components
+- ``app``: logging from the application layer (not used by Broker itself)
+
+The name of the component combined with the severity level forms the full
+function name. For example, the function name for the ``core`` component and
+``info`` severity level is ``broker::log::core::info``.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,6 +48,7 @@ Synopsis
 
   overview
   comm
+  formatting
   data
   stores
   web-socket

--- a/libbroker/CMakeLists.txt
+++ b/libbroker/CMakeLists.txt
@@ -17,6 +17,7 @@ set(BROKER_SRC
     broker/address.cc
     broker/alm/multipath.cc
     broker/alm/routing_table.cc
+    broker/backend.cc
     broker/builder.cc
     broker/command_envelope.cc
     broker/configuration.cc
@@ -41,6 +42,7 @@ set(BROKER_SRC
     broker/endpoint_id.cc
     broker/endpoint_info.cc
     broker/entity_id.cc
+    broker/enum_value.cc
     broker/envelope.cc
     broker/error.cc
     broker/event_observer.cc
@@ -71,8 +73,10 @@ set(BROKER_SRC
     broker/logger.cc
     broker/mailbox.cc
     broker/network_info.cc
+    broker/none.cc
     broker/overflow_policy.cc
     broker/p2p_message_type.cc
+    broker/peer_info.cc
     broker/peer_status.cc
     broker/ping_envelope.cc
     broker/pong_envelope.cc

--- a/libbroker/broker/alm/multipath.cc
+++ b/libbroker/broker/alm/multipath.cc
@@ -107,8 +107,10 @@ bool multipath_node::contains(const endpoint_id& id) const noexcept {
 }
 
 void multipath_node::stringify(std::string& buf) const {
+  std::string id_str;
+  convert(id_, id_str);
   buf += '(';
-  buf += to_string(id_);
+  buf += id_str;
   if (!down_.empty()) {
     buf += ", [";
     auto i = down_.begin();

--- a/libbroker/broker/backend.cc
+++ b/libbroker/broker/backend.cc
@@ -1,0 +1,12 @@
+#include "broker/backend.hh"
+
+namespace broker {
+
+void convert(const backend& src, std::string& dst) {
+  if (src == backend::memory)
+    dst = "memory";
+  else if (src == backend::sqlite)
+    dst = "sqlite";
+}
+
+} // namespace broker

--- a/libbroker/broker/backend.hh
+++ b/libbroker/broker/backend.hh
@@ -27,11 +27,6 @@ bool inspect(Inspector& f, backend& x) {
 }
 
 /// @relates backend
-inline void convert(backend x, std::string& str) {
-  if (x == backend::memory)
-    str = "memory";
-  else if (x == backend::sqlite)
-    str = "sqlite";
-}
+void convert(const backend& x, std::string& str);
 
 } // namespace broker

--- a/libbroker/broker/builder.cc
+++ b/libbroker/broker/builder.cc
@@ -4,6 +4,7 @@
 #include "broker/defaults.hh"
 #include "broker/envelope.hh"
 #include "broker/error.hh"
+#include "broker/format.hh"
 #include "broker/fwd.hh"
 #include "broker/topic.hh"
 
@@ -64,9 +65,8 @@ data_envelope_ptr make_builder_envelope(std::string_view topic_str,
   auto res = builder_envelope_ptr::make(topic_str, std::move(bytes), offset);
 #ifndef NDEBUG
   if (auto err = res->parse()) {
-    auto errstr = to_string(err);
-    fprintf(stderr, "make_builder_envelope received malformed data: %s\n",
-            errstr.c_str());
+    detail::println(stderr, "make_builder_envelope received malformed data: {}",
+                    err);
     abort();
   }
 #else

--- a/libbroker/broker/command_envelope.cc
+++ b/libbroker/broker/command_envelope.cc
@@ -171,11 +171,7 @@ expected<envelope_ptr> command_envelope::deserialize(
 }
 
 void convert(const command_envelope_ptr& cmd, std::string& str) {
-  if (!cmd) {
-    str = "null";
-    return;
-  }
-  str = cmd->stringify();
+  convert(cmd.get(), str);
 }
 
 } // namespace broker

--- a/libbroker/broker/data.cc
+++ b/libbroker/broker/data.cc
@@ -5,6 +5,7 @@
 
 #include "broker/convert.hh"
 #include "broker/expected.hh"
+#include "broker/format.hh"
 #include "broker/format/bin.hh"
 #include "broker/format/txt.hh"
 #include "broker/internal/native.hh"
@@ -407,11 +408,18 @@ bool convert(const endpoint_id& node, data& d) {
   return true;
 }
 
+void convert(const expected<data>& x, std::string& str) {
+  if (x) {
+    convert(*x, str);
+  } else {
+    str = std::format("!{}", x.error());
+  }
+}
+
 std::string to_string(const expected<data>& x) {
-  if (x)
-    return to_string(*x);
-  else
-    return "!" + to_string(x.error());
+  std::string result;
+  convert(x, result);
+  return result;
 }
 
 } // namespace broker

--- a/libbroker/broker/data.test.cc
+++ b/libbroker/broker/data.test.cc
@@ -1,10 +1,12 @@
 #include "broker/data.hh"
 
 #include "broker/broker-test.test.hh"
+#include "broker/format.hh"
 #include "broker/format/bin.hh"
 
 #include <chrono>
 #include <cstdint>
+#include <format>
 #include <map>
 #include <optional>
 #include <string>
@@ -20,6 +22,11 @@ static_assert(std::is_same_v<boolean, bool>);
 static_assert(std::is_same_v<integer, int64_t>);
 static_assert(std::is_same_v<count, uint64_t>);
 static_assert(std::is_same_v<real, double>);
+
+TEST(can format) {
+  auto val = data{42};
+  CHECK_EQUAL(std::format("{}", val), "42");
+}
 
 TEST(timespan) {
   auto s = timespan{42};

--- a/libbroker/broker/data_envelope.cc
+++ b/libbroker/broker/data_envelope.cc
@@ -259,4 +259,8 @@ data_envelope_ptr data_envelope::make(std::string_view t, variant d) {
   return make(broker::topic{std::string{t}}, std::move(d));
 }
 
+void convert(const data_envelope_ptr& src, std::string& dst) {
+  convert(src.get(), dst);
+}
+
 } // namespace broker

--- a/libbroker/broker/detail/flare.cc
+++ b/libbroker/broker/detail/flare.cc
@@ -80,7 +80,7 @@ flare::flare() {
   auto maybe_fds = caf::net::make_pipe();
   if (!maybe_fds) {
     log::core::critical("cannot-create-pipe", "failed to create pipe: {}",
-                        maybe_fds.error());
+                        caf::to_string(maybe_fds.error()));
     abort();
   }
   auto [first, second] = *maybe_fds;
@@ -88,13 +88,16 @@ flare::flare() {
   fds_[1] = second.id;
   if (auto err = caf::net::child_process_inherit(first, false))
     log::core::error("cannot-set-cloexec",
-                     "failed to set flare fd 0 CLOEXEC: {}", err);
+                     "failed to set flare fd 0 CLOEXEC: {}",
+                     caf::to_string(err));
   if (auto err = caf::net::child_process_inherit(second, false))
     log::core::error("cannot-set-cloexec",
-                     "failed to set flare fd 1 CLOEXEC: {}", err);
+                     "failed to set flare fd 1 CLOEXEC: {}",
+                     caf::to_string(err));
   if (auto err = caf::net::nonblocking(first, true)) {
     log::core::critical("cannot-set-nonblock",
-                        "failed to set flare fd 0 NONBLOCK: {}", err);
+                        "failed to set flare fd 0 NONBLOCK: {}",
+                        caf::to_string(err));
     std::terminate();
   }
   // Do not set the write handle to nonblock, because we want the producer to

--- a/libbroker/broker/detail/sqlite_backend.cc
+++ b/libbroker/broker/detail/sqlite_backend.cc
@@ -16,6 +16,7 @@
 #include "broker/detail/sqlite_backend.hh"
 #include "broker/error.hh"
 #include "broker/expected.hh"
+#include "broker/format.hh"
 #include "broker/format/bin.hh"
 #include "broker/internal/type_id.hh"
 #include "broker/logger.hh"
@@ -281,7 +282,8 @@ struct sqlite_backend::impl {
     if (!dir.empty()) {
       if (!detail::is_directory(dir) && !detail::mkdirs(dir)) {
         log::store::error("sqlite-create-dir-failed",
-                          "failed to create directory for database: {}", dir);
+                          "failed to create directory for database: {}",
+                          dir.native());
         return false;
       }
     }

--- a/libbroker/broker/endpoint.cc
+++ b/libbroker/broker/endpoint.cc
@@ -4,6 +4,7 @@
 #include "broker/defaults.hh"
 #include "broker/detail/die.hh"
 #include "broker/detail/filesystem.hh"
+#include "broker/format.hh"
 #include "broker/hub.hh"
 #include "broker/internal/configuration_access.hh"
 #include "broker/internal/core_actor.hh"
@@ -233,7 +234,8 @@ public:
         },
         [&](const caf::error& reason) {
           log::endpoint::debug("sim-clock-error",
-                               "advance_time actor syncing failed: {}", reason);
+                               "advance_time actor syncing failed: {}",
+                               caf::to_string(reason));
           abort_syncing = true;
         });
     // Dispose the timeout if it's still pending to avoid unnecessary messaging.
@@ -546,7 +548,8 @@ uint16_t endpoint::listen(const std::string& address, uint16_t port,
       },
       [&](caf::error& err) {
         log::endpoint::warning("listen-failed",
-                               "failed to listen on port {}: {}", port, err);
+                               "failed to listen on port {}: {}", port,
+                               caf::to_string(err));
         if (err_ptr)
           *err_ptr = facade(err);
       });
@@ -571,7 +574,7 @@ bool endpoint::peer(const std::string& address, uint16_t port,
       },
       [&](const caf::error& reason) {
         log::endpoint::warning("sync-peer-error", "cannot peer to {}:{}: {}",
-                               address, port, reason);
+                               address, port, caf::to_string(reason));
       });
   return result;
 }
@@ -619,7 +622,7 @@ bool endpoint::unpeer(const std::string& address, uint16_t port) {
       [&](const caf::error& reason) {
         log::endpoint::warning("sync-unpeer-error",
                                "cannot unpeer from {}:{}: {}", address, port,
-                               reason);
+                               caf::to_string(reason));
       });
 
   return result;
@@ -885,7 +888,7 @@ expected<store> endpoint::attach_master(std::string name, backend type,
         log::endpoint::warning(
           "attach-master-failed",
           "failed to attached master store {} of type {}: {}", name, type,
-          reason);
+          caf::to_string(reason));
         res = facade(reason);
       });
   return res;
@@ -914,7 +917,7 @@ expected<store> endpoint::attach_clone(std::string name, double resync_interval,
       [&](const caf::error& reason) {
         log::endpoint::warning("attach-clone-failed",
                                "failed to attached clone store {}: {}", name,
-                               reason);
+                               caf::to_string(reason));
         res = facade(reason);
       });
   return res;

--- a/libbroker/broker/endpoint_id.cc
+++ b/libbroker/broker/endpoint_id.cc
@@ -61,8 +61,8 @@ bool endpoint_id::can_parse(std::string_view str) {
 
 // -- free functions -----------------------------------------------------------
 
-void convert(endpoint_id x, std::string& str) {
-  str = caf::to_string(to_uuid(x));
+void convert(const endpoint_id& from, std::string& str) {
+  str = caf::to_string(to_uuid(from));
 }
 
 bool convert(const std::string& str, endpoint_id& x) {

--- a/libbroker/broker/endpoint_id.hh
+++ b/libbroker/broker/endpoint_id.hh
@@ -95,7 +95,7 @@ private:
 // -- free functions -----------------------------------------------------------
 
 /// @relates endpoint_id
-void convert(endpoint_id x, std::string& str);
+void convert(const endpoint_id& from, std::string& str);
 
 /// @relates endpoint_id
 bool convert(const std::string& str, endpoint_id& x);

--- a/libbroker/broker/endpoint_info.cc
+++ b/libbroker/broker/endpoint_info.cc
@@ -1,15 +1,16 @@
 #include "broker/endpoint_info.hh"
 
-#include <regex>
-
 #include <caf/expected.hpp>
 #include <caf/node_id.hpp>
 #include <caf/uri.hpp>
 
 #include "broker/data.hh"
+#include "broker/format.hh"
 #include "broker/internal/native.hh"
 #include "broker/variant.hh"
 #include "broker/variant_list.hh"
+
+#include <format>
 
 namespace broker {
 
@@ -98,16 +99,11 @@ bool convert(const endpoint_info& src, data& dst) {
 }
 
 void convert(const endpoint_info& src, std::string& dst) {
-  dst += "endpoint_info(";
-  dst += to_string(src.node);
-  dst += ", ";
   if (auto& net = src.network) {
-    dst += '*';
-    dst += to_string(*net);
+    dst = std::format("endpoint_info({}, *{})", src.node, *net);
   } else {
-    dst += "none";
+    dst = std::format("endpoint_info({}, none)", src.node);
   }
-  dst += ')';
 }
 
 } // namespace broker

--- a/libbroker/broker/entity_id.cc
+++ b/libbroker/broker/entity_id.cc
@@ -1,22 +1,21 @@
 #include "broker/entity_id.hh"
-
-#include <caf/hash/fnv.hpp>
+#include "broker/format.hh"
 
 #include "broker/internal/native.hh"
 #include "broker/internal/type_id.hh"
 
-namespace broker {
+#include <caf/hash/fnv.hpp>
 
+#include <format>
+
+namespace broker {
 size_t entity_id ::hash() const noexcept {
   return caf::hash::fnv<size_t>::compute(*this);
 }
 
 void convert(const entity_id& in, std::string& out) {
-  using std::to_string;
   if (in.object != 0 || in.endpoint) {
-    out = to_string(in.object);
-    out += "@";
-    out += to_string(in.endpoint);
+    out = std::format("{}@{}", in.object, in.endpoint);
   } else {
     out = "none";
   }

--- a/libbroker/broker/enum_value.cc
+++ b/libbroker/broker/enum_value.cc
@@ -1,0 +1,13 @@
+#include "broker/enum_value.hh"
+
+namespace broker {
+
+void convert(const enum_value& e, std::string& str) {
+  str = e.name;
+}
+
+void convert(const enum_value_view& e, std::string& str) {
+  str = e.name;
+}
+
+} // namespace broker

--- a/libbroker/broker/enum_value.hh
+++ b/libbroker/broker/enum_value.hh
@@ -33,11 +33,6 @@ bool inspect(Inspector& f, enum_value& e) {
   return f.apply(e.name);
 }
 
-/// @relates enum_value
-inline void convert(const enum_value& e, std::string& str) {
-  str = e.name;
-}
-
 /// Like enum_value, but wraps a value of type `std::string_view` instead.
 class enum_value_view : detail::comparable<enum_value_view>,
                         detail::comparable<enum_value_view, enum_value> {

--- a/libbroker/broker/envelope.cc
+++ b/libbroker/broker/envelope.cc
@@ -40,9 +40,9 @@ using const_byte_pointer = const std::byte*;
 
 // -- envelope_type ------------------------------------------------------------
 
-std::string to_string(envelope_type x) {
+void convert(const envelope_type& x, std::string& str) {
   // Same strings since packed_message is a subset of p2p_message.
-  return to_string(static_cast<p2p_message_type>(x));
+  convert(static_cast<p2p_message_type>(x), str);
 }
 
 bool from_string(std::string_view str, envelope_type& x) {
@@ -214,6 +214,22 @@ pong_envelope_ptr envelope::as_pong() const {
 
 envelope_type data_envelope::type() const noexcept {
   return envelope_type::data;
+}
+
+void convert(const envelope& src, std::string& dst) {
+  dst = src.stringify();
+}
+
+void convert(const envelope* src, std::string& dst) {
+  if (src) {
+    dst = src->stringify();
+  } else {
+    dst = "null";
+  }
+}
+
+void convert(const envelope_ptr& src, std::string& dst) {
+  convert(src.get(), dst);
 }
 
 } // namespace broker

--- a/libbroker/broker/envelope.hh
+++ b/libbroker/broker/envelope.hh
@@ -24,9 +24,6 @@ enum class envelope_type : uint8_t {
 };
 
 /// @relates envelope_type
-std::string to_string(envelope_type);
-
-/// @relates envelope_type
 bool from_string(std::string_view, envelope_type&);
 
 /// @relates envelope_type
@@ -224,16 +221,12 @@ private:
 using envelope_ptr = intrusive_ptr<const envelope>;
 
 /// @relates envelope
-inline std::string to_string(const envelope& x) {
-  return x.stringify();
-}
+void convert(const envelope& src, std::string& dst);
 
 /// @relates envelope
-inline std::string to_string(const envelope_ptr& x) {
-  if (x)
-    return x->stringify();
-  else
-    return "<null>";
-}
+void convert(const envelope* src, std::string& dst);
+
+/// @relates envelope
+void convert(const envelope_ptr& src, std::string& dst);
 
 } // namespace broker

--- a/libbroker/broker/error.cc
+++ b/libbroker/broker/error.cc
@@ -175,10 +175,10 @@ error make_error(ec code, endpoint_info info, std::string description) {
   return error{code, std::move(info), std::move(description)};
 }
 
-std::string to_string(ec code) {
-  auto index = static_cast<uint8_t>(code);
+void convert(const ec& src, std::string& dst) {
+  auto index = static_cast<uint8_t>(src);
   BROKER_ASSERT(index < array_size(ec_names));
-  return std::string{ec_names[index]};
+  dst = ec_names[index];
 }
 
 std::string_view enum_str(ec code) {

--- a/libbroker/broker/error.hh
+++ b/libbroker/broker/error.hh
@@ -218,7 +218,7 @@ template <ec Value>
 using ec_constant = std::integral_constant<ec, Value>;
 
 /// @relates ec
-std::string to_string(ec code);
+void convert(const ec& src, std::string& dst);
 
 /// @relates ec
 std::string_view enum_str(ec code);

--- a/libbroker/broker/error.test.cc
+++ b/libbroker/broker/error.test.cc
@@ -23,6 +23,12 @@ data make_data_error(ec code, vector context = {}) {
 FIXTURE_SCOPE(status_tests, ids_fixture)
 
 TEST(ec is convertible to and from string) {
+  auto ec_from_string = [](std::string_view str) -> std::optional<ec> {
+    auto resutl = ec::none;
+    if (convert(str, resutl))
+      return resutl;
+    return {};
+  };
   CHECK_EQUAL(to_string(ec::unspecified), "unspecified"s);
   CHECK_EQUAL(to_string(ec::peer_incompatible), "peer_incompatible"s);
   CHECK_EQUAL(to_string(ec::peer_invalid), "peer_invalid"s);
@@ -41,26 +47,26 @@ TEST(ec is convertible to and from string) {
   CHECK_EQUAL(to_string(ec::invalid_topic_key), "invalid_topic_key"s);
   CHECK_EQUAL(to_string(ec::end_of_file), "end_of_file"s);
   CHECK_EQUAL(to_string(ec::invalid_tag), "invalid_tag"s);
-  CHECK_EQUAL(from_string<ec>("unspecified"), ec::unspecified);
-  CHECK_EQUAL(from_string<ec>("peer_incompatible"), ec::peer_incompatible);
-  CHECK_EQUAL(from_string<ec>("peer_invalid"), ec::peer_invalid);
-  CHECK_EQUAL(from_string<ec>("peer_unavailable"), ec::peer_unavailable);
-  CHECK_EQUAL(from_string<ec>("peer_timeout"), ec::peer_timeout);
-  CHECK_EQUAL(from_string<ec>("master_exists"), ec::master_exists);
-  CHECK_EQUAL(from_string<ec>("no_such_master"), ec::no_such_master);
-  CHECK_EQUAL(from_string<ec>("no_such_key"), ec::no_such_key);
-  CHECK_EQUAL(from_string<ec>("request_timeout"), ec::request_timeout);
-  CHECK_EQUAL(from_string<ec>("type_clash"), ec::type_clash);
-  CHECK_EQUAL(from_string<ec>("invalid_data"), ec::invalid_data);
-  CHECK_EQUAL(from_string<ec>("backend_failure"), ec::backend_failure);
-  CHECK_EQUAL(from_string<ec>("stale_data"), ec::stale_data);
-  CHECK_EQUAL(from_string<ec>("cannot_open_file"), ec::cannot_open_file);
-  CHECK_EQUAL(from_string<ec>("cannot_write_file"), ec::cannot_write_file);
-  CHECK_EQUAL(from_string<ec>("invalid_topic_key"), ec::invalid_topic_key);
-  CHECK_EQUAL(from_string<ec>("end_of_file"), ec::end_of_file);
-  CHECK_EQUAL(from_string<ec>("invalid_tag"), ec::invalid_tag);
-  CHECK_EQUAL(from_string<ec>("none"), ec::none);
-  CHECK_EQUAL(from_string<ec>("foo"), std::nullopt);
+  CHECK_EQUAL(ec_from_string("unspecified"), ec::unspecified);
+  CHECK_EQUAL(ec_from_string("peer_incompatible"), ec::peer_incompatible);
+  CHECK_EQUAL(ec_from_string("peer_invalid"), ec::peer_invalid);
+  CHECK_EQUAL(ec_from_string("peer_unavailable"), ec::peer_unavailable);
+  CHECK_EQUAL(ec_from_string("peer_timeout"), ec::peer_timeout);
+  CHECK_EQUAL(ec_from_string("master_exists"), ec::master_exists);
+  CHECK_EQUAL(ec_from_string("no_such_master"), ec::no_such_master);
+  CHECK_EQUAL(ec_from_string("no_such_key"), ec::no_such_key);
+  CHECK_EQUAL(ec_from_string("request_timeout"), ec::request_timeout);
+  CHECK_EQUAL(ec_from_string("type_clash"), ec::type_clash);
+  CHECK_EQUAL(ec_from_string("invalid_data"), ec::invalid_data);
+  CHECK_EQUAL(ec_from_string("backend_failure"), ec::backend_failure);
+  CHECK_EQUAL(ec_from_string("stale_data"), ec::stale_data);
+  CHECK_EQUAL(ec_from_string("cannot_open_file"), ec::cannot_open_file);
+  CHECK_EQUAL(ec_from_string("cannot_write_file"), ec::cannot_write_file);
+  CHECK_EQUAL(ec_from_string("invalid_topic_key"), ec::invalid_topic_key);
+  CHECK_EQUAL(ec_from_string("end_of_file"), ec::end_of_file);
+  CHECK_EQUAL(ec_from_string("invalid_tag"), ec::invalid_tag);
+  CHECK_EQUAL(ec_from_string("none"), ec::none);
+  CHECK_EQUAL(ec_from_string("foo"), std::nullopt);
 }
 
 TEST(default constructed errors have a fixed representation) {

--- a/libbroker/broker/expected.hh
+++ b/libbroker/broker/expected.hh
@@ -384,11 +384,4 @@ inline bool operator!=(const expected<void>& x, const expected<void>& y) {
   return !(x == y);
 }
 
-inline std::string to_string(const expected<void>& x) {
-  if (x)
-    return "unit";
-  else
-    return "!" + to_string(x.error());
-}
-
 } // namespace broker

--- a/libbroker/broker/filter_type.cc
+++ b/libbroker/broker/filter_type.cc
@@ -50,4 +50,20 @@ bool filter_extend(filter_type& f, const filter_type& other) {
   return count > 0;
 }
 
+void convert(const filter_type& src, std::string& dst) {
+  if (src.empty()) {
+    dst += "[]";
+    return;
+  }
+  dst = "[";
+  auto i = src.begin();
+  auto e = src.end();
+  dst += i->string();
+  for (++i; i != e; ++i) {
+    dst += ", ";
+    dst += i->string();
+  }
+  dst += "]";
+}
+
 } // namespace broker

--- a/libbroker/broker/format.hh
+++ b/libbroker/broker/format.hh
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "broker/data.hh"
+#include "broker/detail/type_traits.hh"
+
+#include <format>
+#include <type_traits>
+
+namespace broker::detail {
+
+template <class T>
+struct default_formatter {
+  using string_formatter = std::formatter<std::string, char>;
+
+  constexpr auto parse(std::format_parse_context& ctx) {
+    return string_formatter{}.parse(ctx);
+  }
+
+  template <typename FormatContext>
+  auto format(const T& value, FormatContext& ctx) const {
+    std::string out;
+    broker::convert(value, out);
+    return string_formatter{}.format(out, ctx);
+  }
+};
+
+// Backported from C++23.
+template <class... Args>
+void println(std::format_string<Args...> fmt, Args&&... args) {
+  auto str = std::format(fmt, std::forward<Args>(args)...);
+  printf("%s\n", str.c_str());
+}
+
+// Backported from C++23.
+template <class... Args>
+void println(std::FILE* stream, std::format_string<Args...> fmt,
+             Args&&... args) {
+  auto str = std::format(fmt, std::forward<Args>(args)...);
+  fprintf(stream, "%s\n", str.c_str());
+}
+
+} // namespace broker::detail
+
+#define BROKER_STD_FORMATTER_IMPL(type_name)                                   \
+  template <>                                                                  \
+  struct formatter<broker::type_name, char>                                    \
+    : broker::detail::default_formatter<broker::type_name> {}
+
+namespace std {
+
+BROKER_STD_FORMATTER_IMPL(endpoint_info);
+BROKER_STD_FORMATTER_IMPL(entity_id);
+BROKER_STD_FORMATTER_IMPL(enum_value);
+BROKER_STD_FORMATTER_IMPL(network_info);
+BROKER_STD_FORMATTER_IMPL(none);
+BROKER_STD_FORMATTER_IMPL(peer_info);
+BROKER_STD_FORMATTER_IMPL(put_command);
+BROKER_STD_FORMATTER_IMPL(put_unique_command);
+BROKER_STD_FORMATTER_IMPL(put_unique_result_command);
+BROKER_STD_FORMATTER_IMPL(erase_command);
+BROKER_STD_FORMATTER_IMPL(expire_command);
+BROKER_STD_FORMATTER_IMPL(add_command);
+BROKER_STD_FORMATTER_IMPL(subtract_command);
+BROKER_STD_FORMATTER_IMPL(clear_command);
+BROKER_STD_FORMATTER_IMPL(attach_writer_command);
+BROKER_STD_FORMATTER_IMPL(ack_clone_command);
+BROKER_STD_FORMATTER_IMPL(cumulative_ack_command);
+BROKER_STD_FORMATTER_IMPL(nack_command);
+BROKER_STD_FORMATTER_IMPL(keepalive_command);
+BROKER_STD_FORMATTER_IMPL(retransmit_failed_command);
+BROKER_STD_FORMATTER_IMPL(address);
+BROKER_STD_FORMATTER_IMPL(endpoint_id);
+BROKER_STD_FORMATTER_IMPL(enum_value_view);
+BROKER_STD_FORMATTER_IMPL(envelope);
+BROKER_STD_FORMATTER_IMPL(error);
+BROKER_STD_FORMATTER_IMPL(internal_command);
+BROKER_STD_FORMATTER_IMPL(port);
+BROKER_STD_FORMATTER_IMPL(shutdown_options);
+BROKER_STD_FORMATTER_IMPL(status);
+BROKER_STD_FORMATTER_IMPL(subnet);
+BROKER_STD_FORMATTER_IMPL(topic);
+BROKER_STD_FORMATTER_IMPL(variant);
+BROKER_STD_FORMATTER_IMPL(variant_data);
+BROKER_STD_FORMATTER_IMPL(variant_list);
+BROKER_STD_FORMATTER_IMPL(variant_set);
+BROKER_STD_FORMATTER_IMPL(variant_table);
+BROKER_STD_FORMATTER_IMPL(backend);
+BROKER_STD_FORMATTER_IMPL(ec);
+BROKER_STD_FORMATTER_IMPL(overflow_policy);
+BROKER_STD_FORMATTER_IMPL(p2p_message_type);
+BROKER_STD_FORMATTER_IMPL(peer_status);
+BROKER_STD_FORMATTER_IMPL(sc);
+BROKER_STD_FORMATTER_IMPL(data);
+BROKER_STD_FORMATTER_IMPL(command_envelope_ptr);
+BROKER_STD_FORMATTER_IMPL(data_envelope_ptr);
+BROKER_STD_FORMATTER_IMPL(envelope_ptr);
+BROKER_STD_FORMATTER_IMPL(ping_envelope_ptr);
+BROKER_STD_FORMATTER_IMPL(pong_envelope_ptr);
+BROKER_STD_FORMATTER_IMPL(routing_update_envelope_ptr);
+BROKER_STD_FORMATTER_IMPL(filter_type);
+BROKER_STD_FORMATTER_IMPL(internal::expiry_formatter);
+
+template <class T>
+struct formatter<broker::expected<T>, char> {
+  using string_formatter = std::formatter<std::string, char>;
+
+  constexpr auto parse(std::format_parse_context& ctx) {
+    return string_formatter{}.parse(ctx);
+  }
+
+  template <typename FormatContext>
+  auto format(const broker::expected<T>& value, FormatContext& ctx) const {
+    if (value) {
+      std::string out;
+      broker::convert(*value, out);
+      return string_formatter{}.format(out, ctx);
+    }
+    std::string out;
+    broker::convert(value.error(), out);
+    return string_formatter{}.format(out, ctx);
+  }
+};
+
+} // namespace std

--- a/libbroker/broker/fwd.hh
+++ b/libbroker/broker/fwd.hh
@@ -1,13 +1,10 @@
 #pragma once
 
-#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <future>
 #include <map>
 #include <memory>
-#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -98,9 +95,13 @@ class intrusive_ptr;
 // -- enum classes -------------------------------------------------------------
 
 enum class backend : uint8_t;
+enum class command_tag;
 enum class ec : uint8_t;
+enum class envelope_type : uint8_t;
 enum class hub_id : uint64_t;
+enum class overflow_policy;
 enum class p2p_message_type : uint8_t;
+enum class peer_status;
 enum class sc : uint8_t;
 enum class variant_tag : uint8_t;
 
@@ -198,6 +199,14 @@ class IdentifierUpdate;
 
 } // namespace broker::zeek
 
+// -- internal utility types ---------------------------------------------------
+
+namespace broker::internal {
+
+struct expiry_formatter;
+
+} // namespace broker::internal
+
 // -- third-party types --------------------------------------------------------
 
 namespace prometheus {
@@ -212,5 +221,73 @@ class Registry;
 namespace broker {
 
 using prometheus_registry_ptr = std::shared_ptr<prometheus::Registry>;
+
+} // namespace broker
+
+// -- forward declarations for various convert overloads (needed in format.hh) -
+
+#define BROKER_CONVERT_AND_TO_STRING(type_name)                                \
+  void convert(const type_name& src, std::string& dst);                        \
+  inline std::string to_string(const type_name& src) {                         \
+    std::string result;                                                        \
+    convert(src, result);                                                      \
+    return result;                                                             \
+  }
+
+namespace broker {
+
+BROKER_CONVERT_AND_TO_STRING(ack_clone_command)
+BROKER_CONVERT_AND_TO_STRING(add_command)
+BROKER_CONVERT_AND_TO_STRING(address)
+BROKER_CONVERT_AND_TO_STRING(attach_writer_command)
+BROKER_CONVERT_AND_TO_STRING(backend)
+BROKER_CONVERT_AND_TO_STRING(clear_command)
+BROKER_CONVERT_AND_TO_STRING(command_envelope_ptr)
+BROKER_CONVERT_AND_TO_STRING(command_tag)
+BROKER_CONVERT_AND_TO_STRING(cumulative_ack_command)
+BROKER_CONVERT_AND_TO_STRING(data_envelope_ptr)
+BROKER_CONVERT_AND_TO_STRING(ec)
+BROKER_CONVERT_AND_TO_STRING(endpoint_id)
+BROKER_CONVERT_AND_TO_STRING(endpoint_info)
+BROKER_CONVERT_AND_TO_STRING(entity_id)
+BROKER_CONVERT_AND_TO_STRING(enum_value)
+BROKER_CONVERT_AND_TO_STRING(enum_value_view)
+BROKER_CONVERT_AND_TO_STRING(envelope)
+BROKER_CONVERT_AND_TO_STRING(envelope_ptr)
+BROKER_CONVERT_AND_TO_STRING(envelope_type)
+BROKER_CONVERT_AND_TO_STRING(erase_command)
+BROKER_CONVERT_AND_TO_STRING(error)
+BROKER_CONVERT_AND_TO_STRING(expire_command)
+BROKER_CONVERT_AND_TO_STRING(filter_type)
+BROKER_CONVERT_AND_TO_STRING(internal::expiry_formatter)
+BROKER_CONVERT_AND_TO_STRING(internal_command)
+BROKER_CONVERT_AND_TO_STRING(keepalive_command)
+BROKER_CONVERT_AND_TO_STRING(nack_command)
+BROKER_CONVERT_AND_TO_STRING(network_info)
+BROKER_CONVERT_AND_TO_STRING(none)
+BROKER_CONVERT_AND_TO_STRING(overflow_policy)
+BROKER_CONVERT_AND_TO_STRING(p2p_message_type)
+BROKER_CONVERT_AND_TO_STRING(peer_info)
+BROKER_CONVERT_AND_TO_STRING(peer_status)
+BROKER_CONVERT_AND_TO_STRING(ping_envelope_ptr)
+BROKER_CONVERT_AND_TO_STRING(pong_envelope_ptr)
+BROKER_CONVERT_AND_TO_STRING(port)
+BROKER_CONVERT_AND_TO_STRING(put_command)
+BROKER_CONVERT_AND_TO_STRING(put_unique_command)
+BROKER_CONVERT_AND_TO_STRING(put_unique_result_command)
+BROKER_CONVERT_AND_TO_STRING(retransmit_failed_command)
+BROKER_CONVERT_AND_TO_STRING(routing_update_envelope_ptr)
+BROKER_CONVERT_AND_TO_STRING(sc)
+BROKER_CONVERT_AND_TO_STRING(shutdown_options)
+BROKER_CONVERT_AND_TO_STRING(status)
+BROKER_CONVERT_AND_TO_STRING(subnet)
+BROKER_CONVERT_AND_TO_STRING(subtract_command)
+BROKER_CONVERT_AND_TO_STRING(topic)
+BROKER_CONVERT_AND_TO_STRING(variant)
+BROKER_CONVERT_AND_TO_STRING(variant_data)
+BROKER_CONVERT_AND_TO_STRING(variant_list)
+BROKER_CONVERT_AND_TO_STRING(variant_set)
+BROKER_CONVERT_AND_TO_STRING(variant_table)
+BROKER_CONVERT_AND_TO_STRING(worker)
 
 } // namespace broker

--- a/libbroker/broker/hub.cc
+++ b/libbroker/broker/hub.cc
@@ -76,7 +76,8 @@ hub hub::make(endpoint& ep, filter_type filter) {
         // OK, the core has completed the setup.
       },
       [](const caf::error& what) {
-        log::core::error("cannot-create-hub", "failed to create hub: {}", what);
+        log::core::error("cannot-create-hub", "failed to create hub: {}",
+                         caf::to_string(what));
         throw std::runtime_error("cannot create hub");
       });
   // Wrap the queues in shared pointers and create the hub.

--- a/libbroker/broker/internal/clone_actor.cc
+++ b/libbroker/broker/internal/clone_actor.cc
@@ -6,6 +6,7 @@
 #include "broker/detail/appliers.hh"
 #include "broker/detail/assert.hh"
 #include "broker/error.hh"
+#include "broker/format.hh"
 #include "broker/internal/type_id.hh"
 #include "broker/logger.hh"
 #include "broker/store.hh"

--- a/libbroker/broker/internal/connector_adapter.cc
+++ b/libbroker/broker/internal/connector_adapter.cc
@@ -124,7 +124,7 @@ caf::message_handler connector_adapter::message_handlers() {
         } else {
           log::core::error("unexpected-connector-message",
                            "connector_adapter received unexpected message: {}",
-                           msg);
+                           caf::to_string(msg));
         }
       } else if (auto i = pending_.find(event_id); i != pending_.end()) {
         i->second(msg);

--- a/libbroker/broker/internal/core_actor.cc
+++ b/libbroker/broker/internal/core_actor.cc
@@ -24,6 +24,7 @@
 #include "broker/detail/prefix_matcher.hh"
 #include "broker/domain_options.hh"
 #include "broker/filter_type.hh"
+#include "broker/format.hh"
 #include "broker/hub_id.hh"
 #include "broker/internal/checked.hh"
 #include "broker/internal/clone_actor.hh"
@@ -283,7 +284,7 @@ caf::behavior core_actor_state::make_behavior() {
       log::core::debug(
         "exit-msg",
         "shutting down after receiving an exit message with reason {}",
-        msg.reason);
+        caf::to_string(msg.reason));
       shutdown(shutdown_options{});
     }
   });
@@ -880,7 +881,7 @@ void core_actor_state::try_connect(const network_info& addr,
     },
     [this, rp, addr](const caf::error& what) mutable {
       log::core::debug("try-connect-failed", "failed to connect to {}: {}",
-                       addr, what);
+                       addr, caf::to_string(what));
       rp.deliver(what);
       peer_unavailable(addr);
     });
@@ -992,7 +993,7 @@ core_actor_state::do_init_new_peer(endpoint_id peer_id,
       })
       .do_on_error([this, ptr, peer_id](const caf::error& what) {
         log::core::debug("remove-peer", "remove peer {} due to: {}", peer_id,
-                         what);
+                         caf::to_string(what));
         if (auto* lptr = logger()) {
           lptr->on_peer_disconnect(peer_id, facade(what));
         }
@@ -1093,7 +1094,8 @@ caf::error core_actor_state::init_new_peer(endpoint_id peer,
   auto& [rd_2, wr_2] = resources2;
   if (auto err = ptr->run(self->system(), std::move(rd_1), std::move(wr_2))) {
     log::core::debug("init-new-peer-failed",
-                     "failed to run pending connection: {}", err);
+                     "failed to run pending connection: {}",
+                     caf::to_string(err));
     return err;
   } else {
     // With the connected buffers, dispatch to the other overload.

--- a/libbroker/broker/internal/hub_impl.hh
+++ b/libbroker/broker/internal/hub_impl.hh
@@ -101,7 +101,8 @@ private:
         .receive([] {},
                  [](const caf::error& err) {
                    log::core::debug("update-hub-filter",
-                                    "failed to update hub filter: {}", err);
+                                    "failed to update hub filter: {}",
+                                    caf::to_string(err));
                  });
     } else {
       caf::anon_send(core_, id_, filter_);

--- a/libbroker/broker/internal/master_actor.cc
+++ b/libbroker/broker/internal/master_actor.cc
@@ -13,6 +13,7 @@
 #include "broker/detail/abstract_backend.hh"
 #include "broker/detail/assert.hh"
 #include "broker/detail/die.hh"
+#include "broker/format.hh"
 #include "broker/internal/checked.hh"
 #include "broker/internal/master_actor.hh"
 #include "broker/internal/metric_factory.hh"

--- a/libbroker/broker/internal/store_actor.cc
+++ b/libbroker/broker/internal/store_actor.cc
@@ -9,6 +9,17 @@
 
 using namespace std::string_literals;
 
+namespace broker {
+
+void convert(const internal::expiry_formatter& x, std::string& str) {
+  if (x.expiry)
+    str += to_string(*x.expiry);
+  else
+    str += "none";
+}
+
+} // namespace broker
+
 namespace broker::internal {
 
 namespace {
@@ -53,13 +64,6 @@ void fill_vector(vector& vec, const Ts&... xs) {
 }
 
 } // namespace
-
-void convert(const expiry_formatter& x, std::string& str) {
-  if (x.expiry)
-    str += to_string(*x.expiry);
-  else
-    str += "none";
-}
 
 store_actor_state::~store_actor_state() {
   // nop

--- a/libbroker/broker/internal/store_actor.hh
+++ b/libbroker/broker/internal/store_actor.hh
@@ -51,8 +51,6 @@ struct expiry_formatter {
   std::optional<timespan> expiry;
 };
 
-void convert(const expiry_formatter& x, std::string& str);
-
 class store_actor_state {
 public:
   // -- member types -----------------------------------------------------------

--- a/libbroker/broker/internal/type_id.hh
+++ b/libbroker/broker/internal/type_id.hh
@@ -9,6 +9,8 @@
 #include "broker/internal/native.hh"
 #include "broker/time.hh"
 
+#include <future>
+
 #include <caf/config.hpp>
 #include <caf/fwd.hpp>
 #include <caf/is_error_code_enum.hpp>

--- a/libbroker/broker/internal/web_socket.cc
+++ b/libbroker/broker/internal/web_socket.cc
@@ -1,6 +1,7 @@
 #include "broker/internal/web_socket.hh"
 
 #include "broker/expected.hh"
+#include "broker/format.hh"
 #include "broker/internal/connector.hh"
 #include "broker/internal/native.hh"
 #include "broker/logger.hh"
@@ -88,7 +89,8 @@ public:
     };
     auto on_error = [](const caf::error& reason) {
       log::network::info("wss-handshake-failed",
-                         "SSL handshake on WebSocket failed: {}", reason);
+                         "SSL handshake on WebSocket failed: {}",
+                         caf::to_string(reason));
     };
     return caf::net::openssl::async_accept(fd, mpx, std::move(policy),
                                            on_success, on_error);
@@ -132,14 +134,14 @@ expected<uint16_t> launch(caf::actor_system& sys,
   if (!fd) {
     log::network::error("ws-start-failed",
                         "failed to open WebSocket on port {} -> {}", port,
-                        fd.error());
+                        caf::to_string(fd.error()));
     return {facade(fd.error())};
   }
   auto actual_port = caf::net::local_port(*fd);
   if (!actual_port) {
     log::network::error("ws-start-failed",
                         "failed to retrieve actual port from socket: {}",
-                        actual_port.error());
+                        caf::to_string(actual_port.error()));
     return {facade(actual_port.error())};
   }
   // Callback for connecting the flows.

--- a/libbroker/broker/internal/wire_format.cc
+++ b/libbroker/broker/internal/wire_format.cc
@@ -2,6 +2,7 @@
 
 #include "broker/envelope.hh"
 #include "broker/expected.hh"
+#include "broker/format.hh"
 #include "broker/format/bin.hh"
 #include "broker/internal/native.hh"
 #include "broker/logger.hh"

--- a/libbroker/broker/internal_command.cc
+++ b/libbroker/broker/internal_command.cc
@@ -20,16 +20,20 @@ void do_stringify(const T& what, std::string& out) {
 
 } // namespace
 
-std::string to_string(command_tag x) {
+void convert(const command_tag& x, std::string& str) {
   switch (x) {
     case command_tag::action:
-      return "action";
+      str = "action";
+      break;
     case command_tag::producer_control:
-      return "producer_control";
+      str = "producer_control";
+      break;
     case command_tag::consumer_control:
-      return "consumer_control";
+      str = "consumer_control";
+      break;
     default:
-      return "???";
+      str = "???";
+      break;
   }
 }
 

--- a/libbroker/broker/internal_command.hh
+++ b/libbroker/broker/internal_command.hh
@@ -26,8 +26,6 @@ enum class command_tag {
   consumer_control,
 };
 
-std::string to_string(command_tag);
-
 // -- broadcast: actions on the key-value store such as put and erase ----------
 
 /// Sets a value in the key-value store.

--- a/libbroker/broker/network_info.cc
+++ b/libbroker/broker/network_info.cc
@@ -29,17 +29,19 @@ void convert(const network_info& x, std::string& str) {
   str += std::to_string(x.port);
 }
 
-std::string to_string(const network_info& x) {
-  std::string result;
-  convert(x, result);
-  return result;
+void convert(const std::optional<network_info>& x, std::string& str) {
+  if (x) {
+    str = "*";
+    convert(*x, str);
+  } else {
+    str = "null";
+  }
 }
 
 std::string to_string(const std::optional<network_info>& x) {
-  if (x)
-    return "*" + to_string(*x);
-  else
-    return "null";
+  std::string result;
+  convert(x, result);
+  return result;
 }
 
 } // namespace broker

--- a/libbroker/broker/network_info.hh
+++ b/libbroker/broker/network_info.hh
@@ -36,9 +36,6 @@ bool inspect(Inspector& f, network_info& x) {
 void convert(const network_info& x, std::string& str);
 
 /// @relates network_info
-std::string to_string(const network_info& x);
-
-/// @relates network_info
 std::string to_string(const std::optional<network_info>& x);
 
 } // namespace broker

--- a/libbroker/broker/none.cc
+++ b/libbroker/broker/none.cc
@@ -1,0 +1,10 @@
+#include "broker/none.hh"
+
+#include <string>
+
+namespace broker {
+
+void convert(const none&, std::string& str) {
+  str = "nil";
+}
+} // namespace broker

--- a/libbroker/broker/none.hh
+++ b/libbroker/broker/none.hh
@@ -39,9 +39,7 @@ inline constexpr bool operator>=(none, none) noexcept {
 }
 
 /// @relates none
-inline void convert(none, std::string& str) {
-  str = "nil";
-}
+void convert(const none&, std::string& str);
 
 /// The only instance of @ref none.
 /// @relates none

--- a/libbroker/broker/overflow_policy.cc
+++ b/libbroker/broker/overflow_policy.cc
@@ -5,7 +5,7 @@
 
 namespace broker {
 
-void convert(overflow_policy src, std::string& dst) {
+void convert(const overflow_policy& src, std::string& dst) {
   switch (src) {
     case overflow_policy::disconnect:
       dst = "disconnect";

--- a/libbroker/broker/overflow_policy.hh
+++ b/libbroker/broker/overflow_policy.hh
@@ -15,7 +15,7 @@ enum class overflow_policy {
   disconnect,
 };
 
-void convert(overflow_policy src, std::string& dst);
+void convert(const overflow_policy& src, std::string& dst);
 
 bool convert(const std::string& src, overflow_policy& dst);
 

--- a/libbroker/broker/p2p_message_type.cc
+++ b/libbroker/broker/p2p_message_type.cc
@@ -13,10 +13,10 @@ constexpr std::string_view p2p_message_type_names[] = {
   "originator_ack",
 };
 
-std::string to_string(p2p_message_type x) {
-  auto index = static_cast<uint8_t>(x);
+void convert(const p2p_message_type& src, std::string& dst) {
+  auto index = static_cast<uint8_t>(src);
   BROKER_ASSERT(index < std::size(p2p_message_type_names));
-  return std::string{p2p_message_type_names[index]};
+  dst = p2p_message_type_names[index];
 }
 
 bool from_string(std::string_view str, p2p_message_type& x) {

--- a/libbroker/broker/p2p_message_type.hh
+++ b/libbroker/broker/p2p_message_type.hh
@@ -26,7 +26,7 @@ enum class p2p_message_type : uint8_t {
 };
 
 /// @relates p2p_message_type
-std::string to_string(p2p_message_type);
+void convert(const p2p_message_type& src, std::string& dst);
 
 /// @relates p2p_message_type
 bool from_string(std::string_view, p2p_message_type&);

--- a/libbroker/broker/peer_info.cc
+++ b/libbroker/broker/peer_info.cc
@@ -1,0 +1,15 @@
+#include "broker/peer_info.hh"
+
+namespace broker {
+
+void convert(const peer_info& x, std::string& str) {
+  str = "peer_info(";
+  str += to_string(x.peer);
+  str += ", ";
+  str += std::to_string(static_cast<int>(x.flags));
+  str += ", ";
+  str += to_string(x.status);
+  str += ")";
+}
+
+} // namespace broker

--- a/libbroker/broker/peer_status.cc
+++ b/libbroker/broker/peer_status.cc
@@ -13,12 +13,8 @@ constexpr const char* peer_status_strings[] = {
 
 } // namespace
 
-void convert(peer_status x, std::string& str) {
+void convert(const peer_status& x, std::string& str) {
   str = peer_status_strings[static_cast<size_t>(x)];
-}
-
-const char* to_string(peer_status x) {
-  return peer_status_strings[static_cast<size_t>(x)];
 }
 
 } // namespace broker

--- a/libbroker/broker/peer_status.hh
+++ b/libbroker/broker/peer_status.hh
@@ -19,10 +19,7 @@ enum class peer_status {
 };
 
 /// @relates peer_status
-void convert(peer_status x, std::string& str);
-
-/// @relates peer_status
-const char* to_string(peer_status);
+void convert(const peer_status& x, std::string& str);
 
 /// @relates peer_status
 template <class Inspector>

--- a/libbroker/broker/ping_envelope.cc
+++ b/libbroker/broker/ping_envelope.cc
@@ -85,4 +85,8 @@ expected<envelope_ptr> ping_envelope::deserialize(
   return envelope_ptr{std::move(ptr)};
 }
 
+void convert(const ping_envelope_ptr& src, std::string& dst) {
+  convert(src.get(), dst);
+}
+
 } // namespace broker

--- a/libbroker/broker/pong_envelope.cc
+++ b/libbroker/broker/pong_envelope.cc
@@ -90,4 +90,8 @@ expected<envelope_ptr> pong_envelope::deserialize(
   return envelope_ptr{std::move(ptr)};
 }
 
+void convert(const pong_envelope_ptr& src, std::string& dst) {
+  convert(src.get(), dst);
+}
+
 } // namespace broker

--- a/libbroker/broker/publisher.cc
+++ b/libbroker/broker/publisher.cc
@@ -59,7 +59,8 @@ publisher publisher::make(endpoint& ep, topic dst) {
         // OK, the core has completed the setup.
       },
       [](const caf::error& what) {
-        log::core::error("cannot-create-hub", "failed to create hub: {}", what);
+        log::core::error("cannot-create-hub", "failed to create hub: {}",
+                         caf::to_string(what));
         throw std::runtime_error("cannot create hub");
       });
   // Wrap the queues in shared pointers and create the hub.

--- a/libbroker/broker/routing_update_envelope.cc
+++ b/libbroker/broker/routing_update_envelope.cc
@@ -154,4 +154,8 @@ expected<envelope_ptr> routing_update_envelope::deserialize(
   return {std::move(result)};
 }
 
+void convert(const routing_update_envelope_ptr& src, std::string& dst) {
+  convert(src.get(), dst);
+}
+
 } // namespace broker

--- a/libbroker/broker/shutdown_options.cc
+++ b/libbroker/broker/shutdown_options.cc
@@ -17,13 +17,12 @@ void append(std::string& result, broker::shutdown_options::flag flag) {
 
 namespace broker {
 
-std::string to_string(shutdown_options options) {
-  std::string result = "shutdown_options(";
+void convert(const shutdown_options& src, std::string& dst) {
+  dst = "shutdown_options(";
   for (auto flag : {shutdown_options::await_stores_on_shutdown})
-    if (options.contains(flag))
-      append(result, flag);
-  result += ')';
-  return result;
+    if (src.contains(flag))
+      append(dst, flag);
+  dst += ')';
 }
 
 } // namespace broker

--- a/libbroker/broker/shutdown_options.hh
+++ b/libbroker/broker/shutdown_options.hh
@@ -32,6 +32,6 @@ private:
   uint8_t flags_ = 0;
 };
 
-std::string to_string(shutdown_options options);
+void convert(const shutdown_options& src, std::string& dst);
 
 } // namespace broker

--- a/libbroker/broker/status.hh
+++ b/libbroker/broker/status.hh
@@ -38,7 +38,7 @@ template <sc S>
 using sc_constant = std::integral_constant<sc, S>;
 
 /// @relates sc
-std::string to_string(sc code);
+void convert(const sc& code, std::string& str);
 
 /// @relates sc
 bool convert(std::string_view str, sc& code) noexcept;
@@ -203,7 +203,7 @@ inline bool operator!=(sc lhs, const status& rhs) {
 }
 
 /// @relates status
-std::string to_string(const status& x);
+void convert(const status& src, std::string& dst);
 
 /// @relates status
 template <sc S, class... Ts>
@@ -276,7 +276,7 @@ private:
 };
 
 /// @relates status_view
-std::string to_string(status_view sv);
+void convert(const status_view& src, std::string& dst);
 
 /// @relates status_view
 inline status_view make_status_view(const data& src) {

--- a/libbroker/broker/status.test.cc
+++ b/libbroker/broker/status.test.cc
@@ -38,20 +38,25 @@ struct fixture {
 FIXTURE_SCOPE(status_tests, fixture)
 
 TEST(sc is convertible to and from string) {
+  auto sc_from_string = [](std::string_view str) -> std::optional<sc> {
+    auto resutl = sc::unspecified;
+    if (convert(str, resutl))
+      return resutl;
+    return {};
+  };
   CHECK_EQUAL(to_string(sc::unspecified), "unspecified"s);
   CHECK_EQUAL(to_string(sc::peer_added), "peer_added"s);
   CHECK_EQUAL(to_string(sc::peer_removed), "peer_removed"s);
   CHECK_EQUAL(to_string(sc::peer_lost), "peer_lost"s);
-  CHECK_EQUAL(from_string<sc>("unspecified"), sc::unspecified);
   CHECK_EQUAL(to_string(sc::endpoint_discovered), "endpoint_discovered"s);
   CHECK_EQUAL(to_string(sc::endpoint_unreachable), "endpoint_unreachable"s);
-  CHECK_EQUAL(from_string<sc>("peer_added"), sc::peer_added);
-  CHECK_EQUAL(from_string<sc>("peer_removed"), sc::peer_removed);
-  CHECK_EQUAL(from_string<sc>("peer_lost"), sc::peer_lost);
-  CHECK_EQUAL(from_string<sc>("endpoint_discovered"), sc::endpoint_discovered);
-  CHECK_EQUAL(from_string<sc>("endpoint_unreachable"),
-              sc::endpoint_unreachable);
-  CHECK_EQUAL(from_string<sc>("foo"), std::nullopt);
+  CHECK_EQUAL(sc_from_string("unspecified"), sc::unspecified);
+  CHECK_EQUAL(sc_from_string("peer_added"), sc::peer_added);
+  CHECK_EQUAL(sc_from_string("peer_removed"), sc::peer_removed);
+  CHECK_EQUAL(sc_from_string("peer_lost"), sc::peer_lost);
+  CHECK_EQUAL(sc_from_string("endpoint_discovered"), sc::endpoint_discovered);
+  CHECK_EQUAL(sc_from_string("endpoint_unreachable"), sc::endpoint_unreachable);
+  CHECK_EQUAL(sc_from_string("foo"), std::nullopt);
 }
 
 TEST(status is convertible to and from data) {

--- a/libbroker/broker/store.cc
+++ b/libbroker/broker/store.cc
@@ -14,6 +14,7 @@
 #include <caf/send.hpp>
 
 #include "broker/expected.hh"
+#include "broker/format.hh"
 #include "broker/internal/flare_actor.hh"
 #include "broker/internal/native.hh"
 #include "broker/internal/type_id.hh"
@@ -324,7 +325,7 @@ store::response store::proxy::receive() {
     caf::others >> [&](caf::message& x) -> caf::skippable_result {
       log::store::error("store-obj-unexpected-response",
                         "proxy {} received an unexpected message: {}",
-                        native(proxy_).id(), x);
+                        native(proxy_).id(), caf::to_string(x));
       // We *must* make sure to consume any and all messages, because the flare
       // actor messes with the mailbox signaling. The flare fires on each
       // enqueued message and the flare actor reports data available as long as
@@ -461,7 +462,8 @@ bool store::await_idle(timespan timeout) {
       .receive([&result](atom::ok) { result = true; },
                []([[maybe_unused]] const caf::error& err) {
                  log::store::error("store-obj-await-idle",
-                                   "await_idle failed: {}", err);
+                                   "await_idle failed: {}",
+                                   caf::to_string(err));
                });
   });
   return result;
@@ -491,8 +493,8 @@ void store::reset() {
   state_.reset();
 }
 
-std::string to_string(const store::response& x) {
-  return caf::deep_to_string(std::tie(x.answer, x.id));
+void convert(const store::response& x, std::string& str) {
+  str = caf::deep_to_string(std::tie(x.answer, x.id));
 }
 
 } // namespace broker

--- a/libbroker/broker/store.hh
+++ b/libbroker/broker/store.hh
@@ -356,6 +356,6 @@ private:
   detail::weak_store_state_ptr state_;
 };
 
-std::string to_string(const store::response& x);
+BROKER_CONVERT_AND_TO_STRING(store::response)
 
 } // namespace broker

--- a/libbroker/broker/store_event.hh
+++ b/libbroker/broker/store_event.hh
@@ -3,6 +3,7 @@
 #include "broker/convert.hh"
 #include "broker/data.hh"
 #include "broker/entity_id.hh"
+#include "broker/fwd.hh"
 
 #include <cstdint>
 #include <string>
@@ -262,17 +263,10 @@ public:
   };
 };
 
-/// @relates store_event::type
-const char* to_string(store_event::type code) noexcept;
-
-/// @relates store_event::insert
-std::string to_string(const store_event::insert& x);
-
-/// @relates store_event::update
-std::string to_string(const store_event::update& x);
-
-/// @relates store_event::erase
-std::string to_string(const store_event::erase& x);
+BROKER_CONVERT_AND_TO_STRING(store_event::type)
+BROKER_CONVERT_AND_TO_STRING(store_event::insert)
+BROKER_CONVERT_AND_TO_STRING(store_event::update)
+BROKER_CONVERT_AND_TO_STRING(store_event::erase)
 
 /// @relates store_event::type
 bool convert(const std::string& src, store_event::type& dst) noexcept;

--- a/libbroker/broker/subscriber.cc
+++ b/libbroker/broker/subscriber.cc
@@ -17,6 +17,7 @@
 #include "broker/detail/assert.hh"
 #include "broker/endpoint.hh"
 #include "broker/filter_type.hh"
+#include "broker/format.hh"
 #include "broker/hub.hh"
 #include "broker/internal/endpoint_access.hh"
 #include "broker/internal/hub_impl.hh"
@@ -60,7 +61,8 @@ subscriber subscriber::make(endpoint& ep, filter_type filter, size_t) {
         // OK, the core has completed the setup.
       },
       [](const caf::error& what) {
-        log::core::error("cannot-create-hub", "failed to create hub: {}", what);
+        log::core::error("cannot-create-hub", "failed to create hub: {}",
+                         caf::to_string(what));
         throw std::runtime_error("cannot create hub");
       });
   // Wrap the queues in shared pointers and create the hub.

--- a/libbroker/broker/topic.cc
+++ b/libbroker/broker/topic.cc
@@ -65,22 +65,6 @@ topic operator/(const topic& lhs, const topic& rhs) {
   return result /= rhs;
 }
 
-void convert(const std::vector<topic>& ts, std::string& str) {
-  if (ts.empty()) {
-    str += "[]";
-    return;
-  }
-  str += '[';
-  auto i = ts.begin();
-  auto e = ts.end();
-  str += i->string();
-  for (++i; i != e; ++i) {
-    str += ", ";
-    str += i->string();
-  }
-  str += ']';
-}
-
 namespace {
 
 constexpr caf::string_view internal_prefix = "<$>/local/";

--- a/libbroker/broker/topic.hh
+++ b/libbroker/broker/topic.hh
@@ -128,9 +128,6 @@ inline void convert(const topic& t, std::string& str) {
   str = t.string();
 }
 
-/// @relates topic
-void convert(const std::vector<topic>& ts, std::string& str);
-
 /// Checks whether a topic is internal, i.e., messages on this topic are always
 /// only visible locally and never forwarded to peers.
 /// @relates topic

--- a/libbroker/broker/worker.cc
+++ b/libbroker/broker/worker.cc
@@ -82,8 +82,8 @@ const worker::impl* worker::native_ptr() const noexcept {
   return reinterpret_cast<const impl*>(obj_);
 }
 
-std::string to_string(const worker& x) {
-  return to_string(native(x));
+void convert(const worker& x, std::string& str) {
+  str = to_string(native(x));
 }
 
 } // namespace broker

--- a/libbroker/broker/worker.hh
+++ b/libbroker/broker/worker.hh
@@ -95,8 +95,6 @@ inline bool operator!=(std::nullptr_t, const worker& hdl) {
   return hdl.valid();
 }
 
-std::string to_string(const worker& x);
-
 } // namespace broker
 
 namespace std {


### PR DESCRIPTION
- re-implement the logging functions to use `std::format`
- provide formatters for Broker types implementing `convert`
- explicitly generate `to_string` instead forcing them

In particular the latter change is targeting the over-reliance on "automagic" injection of functions which makes the code both brittle and hard to follow. Consequently, the `std::formatter` implementations for Broker are all opt-in via explicitly calling
`BROKER_STD_FORMATTER_IMPL`. We could try specializing based on the existence of a `convert` function, but this could pull in unwanted types and cause ambiguity. Instantiating the formatters via macro is more verbose, but also safer.