### PR TITLE
internal/json: Do not throw on invalid addresses

### DIFF
--- a/libbroker/broker/internal/json.cc
+++ b/libbroker/broker/internal/json.cc
@@ -67,7 +67,7 @@ bool to_binary_impl(const caf::json_object& obj, OutIter& out) {
     auto val = dval.to_string();
     broker::address tmp;
     if (!convert(caf::to_string(val), tmp))
-      throw std::runtime_error("failed to convert address");
+      return false;
     out = bin_v1::encode_with_tag(tmp, out);
     return true;
   }

--- a/libbroker/broker/internal/json.test.cc
+++ b/libbroker/broker/internal/json.test.cc
@@ -154,3 +154,29 @@ TEST(a data message in JSON can be rewritten to the binary format) {
   REQUIRE(maybe_msg);
   CHECK_EQ((*maybe_msg)->value().to_data(), native()->value().to_data());
 }
+
+namespace {
+constexpr caf::string_view json_bad_address = R"_({
+  "type": "data-message",
+  "topic": "/test/cpp/internal/json-type-mapper",
+  "@data-type": "vector",
+  "data": [
+    {
+      "@data-type": "address",
+      "data": "123ns"
+    }
+  ]
+})_";
+
+}
+
+TEST(invalid address) {
+  using util = broker::internal::json;
+  auto bin = std::vector<std::byte>{};
+  auto val = caf::json_value::parse_shallow(json_bad_address);
+  REQUIRE(val);
+  auto obj = val->to_object();
+  CHECK_EQ(obj.value("type").to_string(), "data-message");
+  auto err = util::data_message_to_binary(obj, bin);
+  CHECK(err); // Error is expected. It's an invalid address.
+}


### PR DESCRIPTION
A WebSocket client sending `{"@data-type": "address", "data": "123ns"}` can trigger a runtime_error, resulting in process termination.