### PR TITLE
Make broker-node rate calculation more accurate

### DIFF
--- a/broker-node/broker-node.cc
+++ b/broker-node/broker-node.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cerrno>
 #include <cstddef>
@@ -10,6 +11,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -216,6 +218,26 @@ broker::variant make_stop_msg() {
 
 // -- mode implementations -----------------------------------------------------
 
+// Prints the rate of messages received per second. Calculates the rate by
+// reading the value of `received` once per second and printing the difference
+// until the `stopped` flag becomes true.
+// @note This function is blocking and is supposed to run in its own thread.
+void print_rate(const std::shared_ptr<std::atomic<bool>>& stopped,
+                const std::shared_ptr<std::atomic<size_t>>& received) {
+  size_t last_count = 0;
+  auto next_print = std::chrono::system_clock::now() + 1s;
+  while (!stopped->load()) {
+    std::this_thread::sleep_until(next_print);
+    if (stopped->load()) { // Re-check in case the flag was set in the meantime.
+      return;
+    }
+    auto current_count = received->load();
+    verbose::println("rate: ", current_count - last_count, " messages/s");
+    last_count = current_count;
+    next_print += 1s;
+  }
+}
+
 void relay_mode(broker::endpoint& ep, topic_list topics) {
   verbose::println("relay messages");
   auto handle_message = [&](const broker::data_message& x) {
@@ -230,30 +252,35 @@ void relay_mode(broker::endpoint& ep, topic_list topics) {
     }
     return true;
   };
+  verbose::println("make subscriber for topics ", topics);
   auto in = ep.make_subscriber(std::move(topics));
   auto& cfg = broker::internal::endpoint_access{&ep}.cfg();
+  // Run with rate printing if configured.
   if (get_or(cfg, "verbose", false) && get_or(cfg, "rate", false)) {
-    auto timeout = std::chrono::system_clock::now();
-    timeout += std::chrono::seconds(1);
-    size_t received = 0;
-    for (;;) {
-      if (auto maybe_msg = in.get(timeout)) {
-        auto msg = std::move(*maybe_msg);
-        if (!handle_message(msg))
-          return;
-        ++received;
-      } else {
-        verbose::println(received, "/s");
-        timeout += std::chrono::seconds(1);
-        received = 0;
+    auto received = std::make_shared<std::atomic<size_t>>(0);
+    auto stopped = std::make_shared<std::atomic<bool>>(false);
+    auto rate_printer = std::thread{print_rate, stopped, received};
+    auto guard = caf::detail::make_scope_guard([&]() noexcept {
+      stopped->store(true);
+      try {
+        rate_printer.join();
+      } catch (const std::exception& ex) {
+        err::println("failed to join rate printer: ", ex.what());
       }
-    }
-  } else {
+    });
     for (;;) {
-      auto x = in.get();
-      if (!handle_message(x))
+      auto msg = in.get();
+      if (!handle_message(msg)) {
         return;
+      }
+      ++*received;
     }
+  }
+  // Run without rate printing.
+  for (;;) {
+    auto x = in.get();
+    if (!handle_message(x))
+      return;
   }
 }
 


### PR DESCRIPTION
Decouple the message processing from the rate calculation by pushing the latter to a separate thread. By performing the rate calculation separately, we get more accurate results and also keep the code more structured.